### PR TITLE
Fix: support symlinked skill directories in Skills UI

### DIFF
--- a/packages/shared/src/skills/storage.ts
+++ b/packages/shared/src/skills/storage.ts
@@ -121,7 +121,7 @@ export function loadWorkspaceSkills(workspaceRoot: string): LoadedSkill[] {
   try {
     const entries = readdirSync(skillsDir, { withFileTypes: true });
     for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
 
       const skill = loadSkill(workspaceRoot, entry.name);
       if (skill) {
@@ -207,7 +207,7 @@ export function listSkillSlugs(workspaceRoot: string): string[] {
   try {
     return readdirSync(skillsDir, { withFileTypes: true })
       .filter((entry) => {
-        if (!entry.isDirectory()) return false;
+        if (!entry.isDirectory() && !entry.isSymbolicLink()) return false;
         const skillFile = join(skillsDir, entry.name, 'SKILL.md');
         return existsSync(skillFile);
       })


### PR DESCRIPTION
## Summary

- `loadWorkspaceSkills` and `listSkillSlugs` now recognize symlinked skill directories
- Two-line change: added `|| entry.isSymbolicLink()` check alongside existing `isDirectory()`

## Problem

Node.js `readdirSync` with `withFileTypes` uses `lstat`, so `entry.isDirectory()` returns `false` for symbolic links. Symlinked skills worked at runtime (Claude Code SDK resolves them) but didn't appear in the Skills UI panel.

## Use Case

Sharing skills between Claude Code CLI and Craft Agents via symlinks from a canonical directory:

```
~/shared-skills/shared/daily-notes/SKILL.md              ← real file
~/.craft-agent/.../skills/daily-notes → ~/shared-skills/  ← symlink (invisible in UI)
```

## Test plan

- [ ] Verify symlinked skills appear in Skills panel alongside native skills
- [ ] Verify native (non-symlinked) skills continue to appear normally
- [ ] Verify skill invocation works for both symlinked and native skills
- [ ] Verify skill deletion of a symlinked skill removes the symlink, not the target

Fixes #112
