### PR TITLE
fix(ui): Fix GenericOverlay scroll issue for long content

### DIFF
--- a/packages/ui/src/components/overlay/GenericOverlay.tsx
+++ b/packages/ui/src/components/overlay/GenericOverlay.tsx
@@ -136,7 +136,7 @@ export function GenericOverlay({
       }}
       title={title}
     >
-      <div className="h-full overflow-auto p-4">
+      <div className="absolute inset-0 overflow-auto p-4">
         {diffMode ? (
           // Side-by-side diff view
           <div className="flex gap-4 h-full">

--- a/packages/ui/src/components/overlay/PreviewOverlay.tsx
+++ b/packages/ui/src/components/overlay/PreviewOverlay.tsx
@@ -123,7 +123,7 @@ export function PreviewOverlay({
     </div>
   )
 
-  const contentArea = <div className="flex-1 min-h-0 flex flex-col overflow-hidden">{children}</div>
+  const contentArea = <div className="flex-1 min-h-0 relative">{children}</div>
 
   // Fullscreen mode - uses FullscreenOverlayBase for portal, traffic lights, and ESC handling
   if (!isModal) {


### PR DESCRIPTION
## Summary
Fix scroll issue in GenericOverlay when displaying long content (e.g., Task tool results).

## Changes
- `PreviewOverlay.tsx`: Change contentArea from `flex flex-col overflow-hidden` to `relative`
- `GenericOverlay.tsx`: Change outer div from `h-full` to `absolute inset-0`

## Problem
The previous `h-full` approach didn't work reliably in nested flex layouts because flexbox's default `min-height: auto` prevents children from shrinking below content height.

## Solution
Use absolute positioning (`absolute inset-0`) to guarantee a fixed height container where `overflow-auto` can trigger scrolling correctly.

## Testing
- Opened a Task tool result with long content
- Verified the overlay content is now scrollable