### PR TITLE
feat: auto-load CLAUDE.md on session start

### DIFF
--- a/packages/shared/src/agent/craft-agent.ts
+++ b/packages/shared/src/agent/craft-agent.ts
@@ -868,6 +868,9 @@ export class CraftAgent {
             this.config.session?.workingDirectory
           ),
         },
+        // Auto-load CLAUDE.md from working directory on session start
+        // SDK reads project-level context files and injects into system prompt
+        settingSources: ['project'],
         // Use sdkCwd for SDK session storage - this is set once at session creation and never changes.
         // This ensures SDK can always find session transcripts regardless of workingDirectory changes.
         // Note: workingDirectory is still used for context injection and shown to the agent.


### PR DESCRIPTION
## Summary

Enable automatic loading of CLAUDE.md content when a session starts, giving the agent immediate project context without requiring manual `/startup` or `/s` commands.

## Changes

- Added `settingSources: ['project']` to SDK options in `CraftAgent`
- This enables the Claude SDK's built-in CLAUDE.md auto-loading feature

## Why

Currently, users must manually invoke `/startup` or `/s` to load project context from CLAUDE.md. This PR makes it automatic by using the SDK's native `settingSources` option, which:

- Reads CLAUDE.md from the working directory on session start
- Injects content into the system prompt invisibly
- Handles missing files gracefully (no error)
- Is maintained by Anthropic as part of the SDK

## Testing

- [x] Type checking passes (`bun run typecheck:all`)
- [ ] Manual testing with workspace containing CLAUDE.md

## References

- [Claude SDK docs on settingSources](https://platform.claude.com/docs/en/agent-sdk/modifying-system-prompts#modifying-system-prompts)

🤖 Generated with [Craft Agent](https://agents.craft.do)