### PR TITLE
Fix GenericOverlay dark mode theme support

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/ChatDisplay.tsx
+++ b/apps/electron/src/renderer/components/app-shell/ChatDisplay.tsx
@@ -975,6 +975,7 @@ export function ChatDisplay({
           onClose={handleCloseOverlay}
           content={overlayState.content}
           title={overlayState.title}
+          theme={isDark ? 'dark' : 'light'}
         />
       )}
 
@@ -985,6 +986,7 @@ export function ChatDisplay({
           onClose={handleCloseOverlay}
           content={overlayData.content}
           title={overlayData.title}
+          theme={isDark ? 'dark' : 'light'}
         />
       )}
     </div>

--- a/packages/ui/src/components/overlay/GenericOverlay.tsx
+++ b/packages/ui/src/components/overlay/GenericOverlay.tsx
@@ -23,6 +23,8 @@ export interface GenericOverlayProps {
   onClose: () => void
   /** Optional title to display in the header */
   title?: string
+  /** Theme mode for proper dark/light styling */
+  theme?: 'light' | 'dark'
   /** Enable diff mode for side-by-side comparison */
   diffMode?: boolean
   /** Original content (left side) for diff mode */
@@ -110,6 +112,7 @@ export function GenericOverlay({
   isOpen,
   onClose,
   title = 'Preview',
+  theme,
   diffMode = false,
   originalContent = '',
   modifiedContent = '',
@@ -129,6 +132,7 @@ export function GenericOverlay({
     <PreviewOverlay
       isOpen={isOpen}
       onClose={onClose}
+      theme={theme}
       badge={{
         icon: FileCode,
         label: detectedLanguage,


### PR DESCRIPTION
## Summary
- Fix markdown preview overlay showing white background in dark mode
- GenericOverlay was not passing `theme` prop to PreviewOverlay, causing it to always use default light theme

<img width="3024" height="2024" alt="RoShot 2026-01-20 at 21 22 28@2x" src="https://github.com/user-attachments/assets/c4d39a41-61ea-46ae-b89b-dd4ad0041139" />

## Changes
- Add `theme` prop to `GenericOverlay` component interface
- Pass `theme` through to `PreviewOverlay` in `GenericOverlay`
- Pass `theme={isDark ? 'dark' : 'light'}` to both `GenericOverlay` usages in `ChatDisplay.tsx`

<img width="3024" height="2024" alt="RoShot 2026-01-20 at 21 47 10@2x" src="https://github.com/user-attachments/assets/61c732cb-550c-4de4-b64b-e392cc36c113" />


## Test plan
- [x] Open app in dark mode
- [x] Click "View as Markdown" on a response
- [x] Verify overlay now has dark background with readable text