### PR TITLE
fix: use Bun baseline ver for non-AVX2 compat on Linux

### DIFF
--- a/apps/electron/scripts/build-linux.sh
+++ b/apps/electron/scripts/build-linux.sh
@@ -90,7 +90,7 @@ mkdir -p "$ELECTRON_DIR/vendor/bun"
 if [ "$ARCH" = "arm64" ]; then
     BUN_DOWNLOAD="bun-linux-aarch64"
 else
-    BUN_DOWNLOAD="bun-linux-x64"
+    BUN_DOWNLOAD="bun-linux-x64-baseline"
 fi
 
 # Create temp directory to avoid race conditions


### PR DESCRIPTION
following similar version to retrieve on Windows build script (apps/electron/scripts/build-win.ps1)

https://github.com/lukilabs/craft-agents-oss/blob/436820567432c61326574a822808c96a969c3a0d/apps/electron/scripts/build-win.ps1#L103-L115