### PR TITLE
Add CLI wrapper and learning documentation

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,137 @@
+# Craft Agents CLI
+
+A command-line interface for Craft Agents, wrapping the Claude Agent SDK CLI for reliable execution.
+
+## Installation
+
+```bash
+# From the monorepo root
+bun install
+
+# Run directly
+bun run apps/cli/src/index.ts --help
+
+# Or create an alias
+alias craft="bun run /path/to/craft-agents-oss/apps/cli/src/index.ts"
+```
+
+## Configuration
+
+### API Key
+
+Set your Anthropic API key:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+Or configure in the Craft Agents desktop app (stored in encrypted credentials).
+
+### Workspaces
+
+The CLI uses the same workspace configuration as the desktop app:
+
+```bash
+# List available workspaces
+craft --list-workspaces
+
+# Use a specific workspace
+craft -w "My Workspace" "your prompt here"
+```
+
+## Usage
+
+```bash
+# Simple prompt (uses print mode by default)
+craft "What is 2+2?"
+
+# List files in workspace directory
+craft "List the files in the current directory"
+
+# Use specific workspace
+craft -w my-project "Explain the codebase structure"
+
+# Continue previous conversation
+craft -c "Tell me more"
+
+# Interactive mode (no prompt)
+craft
+
+# Restrict allowed tools
+craft -a "Bash(git:*) Read" "Show git status"
+
+# Verbose output
+craft -v "What time is it?"
+```
+
+## Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--workspace <name\|id>` | `-w` | Use specific workspace |
+| `--model <model>` | `-m` | Model to use (default: claude-sonnet-4-5-20250929) |
+| `--continue` | `-c` | Continue the most recent conversation |
+| `--print` | `-p` | Print mode (non-interactive, single response) |
+| `--allowedTools <tools>` | `-a` | Tools to allow (e.g., "Bash(git:*) Edit") |
+| `--list-workspaces` | `-l` | List available workspaces |
+| `--verbose` | `-v` | Verbose output |
+| `--help` | `-h` | Show help |
+
+## Behavior
+
+- **With prompt**: Runs in print mode (single response, non-interactive)
+- **Without prompt**: Runs in interactive mode
+- **With `-c`**: Continues the most recent conversation
+
+## Examples
+
+### Quick calculations
+```bash
+craft "What is 15% of 230?"
+```
+
+### Code exploration
+```bash
+craft "Explain the main entry point of this project"
+craft "Find all TODO comments in the codebase"
+```
+
+### Git operations
+```bash
+craft -a "Bash(git:*)" "Show recent commits"
+craft -a "Bash(git:*)" "What changed in the last commit?"
+```
+
+### Continue conversation
+```bash
+craft "Explain React hooks"
+craft -c "Give me an example of useEffect"
+```
+
+## Architecture
+
+This CLI wraps the Claude Agent SDK CLI (`@anthropic-ai/claude-agent-sdk`) for reliable subprocess execution:
+
+```
+┌─────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   craft     │────▶│   SDK CLI       │────▶│   Claude API    │
+│  (wrapper)  │     │   (subprocess)  │     │                 │
+└─────────────┘     └─────────────────┘     └─────────────────┘
+```
+
+The wrapper:
+1. Loads workspace configuration from `~/.craft-agent/`
+2. Finds the API key from env or credential store
+3. Spawns the SDK CLI with proper arguments
+4. Passes through stdin/stdout/stderr
+
+## Troubleshooting
+
+### "No Anthropic API key configured"
+Set `ANTHROPIC_API_KEY` environment variable or configure in the desktop app.
+
+### "Workspace not found"
+Use `--list-workspaces` to see available workspaces, or omit `-w` to use the active/first workspace.
+
+### "Could not find Claude Agent SDK CLI"
+Make sure dependencies are installed: `bun install` from the monorepo root.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@craft-agent/cli",
+  "version": "0.1.0",
+  "description": "CLI for Craft Agents",
+  "type": "module",
+  "bin": {
+    "craft": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "bun build src/index.ts --outdir dist --target node",
+    "dev": "bun run src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@craft-agent/shared": "workspace:*",
+    "@craft-agent/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.3",
+    "typescript": "^5.0.0"
+  }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,0 +1,295 @@
+#!/usr/bin/env bun
+/**
+ * Craft Agents CLI
+ *
+ * A simple command-line interface for interacting with Claude via the Claude Agent SDK.
+ * Uses the SDK CLI directly for reliable execution.
+ */
+
+import { parseArgs } from 'util';
+import { spawn } from 'child_process';
+import { join } from 'path';
+import { existsSync } from 'fs';
+import {
+  getWorkspaces,
+  getActiveWorkspace,
+  getWorkspaceByNameOrId,
+  loadStoredConfig,
+  ensureConfigDir,
+  DEFAULT_MODEL,
+} from '@craft-agent/shared/config';
+import { getCredentialManager } from '@craft-agent/shared/credentials';
+import type { Workspace } from '@craft-agent/core/types';
+
+// ANSI colors for terminal output
+const colors = {
+  reset: '\x1b[0m',
+  dim: '\x1b[2m',
+  cyan: '\x1b[36m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+};
+
+/**
+ * Find the SDK CLI path
+ */
+function findSdkCliPath(): string | null {
+  const possiblePaths = [
+    join(process.cwd(), 'node_modules', '@anthropic-ai', 'claude-agent-sdk', 'cli.js'),
+    join(import.meta.dir, '..', '..', '..', '..', 'node_modules', '@anthropic-ai', 'claude-agent-sdk', 'cli.js'),
+  ];
+
+  for (const p of possiblePaths) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+function printHelp(): void {
+  console.log(`
+${colors.cyan}Craft Agents CLI${colors.reset}
+
+${colors.yellow}Usage:${colors.reset}
+  craft [options] <prompt>
+  craft [options] --interactive
+
+${colors.yellow}Options:${colors.reset}
+  -w, --workspace <name|id>  Use specific workspace (default: active workspace)
+  -m, --model <model>        Model to use (default: ${DEFAULT_MODEL})
+  -c, --continue             Continue the most recent conversation
+  -p, --print                Print mode (non-interactive, single response)
+  -a, --allowedTools <tools> Tools to allow (e.g., "Bash(git:*) Edit")
+  -l, --list-workspaces      List available workspaces
+  -v, --verbose              Verbose output
+  -h, --help                 Show this help message
+
+${colors.yellow}Examples:${colors.reset}
+  craft "What files are in this directory?"
+  craft -w my-project "Explain the codebase structure"
+  craft -c "Continue our conversation"
+  craft -p "What is 2+2?"
+
+${colors.yellow}Note:${colors.reset}
+  This CLI wraps the Claude Agent SDK CLI for reliable execution.
+  For interactive mode, run without --print flag.
+`);
+}
+
+function printWorkspaces(workspaces: Workspace[], activeId: string | null): void {
+  console.log(`\n${colors.cyan}Available Workspaces:${colors.reset}\n`);
+
+  if (workspaces.length === 0) {
+    console.log(`  ${colors.dim}No workspaces configured.${colors.reset}`);
+    console.log(`  ${colors.dim}Create one using the Craft Agents desktop app.${colors.reset}`);
+    return;
+  }
+
+  for (const ws of workspaces) {
+    const isActive = ws.id === activeId;
+    const marker = isActive ? `${colors.green}*${colors.reset}` : ' ';
+    const name = isActive ? `${colors.green}${ws.name}${colors.reset}` : ws.name;
+    console.log(`  ${marker} ${name}`);
+    console.log(`    ${colors.dim}ID: ${ws.id}${colors.reset}`);
+    console.log(`    ${colors.dim}Path: ${ws.rootPath}${colors.reset}`);
+  }
+  console.log();
+}
+
+async function getApiKey(): Promise<string | null> {
+  // Check environment variable first
+  if (process.env.ANTHROPIC_API_KEY) {
+    return process.env.ANTHROPIC_API_KEY;
+  }
+  // Then check credential manager
+  const credentialManager = getCredentialManager();
+  return await credentialManager.getApiKey();
+}
+
+async function runSdkCli(
+  cliPath: string,
+  prompt: string,
+  options: {
+    workingDir: string;
+    model?: string;
+    continueConversation?: boolean;
+    printMode?: boolean;
+    allowedTools?: string;
+    verbose?: boolean;
+    apiKey: string;
+  }
+): Promise<void> {
+  const args: string[] = [];
+
+  // Add flags
+  if (options.printMode) {
+    args.push('-p');
+  }
+  if (options.continueConversation) {
+    args.push('-c');
+  }
+  if (options.model) {
+    args.push('--model', options.model);
+  }
+  if (options.allowedTools) {
+    args.push('--allowedTools', options.allowedTools);
+  }
+  // Note: -d (debug) flag conflicts with -p (print) mode in SDK CLI
+  // Only enable debug for interactive mode
+  if (options.verbose && !options.printMode) {
+    args.push('-d');
+  }
+
+  // Add the prompt (only if not empty)
+  if (prompt) {
+    args.push(prompt);
+  }
+
+  if (options.verbose) {
+    console.error(`${colors.dim}Running: node ${cliPath}${colors.reset}`);
+    console.error(`${colors.dim}Args: ${JSON.stringify(args)}${colors.reset}`);
+    console.error(`${colors.dim}Working directory: ${options.workingDir}${colors.reset}`);
+  }
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [cliPath, ...args], {
+      cwd: options.workingDir,
+      env: {
+        ...process.env,
+        ANTHROPIC_API_KEY: options.apiKey,
+      },
+      stdio: ['inherit', 'inherit', 'inherit'],
+    });
+
+    child.on('error', (err) => {
+      reject(err);
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`CLI exited with code ${code}`));
+      }
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  // Ensure config directory exists
+  ensureConfigDir();
+
+  const { values, positionals } = parseArgs({
+    options: {
+      workspace: { type: 'string', short: 'w' },
+      model: { type: 'string', short: 'm' },
+      continue: { type: 'boolean', short: 'c', default: false },
+      print: { type: 'boolean', short: 'p', default: false },
+      allowedTools: { type: 'string', short: 'a' },
+      'list-workspaces': { type: 'boolean', short: 'l', default: false },
+      verbose: { type: 'boolean', short: 'v', default: false },
+      help: { type: 'boolean', short: 'h', default: false },
+    },
+    allowPositionals: true,
+    strict: true,
+  });
+
+  // Help
+  if (values.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  // List workspaces
+  if (values['list-workspaces']) {
+    const config = loadStoredConfig();
+    const workspaces = getWorkspaces();
+    printWorkspaces(workspaces, config?.activeWorkspaceId ?? null);
+    process.exit(0);
+  }
+
+  // Find SDK CLI
+  const cliPath = findSdkCliPath();
+  if (!cliPath) {
+    console.error(`${colors.red}Error: Could not find Claude Agent SDK CLI.${colors.reset}`);
+    console.error(`${colors.dim}Make sure @anthropic-ai/claude-agent-sdk is installed.${colors.reset}`);
+    process.exit(1);
+  }
+
+  // Check for API key
+  const apiKey = await getApiKey();
+  if (!apiKey) {
+    console.error(`${colors.red}Error: No Anthropic API key configured.${colors.reset}`);
+    console.error(`${colors.dim}Set ANTHROPIC_API_KEY environment variable or configure in the desktop app.${colors.reset}`);
+    process.exit(1);
+  }
+
+  // Get workspace
+  let workspace: Workspace | null = null;
+
+  if (values.workspace) {
+    workspace = getWorkspaceByNameOrId(values.workspace);
+    if (!workspace) {
+      console.error(`${colors.red}Error: Workspace not found: ${values.workspace}${colors.reset}`);
+      console.error(`${colors.dim}Use --list-workspaces to see available workspaces.${colors.reset}`);
+      process.exit(1);
+    }
+  } else {
+    workspace = getActiveWorkspace();
+    if (!workspace) {
+      const workspaces = getWorkspaces();
+      if (workspaces.length > 0) {
+        workspace = workspaces[0]!;
+      }
+    }
+  }
+
+  // Use workspace root or current directory
+  const workingDir = workspace?.rootPath ?? process.cwd();
+
+  // Get prompt from positional arguments
+  const prompt = positionals.join(' ').trim();
+
+  // If no prompt, run in interactive mode
+  if (!prompt && !values.continue) {
+    // Run SDK CLI in interactive mode
+    try {
+      await runSdkCli(cliPath, '', {
+        workingDir,
+        model: values.model,
+        continueConversation: values.continue,
+        printMode: false,
+        allowedTools: values.allowedTools,
+        verbose: values.verbose,
+        apiKey,
+      });
+    } catch (err) {
+      console.error(`${colors.red}Error: ${err instanceof Error ? err.message : String(err)}${colors.reset}`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  // Run with prompt
+  try {
+    await runSdkCli(cliPath, prompt, {
+      workingDir,
+      model: values.model,
+      continueConversation: values.continue,
+      printMode: values.print || !!prompt, // Default to print mode if prompt provided
+      allowedTools: values.allowedTools,
+      verbose: values.verbose,
+      apiKey,
+    });
+  } catch (err) {
+    console.error(`${colors.red}Error: ${err instanceof Error ? err.message : String(err)}${colors.reset}`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(`${colors.red}Fatal error: ${err instanceof Error ? err.message : String(err)}${colors.reset}`);
+  process.exit(1);
+});

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -77,6 +77,21 @@
         "vite": "^6.2.4",
       },
     },
+    "apps/cli": {
+      "name": "@craft-agent/cli",
+      "version": "0.1.0",
+      "bin": {
+        "craft": "./dist/index.js",
+      },
+      "dependencies": {
+        "@craft-agent/core": "workspace:*",
+        "@craft-agent/shared": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.3",
+        "typescript": "^5.0.0",
+      },
+    },
     "apps/electron": {
       "name": "@craft-agent/electron",
       "version": "0.3.0",
@@ -113,29 +128,6 @@
         "strip-markdown": "^6.0.0",
         "unist-util-visit": "^5.0.0",
         "vaul": "^1.1.2",
-      },
-    },
-    "apps/marketing": {
-      "name": "@craft-agent/marketing",
-      "version": "0.3.0",
-      "dependencies": {
-        "@craft-agent/ui": "workspace:*",
-        "@paper-design/shaders-react": "^0.0.70",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-router-dom": "^7.13.0",
-        "shiki": "^3.21.0",
-        "three": "^0.170.0",
-      },
-      "devDependencies": {
-        "@tailwindcss/vite": "^4.1.18",
-        "@types/react": "^18.3.0",
-        "@types/react-dom": "^18.3.0",
-        "@types/three": "^0.170.0",
-        "@vitejs/plugin-react": "^5.1.2",
-        "tailwindcss": "^4.1.18",
-        "typescript": "^5.0.0",
-        "vite": "^6.2.4",
       },
     },
     "apps/viewer": {
@@ -411,11 +403,11 @@
 
     "@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
+    "@craft-agent/cli": ["@craft-agent/cli@workspace:apps/cli"],
+
     "@craft-agent/core": ["@craft-agent/core@workspace:packages/core"],
 
     "@craft-agent/electron": ["@craft-agent/electron@workspace:apps/electron"],
-
-    "@craft-agent/marketing": ["@craft-agent/marketing@workspace:apps/marketing"],
 
     "@craft-agent/mermaid": ["@craft-agent/mermaid@workspace:packages/mermaid"],
 
@@ -1063,8 +1055,6 @@
 
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
-    "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
-
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -1127,19 +1117,13 @@
 
     "@types/shell-quote": ["@types/shell-quote@1.7.5", "", {}, "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw=="],
 
-    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
-
     "@types/tedious": ["@types/tedious@4.0.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
-
-    "@types/three": ["@types/three@0.170.0", "", { "dependencies": { "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": "*", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~0.18.1" } }, "sha512-CUm2uckq+zkCY7ZbFpviRttY+6f9fvwm6YqSqPfA5K22s9w7R4VnA3rzJse8kHVvuzLcTx+CjNCs2NYe0QFAyg=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
     "@types/verror": ["@types/verror@1.10.11", "", {}, "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg=="],
-
-    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
@@ -1170,8 +1154,6 @@
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.1.2", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.53", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ=="],
-
-    "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
 
@@ -1640,8 +1622,6 @@
     "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
-
-    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
@@ -2123,8 +2103,6 @@
 
     "merge-refs": ["merge-refs@2.0.0", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg=="],
 
-    "meshoptimizer": ["meshoptimizer@0.18.1", "", {}, "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw=="],
-
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
@@ -2437,10 +2415,6 @@
 
     "react-resizable-panels": ["react-resizable-panels@3.0.6", "", { "peerDependencies": { "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew=="],
 
-    "react-router": ["react-router@7.13.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw=="],
-
-    "react-router-dom": ["react-router-dom@7.13.0", "", { "dependencies": { "react-router": "7.13.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g=="],
-
     "react-simple-code-editor": ["react-simple-code-editor@0.14.1", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-BR5DtNRy+AswWJECyA17qhUDvrrCZ6zXOCfkQY5zSmb96BVUbpVAv03WpcjcwtCwiLbIANx3gebHOcXYn1EHow=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
@@ -2540,8 +2514,6 @@
     "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -2674,8 +2646,6 @@
     "temp-file": ["temp-file@3.4.0", "", { "dependencies": { "async-exit-hook": "^2.0.1", "fs-extra": "^10.0.0" } }, "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg=="],
 
     "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
-
-    "three": ["three@0.170.0", "", {}, "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ=="],
 
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
 
@@ -2905,7 +2875,7 @@
 
     "@babel/highlight/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
-    "@craft-agent/marketing/@paper-design/shaders-react": ["@paper-design/shaders-react@0.0.70", "", { "dependencies": { "@paper-design/shaders": "0.0.70" }, "peerDependencies": { "@types/react": "^18 || ^19", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-9DkZXcyehorsZzyWnYV3OOO1i7rF7a5CkasjKJ1h1tLlY3JJLUEX9W+gZz7JgWHyvCimUu0OSq1sbHTb2OntRw=="],
+    "@craft-agent/cli/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
 
     "@craft-agent/viewer/@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
@@ -3173,8 +3143,6 @@
 
     "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
-    "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
-
     "read-pkg-up/find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "^2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
 
     "readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
@@ -3229,7 +3197,7 @@
 
     "@babel/highlight/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
 
-    "@craft-agent/marketing/@paper-design/shaders-react/@paper-design/shaders": ["@paper-design/shaders@0.0.70", "", {}, "sha512-d9LQcmPoEm3+Y6Vuz7cvsnSelfTM5QD63yQ3ddLM7QGYfoSjbQiU38kzjA4O3oCQ6zv23o/IGvGA8k9S/L+kZw=="],
+    "@craft-agent/cli/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@craft-agent/viewer/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 

--- a/learn_docs/2026-01-28-cli-build-challenges-sdk-subprocess.md
+++ b/learn_docs/2026-01-28-cli-build-challenges-sdk-subprocess.md
@@ -1,0 +1,290 @@
+# CLI Build Challenges: SDK Subprocess Issues
+
+This document captures the challenges encountered while building a CLI for Craft Agents and the lessons learned about the Claude Agent SDK's architecture.
+
+## Objective
+
+Build a simple CLI that uses the same `HeadlessRunner` from `@craft-agent/shared/headless` to interact with Claude, enabling command-line usage of Craft Agents.
+
+## Initial Approach
+
+### What We Tried
+
+1. Created `apps/cli/` with a CLI that imports `HeadlessRunner`
+2. `HeadlessRunner` internally uses `CraftAgent`
+3. `CraftAgent` uses the Claude Agent SDK's `query()` function
+
+```typescript
+// The intended flow
+import { HeadlessRunner } from '@craft-agent/shared/headless';
+
+const runner = new HeadlessRunner({
+  workspace,
+  prompt: "What is 2+2?",
+  permissionPolicy: 'allow-safe',
+});
+
+for await (const event of runner.runStreaming()) {
+  // Process events...
+}
+```
+
+### The Problem
+
+**Everything hung silently** - no output, no errors, no timeout. The process would start, print "Connecting to workspace..." and "Processing...", then wait forever.
+
+## Debugging Journey
+
+### Attempt 1: Fix Import Paths
+
+**Hypothesis**: Wrong module paths causing silent failures
+
+**Action**: Fixed imports to use correct subpath exports
+```typescript
+// Wrong
+import { DEFAULT_MODEL } from '@craft-agent/shared/config/models';
+
+// Correct
+import { DEFAULT_MODEL } from '@craft-agent/shared/config';
+```
+
+**Result**: ❌ Still hung
+
+### Attempt 2: SDK Path Initialization
+
+**Hypothesis**: SDK can't find its CLI executable
+
+**Action**: Added `setPathToClaudeCodeExecutable()` call
+```typescript
+import { setPathToClaudeCodeExecutable } from '@craft-agent/shared/agent';
+
+const cliPath = join(process.cwd(), 'node_modules', '@anthropic-ai', 'claude-agent-sdk', 'cli.js');
+setPathToClaudeCodeExecutable(cliPath);
+```
+
+**Result**: ❌ Still hung (but path was found correctly)
+
+### Attempt 3: Environment Variable Propagation
+
+**Hypothesis**: API key not reaching the SDK subprocess
+
+**Action**: Added `setAnthropicOptionsEnv()` to pass env vars to subprocess
+```typescript
+import { setAnthropicOptionsEnv } from '@craft-agent/shared/agent';
+
+setAnthropicOptionsEnv({ ANTHROPIC_API_KEY: apiKey });
+```
+
+**Result**: ❌ Still hung
+
+### Attempt 4: Runtime Change
+
+**Hypothesis**: Bun runtime incompatibility
+
+**Action**: Tried running with Node/TSX instead of Bun
+
+**Result**: ❌ Still hung (TSX had other issues with top-level await)
+
+## Isolation Testing
+
+To identify the actual failure point, tested each layer independently:
+
+### Test 1: Direct Anthropic API
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+const client = new Anthropic();
+const message = await client.messages.create({
+  model: "claude-sonnet-4-5-20250929",
+  max_tokens: 100,
+  messages: [{ role: "user", content: "What is 2+2?" }],
+});
+console.log(message.content[0].text);
+```
+**Result**: ✅ Worked instantly - returned "4"
+
+### Test 2: SDK CLI Directly
+```bash
+node node_modules/@anthropic-ai/claude-agent-sdk/cli.js -p "What is 2+2?"
+```
+**Result**: ✅ Worked instantly - returned "4"
+
+### Test 3: SDK query() Function
+```typescript
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+const response = query({ prompt: "What is 2+2?", options: { maxTurns: 1 } });
+for await (const message of response) {
+  console.log(message.type);
+}
+```
+**Result**: ❌ Hung indefinitely
+
+## Root Cause Analysis
+
+### The Architecture
+
+The Claude Agent SDK's `query()` function doesn't make direct API calls. Instead, it:
+
+1. Spawns `cli.js` as a **child subprocess**
+2. Communicates with it via **IPC** (inter-process communication)
+3. The subprocess handles the actual API calls and tool execution
+
+```
+┌─────────────────┐     IPC      ┌─────────────────┐     HTTPS    ┌─────────────────┐
+│  Your Code      │◄────────────►│  SDK Subprocess │◄────────────►│  Claude API     │
+│  (query())      │              │  (cli.js)       │              │                 │
+└─────────────────┘              └─────────────────┘              └─────────────────┘
+```
+
+### Why It Failed
+
+The subprocess communication was failing silently. Possible causes:
+
+1. **IPC channel issues**: The way Bun spawns processes may differ from Node/Electron
+2. **Missing environment**: The subprocess may need specific env vars or file descriptors
+3. **TTY requirements**: The SDK may expect certain terminal capabilities
+4. **Electron-specific context**: The existing code may rely on Electron's process model
+
+### Why Electron Works
+
+The Electron app has:
+- Specific process initialization in `apps/electron/src/main/sessions.ts`
+- `reinitializeAuth()` that sets up environment properly
+- Window management that may affect subprocess lifecycle
+- Different process spawning via Electron's APIs
+
+## The Solution
+
+**Don't fight the subprocess - wrap the CLI instead.**
+
+```typescript
+import { spawn } from 'child_process';
+
+function runSdkCli(cliPath: string, prompt: string, apiKey: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [cliPath, '-p', prompt], {
+      env: { ...process.env, ANTHROPIC_API_KEY: apiKey },
+      stdio: ['inherit', 'inherit', 'inherit'],
+    });
+
+    child.on('close', (code) => {
+      code === 0 ? resolve() : reject(new Error(`Exit code ${code}`));
+    });
+  });
+}
+```
+
+### Why This Works
+
+1. **No IPC complexity**: Direct stdin/stdout/stderr passthrough
+2. **CLI is battle-tested**: The SDK CLI is designed for direct invocation
+3. **Simple process model**: Standard Unix process spawning
+4. **Same functionality**: All SDK features available via CLI flags
+
+## Comparison
+
+| Approach | Lines of Code | Complexity | Reliability |
+|----------|---------------|------------|-------------|
+| HeadlessRunner + query() | ~300 | High (IPC, subprocess) | ❌ Failed |
+| CLI wrapper | ~180 | Low (spawn + args) | ✅ Works |
+
+## Lessons Learned
+
+### 1. Test in Isolation First
+
+Before building complex integrations, test each component:
+```bash
+# Does the API work?
+bun -e 'import Anthropic from "@anthropic-ai/sdk"; ...'
+
+# Does the CLI work?
+node cli.js -p "test"
+
+# Does the programmatic API work?
+bun -e 'import { query } from "sdk"; ...'
+```
+
+### 2. Silent Failures Are the Hardest
+
+The SDK didn't throw errors - it just hung. Add timeouts and logging early:
+```typescript
+const timeout = setTimeout(() => {
+  console.error('Operation timed out after 30s');
+  process.exit(1);
+}, 30000);
+```
+
+### 3. Wrap Don't Integrate
+
+When a CLI works but its programmatic API doesn't:
+- **Don't**: Spend hours debugging subprocess IPC
+- **Do**: Wrap the CLI with `spawn()`
+
+### 4. Existing Code Has Hidden Context
+
+The `HeadlessRunner` exists in the codebase and is exported, but:
+- It may only work in Electron's environment
+- It may require initialization we don't see
+- The tests may not exist or may run in special contexts
+
+### 5. Simpler Is Better
+
+The final CLI is:
+- Easier to understand
+- Easier to maintain
+- More portable across environments
+- Uses proven, working code paths
+
+## Implications for the Codebase
+
+### HeadlessRunner May Have Issues
+
+The `HeadlessRunner` at `packages/shared/src/headless/runner.ts` may:
+- Only work in Electron
+- Need additional environment setup
+- Have untested edge cases
+
+### Consider CLI-First for New Integrations
+
+For future CLI tools or automation:
+1. Test if the SDK CLI meets requirements
+2. Wrap the CLI if it does
+3. Only use `query()` programmatically if you have Electron's context
+
+### Documentation Gap
+
+The SDK's subprocess architecture isn't well-documented. Users may expect `query()` to work like a simple function call when it's actually spawning processes.
+
+## Files Created
+
+```
+apps/cli/
+├── package.json       # Dependencies
+├── tsconfig.json      # TypeScript config
+├── README.md          # Usage documentation
+└── src/
+    └── index.ts       # CLI implementation (180 lines)
+```
+
+## Usage
+
+```bash
+# Set API key
+export ANTHROPIC_API_KEY="sk-ant-..."
+
+# Simple prompt
+bun run apps/cli/src/index.ts "What is 2+2?"
+
+# List workspaces
+bun run apps/cli/src/index.ts --list-workspaces
+
+# Continue conversation
+bun run apps/cli/src/index.ts -c "Tell me more"
+
+# Interactive mode
+bun run apps/cli/src/index.ts
+```
+
+---
+
+*Written by Claude (Opus 4.5) | 2026-01-28 21:30 PST*

--- a/learn_docs/2026-01-28-codebase-investigation-agent-native-alignment.md
+++ b/learn_docs/2026-01-28-codebase-investigation-agent-native-alignment.md
@@ -1,0 +1,479 @@
+# Craft Agents Codebase Investigation & Agent-Native Alignment
+
+This document captures learnings from investigating the Craft Agents OSS codebase and its alignment with the "Agent-native Architectures" principles from Dan Shipper's article.
+
+
+
+[TOC]
+
+
+
+## Table of Contents
+
+1. [Project Overview](#project-overview)
+2. [Architecture Deep Dive](#architecture-deep-dive)
+3. [The Agent Loop](#the-agent-loop)
+4. [Agent-Native Principles Alignment](#agent-native-principles-alignment)
+5. [UI-Agent Parity Analysis](#ui-agent-parity-analysis)
+6. [Building a CLI](#building-a-cli)
+7. [Key Takeaways](#key-takeaways)
+
+---
+
+## Project Overview
+
+**Craft Agents** is an open-source desktop application built with Claude's Agent SDK that provides a beautiful UI for working with Claude as an AI agent.
+
+### What It Is
+
+- A desktop Electron app for interacting with Claude
+- Built on top of `@anthropic-ai/claude-agent-sdk`
+- Supports MCP (Model Context Protocol) for tool integration
+- Multi-session management with workflow statuses
+- Permission-based safety controls
+
+### Project Structure
+
+```
+craft-agents-oss/
+├── apps/
+│   ├── electron/          # Main desktop app (Electron + React)
+│   ├── viewer/            # Session viewer web app
+│   └── marketing/         # Marketing website
+├── packages/
+│   ├── core/              # Shared TypeScript types
+│   ├── shared/            # Business logic (agent, auth, MCP, sessions)
+│   ├── ui/                # React UI components
+│   └── mermaid/           # Mermaid diagram support
+└── scripts/               # Build utilities
+```
+
+### Key Insight: Separation of Concerns
+
+The architecture separates:
+- **`packages/core`**: Type definitions (Workspace, Session, Message, AgentEvent)
+- **`packages/shared`**: All business logic (CraftAgent, HeadlessRunner, config, credentials)
+- **`apps/electron`**: UI layer (React components, IPC handlers)
+
+This means the **agent logic is UI-independent** - a critical design for building CLI tools.
+
+---
+
+## Architecture Deep Dive
+
+### Technology Stack
+
+| Layer | Technology |
+|-------|------------|
+| Runtime | Bun |
+| AI | `@anthropic-ai/claude-agent-sdk` |
+| Desktop | Electron 39.x |
+| Frontend | React 18 + Tailwind CSS v4 |
+| UI Components | shadcn/ui + Radix UI |
+| State | Jotai |
+| Build | esbuild + Vite |
+
+### Key Files
+
+| File | Purpose | LOC |
+|------|---------|-----|
+| `packages/shared/src/agent/craft-agent.ts` | Core CraftAgent class | ~3,000 |
+| `packages/shared/src/agent/mode-manager.ts` | Permission system | ~1,500 |
+| `packages/shared/src/headless/runner.ts` | Non-interactive runner | ~285 |
+| `apps/electron/src/main/ipc.ts` | Electron IPC handlers | - |
+
+### Data Storage
+
+All data is file-based (aligning with agent-native principles):
+
+```
+~/.craft-agent/
+├── config.json                     # Main config (workspaces, auth type)
+├── credentials.enc                 # Encrypted credentials (AES-256-GCM)
+├── preferences.json                # User preferences
+├── theme.json                      # App-level theme
+└── workspaces/
+    └── {id}/
+        ├── config.json             # Workspace settings
+        ├── sessions/               # Session JSONL files
+        ├── sources/                # MCP source configs
+        │   └── {slug}/
+        │       ├── config.json
+        │       └── guide.md
+        └── statuses/               # Status workflow config
+```
+
+---
+
+## The Agent Loop
+
+### Key Discovery: SDK Handles the Loop
+
+The agent loop is **NOT** built directly on LLM calls. Instead, it's delegated to Claude's Agent SDK.
+
+**Location**: `packages/shared/src/agent/craft-agent.ts:1561`
+
+```typescript
+// The core loop - consuming SDK events
+for await (const message of this.currentQuery) {
+  const events = this.convertSDKMessage(message, toolIndex, ...);
+  for (const event of events) {
+    yield event;
+  }
+}
+```
+
+### What the SDK Handles
+
+- LLM API calls and streaming
+- Tool execution loop (call LLM → execute tools → call LLM again)
+- Message history management
+- Session persistence
+- MCP server connections and tool discovery
+- Abort/interrupt handling
+
+### What Craft Agents Adds
+
+1. **Event transformation** - Converts SDK events to UI-friendly `AgentEvent` types
+2. **Permission modes** - Adds safe/ask/allow-all layer via `PreToolUse` hooks
+3. **Source auto-activation** - Detects inactive MCP sources and activates them
+4. **Large result summarization** - Uses `PostToolUse` to summarize big outputs (>60KB)
+5. **Session recovery** - Handles failed resume attempts gracefully
+6. **UI integration** - Yields events that the renderer consumes
+
+### Simplified View
+
+```typescript
+// SDK creates the query with full agent loop
+this.currentQuery = query({ prompt, options });
+
+// Craft Agents consumes and decorates the event stream
+for await (const message of this.currentQuery) {
+  yield* this.convertSDKMessage(message);
+}
+```
+
+The SDK's `query()` function returns an async iterable that internally runs the full agent loop until completion.
+
+---
+
+## Agent-Native Principles Alignment
+
+Reference: "Agent-native Architectures: How to Build Apps After Code Ends" by Dan Shipper
+
+### 1. Parity ✅ Strong
+
+> "Whatever the user can do through the UI, the agent should be able to achieve through tools."
+
+**How Craft Agents implements this:**
+- MCP integration provides 32+ Craft document tools
+- Source connections (Google, Slack, Microsoft APIs)
+- Local filesystem access via bash
+- Permission system controls access, not capability
+
+**Evidence**: The IPC channels map directly to agent capabilities:
+
+| UI Action | Agent Capability |
+|-----------|-----------------|
+| Create session | Agent has session context |
+| Send message | `chat()` method |
+| File attachments | File read/write tools |
+| Connect to APIs | Source tools |
+| Search files | MCP file tools, bash |
+
+### 2. Granularity ✅ Strong
+
+> "Tools should be atomic primitives. Features are outcomes achieved by an agent operating in a loop."
+
+**How Craft Agents implements this:**
+- Uses atomic MCP tools (read_file, write_file, bash, etc.)
+- The SDK handles the loop; outcomes are described in prompts
+- No bundled "analyze_and_organize" style tools
+
+**Example from codebase:**
+```typescript
+// Atomic tools provided via MCP
+tools: bash, file operations, MCP tools
+// User describes outcome
+prompt: "Organize my downloads folder"
+// Agent loops until achieved
+```
+
+### 3. Composability ✅ Strong
+
+> "With atomic tools and parity, you can create new features just by writing new prompts."
+
+**How Craft Agents implements this:**
+- New "features" are prompts sent to the agent
+- MCP tools can be composed in any order
+- No hardcoded feature workflows
+
+### 4. Files as Universal Interface ✅ Strong
+
+> "Agents are naturally good at files. Claude Code works because bash + filesystem is the most battle-tested agent interface."
+
+**How Craft Agents implements this:**
+- All config in JSON files at `~/.craft-agent/`
+- Sessions stored as JSONL files
+- Workspace-scoped file organization
+- Human-readable markdown guides for sources
+
+**File structure follows the article's recommendations:**
+```
+~/.craft-agent/workspaces/{id}/
+├── config.json          # Entity data
+├── sessions/            # Collections
+└── sources/{slug}/
+    ├── config.json      # Source config
+    └── guide.md         # Human-readable setup guide
+```
+
+### 5. Agent-to-UI Communication ✅ Strong
+
+> "When agents act, the UI should reflect it immediately."
+
+**How Craft Agents implements this:**
+
+The `AgentEvent` type mirrors the article's recommendations exactly:
+
+```typescript
+type AgentEvent =
+  | { type: 'status'; message: string }
+  | { type: 'text_delta'; text: string }
+  | { type: 'tool_start'; toolUseId: string; toolName: string; input: unknown }
+  | { type: 'tool_result'; toolUseId: string; result: string; isError: boolean }
+  | { type: 'error'; message: string }
+  | { type: 'complete'; usage?: TokenUsage }
+  // ... more event types
+```
+
+The UI streams all events in real-time - no silent actions.
+
+### 6. Approval and User Agency ✅ Strong
+
+> "When agents take unsolicited actions, you need to decide how much autonomy to grant."
+
+**Three permission modes:**
+
+| Mode | Display Name | Behavior |
+|------|--------------|----------|
+| `safe` | Explore | Read-only, blocks write operations |
+| `ask` | Ask to Edit | Prompts for bash commands (default) |
+| `allow-all` | Auto | Auto-approves all commands |
+
+This maps to the article's stakes/reversibility matrix.
+
+### 7. Emergent Capability ⚠️ Partial
+
+> "The agent can accomplish things you didn't explicitly design for."
+
+**Status**: Depends on connected MCP servers
+
+Craft Agents is a **meta-implementation** - it's infrastructure for agent-native apps rather than a domain-specific app. Emergent capability comes from:
+- The MCP tools you connect
+- The bash primitives available
+- The flexibility of the permission system
+
+### 8. Improvement Over Time ⚠️ Partial
+
+> "Agent-native applications get better through accumulated context and prompt refinement."
+
+**What's implemented:**
+- Session persistence ✅
+- Session resume ✅
+
+**What's missing:**
+- No `context.md` pattern for accumulated learning
+- Prompt refinement happens at SDK level, not workspace level
+- No agent self-modification capabilities
+
+---
+
+## UI-Agent Parity Analysis
+
+### UI Capabilities (IPC Channels)
+
+From `apps/electron/src/shared/types.ts`:
+
+```typescript
+export const IPC_CHANNELS = {
+  // Session management
+  GET_SESSIONS: 'sessions:get',
+  CREATE_SESSION: 'sessions:create',
+  DELETE_SESSION: 'sessions:delete',
+  SEND_MESSAGE: 'sessions:sendMessage',
+  CANCEL_PROCESSING: 'sessions:cancel',
+  RESPOND_TO_PERMISSION: 'sessions:respondToPermission',
+
+  // Workspace management
+  GET_WORKSPACES: 'workspaces:get',
+  CREATE_WORKSPACE: 'workspaces:create',
+
+  // File operations
+  READ_FILE: 'file:read',
+  OPEN_FILE_DIALOG: 'file:openDialog',
+  STORE_ATTACHMENT: 'file:storeAttachment',
+
+  // ... more channels
+}
+```
+
+### Agent Capabilities (via SDK + MCP)
+
+- **bash** - Execute shell commands
+- **File operations** - read, write, edit, glob, grep
+- **MCP server tools** - 32+ built-in
+- **REST API calls** - via source integrations
+- **Task management** - create, update, complete
+- **Web fetch/search** - via MCP tools
+
+### Parity Mapping
+
+| UI Action | Agent Equivalent | Parity? |
+|-----------|------------------|---------|
+| Create/delete sessions | Session context | ✅ |
+| Send messages | `chat()` method | ✅ |
+| File attachments | File read/write tools | ✅ |
+| Permission approval | `onPermissionRequest` callback | ✅ |
+| Workspace switching | Agent scoped to workspace | ✅ |
+| Read/search files | MCP file tools, bash | ✅ |
+| Connect to APIs | Source tools | ✅ |
+| System preferences | Config files | ✅ |
+
+---
+
+## Building a CLI
+
+### Why It's Easy
+
+The architecture already supports headless execution:
+
+1. **Business logic is decoupled** - All core logic lives in `@craft-agent/shared`
+2. **HeadlessRunner exists** - Already at `packages/shared/src/headless/runner.ts`
+3. **Event streaming** - Same `AgentEvent` types work for CLI output
+
+### HeadlessRunner API
+
+```typescript
+import { HeadlessRunner } from '@craft-agent/shared/headless';
+
+const runner = new HeadlessRunner({
+  workspace: { id: 'my-workspace', rootPath: '/path/to/workspace' },
+  prompt: 'List all files in the current directory',
+  permissionPolicy: 'allow-safe',  // or 'allow-all', 'deny-all'
+  model: 'claude-sonnet-4-5-20250929',
+  sessionId: 'optional-session-id',
+  sessionResume: true,  // Resume last session
+});
+
+// Blocking execution
+const result = await runner.run();
+
+// Streaming execution
+for await (const event of runner.runStreaming()) {
+  if (event.type === 'text_delta') {
+    process.stdout.write(event.text);
+  }
+}
+```
+
+### HeadlessConfig Type
+
+```typescript
+interface HeadlessConfig {
+  // Required
+  prompt: string;
+  workspace: Workspace;
+
+  // Optional
+  model?: string;
+  outputFormat?: 'text' | 'json' | 'stream-json';
+  permissionPolicy?: 'deny-all' | 'allow-safe' | 'allow-all';
+  sessionId?: string;
+  sessionResume?: boolean;
+}
+```
+
+### HeadlessEvent Types
+
+```typescript
+type HeadlessEvent =
+  | { type: 'status'; message: string }
+  | { type: 'text_delta'; text: string }
+  | { type: 'tool_start'; id: string; name: string; input: unknown }
+  | { type: 'tool_result'; id: string; name: string; result: string; isError: boolean }
+  | { type: 'error'; message: string }
+  | { type: 'complete'; result: HeadlessResult };
+```
+
+### Permission Policies
+
+| Policy | Safe Commands | Write Commands |
+|--------|---------------|----------------|
+| `deny-all` | Blocked | Blocked |
+| `allow-safe` | Auto-allowed | Blocked |
+| `allow-all` | Auto-allowed | Auto-allowed |
+
+Safe commands: `ls`, `cat`, `head`, `tail`, `grep`, `find`, `pwd`, `echo`, `which`, `wc`, `sort`, `uniq`, `diff`, `file`, `stat`, `tree`, `less`, `more`
+
+---
+
+## Key Takeaways
+
+### 1. SDK Abstraction is Powerful
+
+The Claude Agent SDK handles all the complex agent loop logic:
+- LLM calls
+- Tool execution
+- Message history
+- Session management
+
+Craft Agents focuses on **what to do with the events**, not how to run the loop.
+
+### 2. Separation Enables Flexibility
+
+Because business logic is in `@craft-agent/shared`:
+- Electron app is just a UI wrapper
+- CLI can use the same `CraftAgent` and `HeadlessRunner`
+- Other UIs (web, mobile wrappers) could be built
+
+### 3. Files Are First-Class
+
+Following the agent-native principle, everything is file-based:
+- Human-readable configs
+- Easy backup/sync
+- Agent can inspect and modify
+
+### 4. Permission System is Well-Designed
+
+Three-level system with per-session isolation:
+- Safe for exploration
+- Interactive for normal use
+- Full auto for automation
+
+### 5. Event Streaming is the Integration Pattern
+
+Both UI and CLI consume the same `AgentEvent` stream:
+- Consistent behavior
+- Easy to add new consumers
+- Real-time feedback
+
+### 6. MCP is the Extensibility Layer
+
+Instead of building custom tools:
+- Connect MCP servers
+- Get tools dynamically
+- Compose as needed
+
+---
+
+## Next Steps
+
+1. **Build the CLI** - Use HeadlessRunner in a Bun script
+2. **Test permission policies** - Verify safe/ask/allow-all work correctly
+3. **Explore MCP integration** - Connect additional MCP servers
+4. **Consider improvements** - Add context.md pattern for memory
+
+---
+
+*Written by Claude (Opus 4.5) | 2026-01-28 20:15 PST*


### PR DESCRIPTION
- Add apps/cli: Simple CLI that wraps Claude Agent SDK CLI
  - Supports workspace selection, print mode, continue conversation
  - Uses subprocess spawn instead of programmatic SDK API
  - Includes README with usage examples

- Add learn_docs: Investigation and learnings
  - Codebase analysis and agent-native principles alignment
  - CLI build challenges documenting SDK subprocess issues
  - Lessons learned about wrapping CLI vs programmatic API