### PR TITLE
fix(electron): register EditPopover with modal registry for proper close handling

### DIFF
--- a/apps/electron/src/renderer/components/ui/EditPopover.tsx
+++ b/apps/electron/src/renderer/components/ui/EditPopover.tsx
@@ -18,6 +18,7 @@ import { usePlatform } from '@craft-agent/ui'
 import type { ContentBadge, Session, CreateSessionOptions } from '../../../shared/types'
 import { useActiveWorkspace, useAppShellContext, useSession } from '@/context/AppShellContext'
 import { useEscapeInterrupt } from '@/context/EscapeInterruptContext'
+import { useRegisterModal } from '@/context/ModalContext'
 import { ChatDisplay } from '../app-shell/ChatDisplay'
 
 /** Rotating placeholders for compact mode input - short, action-oriented */
@@ -670,6 +671,9 @@ export function EditPopover({
       setInternalOpen(value)
     }
   }
+
+  // Register with modal context so Ctrl+W/Cmd+W closes the popover first
+  useRegisterModal(open, () => setOpen(false))
 
   // Use App context for session management (same code path as main chat)
   const { onCreateSession, onSendMessage } = useAppShellContext()


### PR DESCRIPTION
## Summary
Fix uncloseable windows when EditPopover (MCP source dialog, etc.) is open. Pressing Ctrl+W/Cmd+W now properly closes the popover instead of attempting to close the window.

I used amp and opus to fix this problem

## Changes
- Added `useRegisterModal` hook to EditPopover component
- EditPopover now registers with ModalContext when open, allowing the window close handler to close it first

## Testing
I ran the program and added a new MCP, instead of opening a new hyprland window did it create a new window inside the application as in the screenshot.

## Screenshots (if applicable)
<img width="1713" height="1396" alt="image" src="https://github.com/user-attachments/assets/33205c0b-b986-440f-9436-b0040a1e2d23" />

This PR is related to this issue: https://github.com/lukilabs/craft-agents-oss/issues/131