### PR TITLE
fix: auto-enable authenticated sources for all sessions

### DIFF
--- a/apps/electron/src/main/sessions.ts
+++ b/apps/electron/src/main/sessions.ts
@@ -1339,6 +1339,17 @@ export class SessionManager {
       managed.lastReadMessageId = storedSession.lastReadMessageId
       managed.hasUnread = storedSession.hasUnread  // Explicit unread flag for NEW badge state machine
       managed.enabledSourceSlugs = storedSession.enabledSourceSlugs
+      // Backfill: if no sources were saved, auto-enable all authenticated sources
+      if (!managed.enabledSourceSlugs || managed.enabledSourceSlugs.length === 0) {
+        const allSources = loadAllSources(managed.workspace.rootPath)
+        const readySlugs = allSources
+          .filter(s => s.config.enabled && s.config.isAuthenticated)
+          .map(s => s.config.slug)
+        if (readySlugs.length > 0) {
+          managed.enabledSourceSlugs = readySlugs
+          sessionLog.info(`Auto-enabled ${readySlugs.length} sources for session ${managed.id} (backfill): ${readySlugs.join(', ')}`)
+        }
+      }
       managed.sharedUrl = storedSession.sharedUrl
       managed.sharedId = storedSession.sharedId
       // Sync name from disk - ensures title persistence across lazy loading
@@ -1418,6 +1429,16 @@ export class SessionManager {
       messageQueue: [],
       backgroundShellCommands: new Map(),
       messagesLoaded: true,  // New sessions don't need to load messages from disk
+    }
+
+    // Auto-enable all authenticated sources for new sessions
+    const allSources = loadAllSources(workspaceRootPath)
+    const readySlugs = allSources
+      .filter(s => s.config.enabled && s.config.isAuthenticated)
+      .map(s => s.config.slug)
+    if (readySlugs.length > 0) {
+      managed.enabledSourceSlugs = readySlugs
+      sessionLog.info(`Auto-enabled ${readySlugs.length} sources for new session ${storedSession.id}: ${readySlugs.join(', ')}`)
     }
 
     this.sessions.set(storedSession.id, managed)


### PR DESCRIPTION
## Summary

- **Fixes #115** — Stdio MCP source tools never registered despite successful `source_test`
- **Fixes #93** — Auto-enable sources for new sessions

### Root Cause

`enabledSourceSlugs` starts as `undefined` for every session and is never populated automatically. The `reloadSessionSources()` filter requires sources to be in this list, so all sources are silently filtered out — resulting in "0 MCP, 0 API" for every session.

The existing on-demand activation (`onSourceActivationRequest`) can't compensate because the agent sees sources as "inactive" in the system prompt and never attempts to use them — a chicken-and-egg problem.

### Fix

Auto-populate `enabledSourceSlugs` with all sources where `enabled: true && isAuthenticated: true` in two places:

1. **`createSession()`** — new sessions immediately get all authenticated sources
2. **`loadMessagesFromDisk()`** — existing sessions without saved sources get backfilled on lazy-load

### Changes

- `apps/electron/src/main/sessions.ts` — 21 lines added (two insertion points, same logic)

### Testing

- TypeScript compiles cleanly (no new errors)
- Electron app builds successfully
- Logic is conservative: only enables sources that are both `enabled` and `isAuthenticated`
- Existing sessions with saved `enabledSourceSlugs` are unaffected (backfill only triggers when list is empty/undefined)
