### PR TITLE
Fix: Cursor jumps to end when editing first character in message input

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
+++ b/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
@@ -1023,6 +1023,8 @@ export function FreeFormInput({
       const capitalizedFirst = value.charAt(0).toUpperCase()
       if (capitalizedFirst !== value.charAt(0)) {
         newValue = capitalizedFirst + value.slice(1)
+        // Set cursor position BEFORE state update so it's used when useEffect syncs the value
+        richInputRef.current?.setSelectionRange(cursorPosition, cursorPosition)
         setInput(newValue)
         syncToParent(newValue)
         return
@@ -1033,12 +1035,10 @@ export function FreeFormInput({
     const typography = applySmartTypography(value, cursorPosition)
     if (typography.replaced) {
       newValue = typography.text
+      // Set cursor position BEFORE state update so it's used when useEffect syncs the value
+      richInputRef.current?.setSelectionRange(typography.cursor, typography.cursor)
       setInput(newValue)
       syncToParent(newValue)
-      // Restore cursor position after React re-render
-      requestAnimationFrame(() => {
-        richInputRef.current?.setSelectionRange(typography.cursor, typography.cursor)
-      })
     }
   }, [inlineSlash, inlineMention, inlineLabel, syncToParent])
 

--- a/apps/electron/src/renderer/components/ui/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ui/rich-text-input.tsx
@@ -678,10 +678,11 @@ export const RichTextInput = React.forwardRef<RichTextInputHandle, RichTextInput
 
       // Restore cursor position after innerHTML update.
       // Always restore if we have a pending position (from setSelectionRange call).
-      // Otherwise restore to end of value.
+      // Otherwise preserve the current cursor position from the last input event.
+      // Only default to end of value if we have no cursor info at all.
       // Note: We restore even if not focused because focus can momentarily shift
       // during React re-renders, and we don't want cursor to reset to 0.
-      const cursorPos = pendingCursorRef.current ?? value.length
+      const cursorPos = pendingCursorRef.current ?? cursorPositionRef.current ?? value.length
       setCursorPosition(divRef.current, cursorPos)
       pendingCursorRef.current = null // Clear after use
     }, [value, skills, sources, skillSlugs, sourceSlugs, workspaceId])


### PR DESCRIPTION
## Summary
Fixes #63

- Fixes a bug where the cursor would jump to the end of the message input when typing or deleting characters at the beginning of the text
- The issue was caused by React re-renders not preserving cursor position during auto-capitalize and smart typography transformations

## Changes
- **FreeFormInput.tsx**: Call `setSelectionRange()` BEFORE `setInput()` in both auto-capitalize and smart typography handlers to pre-set the cursor position
- **rich-text-input.tsx**: Fall back to `cursorPositionRef` when `pendingCursorRef` isn't set, instead of defaulting to end of text

## Test plan
- [ ] Type some text in the message input
- [ ] Position cursor at the beginning of the text
- [ ] Type a character - cursor should stay at position 1, not jump to end
- [ ] Delete the first character - cursor should stay at position 0, not jump to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)