### PR TITLE
feat(mcp-apps): add MCP App sandboxed widget system

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,44 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Main Process",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/apps/electron",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
+      },
+      "runtimeArgs": ["--inspect=9229"],
+      "args": [".", "--remote-debugging-port=9222"],
+      "outputCapture": "std",
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/apps/electron/dist/**/*.{js,cjs}"],
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ],
+      "trace": true
+    },
+    {
+      "name": "Attach to Renderer",
+      "type": "chrome",
+      "request": "attach",
+      "port": 9222,
+      "webRoot": "${workspaceFolder}",
+      "sourceMaps": true,
+      "sourceMapPathOverrides": {
+        "webpack:///./~/*": "${workspaceFolder}/node_modules/*",
+        "webpack:///./*": "${workspaceFolder}/*",
+        "webpack://?:*/*": "${workspaceFolder}/*"
+      }
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Debug All (Main + Renderer)",
+      "configurations": ["Debug Main Process", "Attach to Renderer"]
+    }
+  ]
+}

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -15,7 +15,7 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "build:main": "source ../../.env 2>/dev/null || true; esbuild src/main/index.ts --bundle --platform=node --format=cjs --outfile=dist/main.cjs --external:electron --define:process.env.GOOGLE_OAUTH_CLIENT_ID=\\\"${GOOGLE_OAUTH_CLIENT_ID:-}\\\" --define:process.env.GOOGLE_OAUTH_CLIENT_SECRET=\\\"${GOOGLE_OAUTH_CLIENT_SECRET:-}\\\" --define:process.env.SLACK_OAUTH_CLIENT_ID=\\\"${SLACK_OAUTH_CLIENT_ID:-}\\\" --define:process.env.SLACK_OAUTH_CLIENT_SECRET=\\\"${SLACK_OAUTH_CLIENT_SECRET:-}\\\" --define:process.env.MICROSOFT_OAUTH_CLIENT_ID=\\\"${MICROSOFT_OAUTH_CLIENT_ID:-}\\\"",
+    "build:main": "source ../../.env 2>/dev/null || true; esbuild src/main/index.ts --bundle --platform=node --format=cjs --outfile=dist/main.cjs --external:electron --sourcemap --define:process.env.GOOGLE_OAUTH_CLIENT_ID=\\\"${GOOGLE_OAUTH_CLIENT_ID:-}\\\" --define:process.env.GOOGLE_OAUTH_CLIENT_SECRET=\\\"${GOOGLE_OAUTH_CLIENT_SECRET:-}\\\" --define:process.env.SLACK_OAUTH_CLIENT_ID=\\\"${SLACK_OAUTH_CLIENT_ID:-}\\\" --define:process.env.SLACK_OAUTH_CLIENT_SECRET=\\\"${SLACK_OAUTH_CLIENT_SECRET:-}\\\" --define:process.env.MICROSOFT_OAUTH_CLIENT_ID=\\\"${MICROSOFT_OAUTH_CLIENT_ID:-}\\\"",
     "build:main:win": "esbuild src/main/index.ts --bundle --platform=node --format=cjs --outfile=dist/main.cjs --external:electron",
     "build:preload": "esbuild src/preload/index.ts --bundle --platform=node --format=cjs --outfile=dist/preload.cjs --external:electron",
     "build:renderer": "vite build",

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -81,6 +81,8 @@ import log, { isDebugMode, mainLog, getLogFilePath } from './logger'
 import { setPerfEnabled, enableDebug } from '@craft-agent/shared/utils'
 import { initNotificationService, clearBadgeCount, initBadgeIcon, initInstanceBadge } from './notifications'
 import { checkForUpdatesOnLaunch, setWindowManager as setAutoUpdateWindowManager, isUpdating } from './auto-update'
+import { registerMcpSandboxScheme, setupMcpSandboxProtocol } from './protocols/mcp-sandbox'
+
 
 // Initialize electron-log for renderer process support
 log.initialize()
@@ -91,6 +93,9 @@ if (isDebugMode) {
   enableDebug()
   setPerfEnabled(true)
 }
+
+// Register custom mcp-sandbox:// protocol scheme (must be before app.whenReady)
+registerMcpSandboxScheme()
 
 // Custom URL scheme for deeplinks (e.g., craftagents://auth-complete)
 // Supports multi-instance dev: CRAFT_DEEPLINK_SCHEME env var (craftagents1, craftagents2, etc.)
@@ -210,6 +215,8 @@ async function createInitialWindows(): Promise<void> {
 }
 
 app.whenReady().then(async () => {
+  // Set up mcp-sandbox:// protocol handler (must be after app.whenReady)
+  setupMcpSandboxProtocol()
   // Register bundled assets root so all seeding functions can find their files
   // (docs, permissions, themes, tool-icons resolve via getBundledAssetsDir)
   setBundledAssetsRoot(__dirname)

--- a/apps/electron/src/main/protocols/mcp-sandbox.ts
+++ b/apps/electron/src/main/protocols/mcp-sandbox.ts
@@ -1,0 +1,198 @@
+/**
+ * MCP Sandbox Protocol Handler
+ *
+ * Registers a custom `mcp-sandbox://` protocol that serves sandbox proxy HTML.
+ * Each `mcp-sandbox://server-{hash}/proxy.html` gets a unique origin for isolation.
+ *
+ * Must call registerMcpSandboxScheme() before app.whenReady().
+ * Must call setupMcpSandboxProtocol() after app.whenReady().
+ */
+
+import { protocol } from 'electron'
+
+/**
+ * The proxy HTML served by the mcp-sandbox:// protocol.
+ * Adapted from SEP-1865 reference implementation.
+ */
+// SECURITY: The outer proxy CSP (in both the meta tag and response header) is intentionally
+// permissive because the proxy only contains bootstrap JS that creates the inner iframe.
+// The actual security boundary is the inner iframe's CSP built by buildCSP().
+const PROXY_HTML = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; img-src * data: blob: 'unsafe-inline'; media-src * blob: data:; font-src * blob: data:; script-src * 'wasm-unsafe-eval' 'unsafe-inline' 'unsafe-eval' blob: data:; style-src * blob: data: 'unsafe-inline'; connect-src * data: blob: about:; frame-src * blob: data: http://localhost:* https://localhost:* http://127.0.0.1:* https://127.0.0.1:*;"
+    />
+    <title>MCP Apps Sandbox Proxy</title>
+    <style>
+      html, body { margin: 0; padding: 0; height: 100%; width: 100%; overflow: hidden; }
+      * { box-sizing: border-box; }
+      iframe { display: block; background-color: transparent; border: 0px none transparent; padding: 0px; width: 100%; height: 100%; }
+    </style>
+  </head>
+  <body>
+    <script>
+      function sanitizeDomain(domain) {
+        if (typeof domain !== "string") return "";
+        return domain.replace(/['"<>;]/g, "").trim();
+      }
+
+      function buildAllowAttribute(permissions) {
+        if (!permissions) return "";
+        var allowList = [];
+        if (permissions.camera) allowList.push("camera *");
+        if (permissions.microphone) allowList.push("microphone *");
+        if (permissions.geolocation) allowList.push("geolocation *");
+        if (permissions.clipboardWrite) allowList.push("clipboard-write *");
+        return allowList.join("; ");
+      }
+
+      function buildCSP(csp) {
+        if (!csp) {
+          return [
+            "default-src 'none'",
+            "script-src 'unsafe-inline'",
+            "style-src 'unsafe-inline'",
+            "img-src data:",
+            "font-src data:",
+            "media-src data:",
+            "connect-src 'none'",
+            "frame-src 'none'",
+            "object-src 'none'",
+            "base-uri 'none'"
+          ].join("; ");
+        }
+
+        var connectDomains = (csp.connectDomains || []).map(sanitizeDomain).filter(Boolean);
+        var resourceDomains = (csp.resourceDomains || []).map(sanitizeDomain).filter(Boolean);
+        var frameDomains = (csp.frameDomains || []).map(sanitizeDomain).filter(Boolean);
+        var baseUriDomains = (csp.baseUriDomains || []).map(sanitizeDomain).filter(Boolean);
+
+        var connectSrc = connectDomains.length > 0 ? connectDomains.join(" ") : "'none'";
+        var resourceSrc = resourceDomains.length > 0
+          ? ["data:", "blob:"].concat(resourceDomains).join(" ")
+          : "data: blob:";
+        var frameSrc = frameDomains.length > 0 ? frameDomains.join(" ") : "'none'";
+        var baseUri = baseUriDomains.length > 0 ? baseUriDomains.join(" ") : "'none'";
+
+        return [
+          "default-src 'none'",
+          "script-src 'unsafe-inline' " + resourceSrc,
+          "style-src 'unsafe-inline' " + resourceSrc,
+          "img-src " + resourceSrc,
+          "font-src " + resourceSrc,
+          "media-src " + resourceSrc,
+          "connect-src " + connectSrc,
+          "frame-src " + frameSrc,
+          "object-src 'none'",
+          "base-uri " + baseUri
+        ].join("; ");
+      }
+
+      function buildViolationListenerScript() {
+        return '<script>document.addEventListener("securitypolicyviolation", function(e) { var v = { type: "mcp-apps:csp-violation", directive: e.violatedDirective, blockedUri: e.blockedURI, sourceFile: e.sourceFile || null, lineNumber: e.lineNumber || null }; console.warn("[MCP Apps CSP Violation]", v.directive, ":", v.blockedUri); window.parent.postMessage(v, "*"); });<\\/script>';
+      }
+
+      function injectCSP(html, cspValue) {
+        var cspMeta = '<meta http-equiv="Content-Security-Policy" content="' + cspValue + '">';
+        var injection = cspMeta + buildViolationListenerScript();
+
+        if (html.includes("<head>")) return html.replace("<head>", "<head>" + injection);
+        if (html.includes("<HEAD>")) return html.replace("<HEAD>", "<HEAD>" + injection);
+        if (html.includes("<html>")) return html.replace("<html>", "<html><head>" + injection + "</head>");
+        if (html.includes("<HTML>")) return html.replace("<HTML>", "<HTML><head>" + injection + "</head>");
+        if (html.includes("<!DOCTYPE") || html.includes("<!doctype")) {
+          return html.replace(/(<!DOCTYPE[^>]*>|<!doctype[^>]*>)/i, "$1<head>" + injection + "</head>");
+        }
+        return injection + html;
+      }
+
+      var inner = document.createElement("iframe");
+      inner.style = "width:100%; height:100%; border:none;";
+      inner.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms");
+      document.body.appendChild(inner);
+
+      window.addEventListener("message", function(event) {
+        if (event.source === window.parent) {
+          if (event.data && event.data.method === "ui/notifications/sandbox-resource-ready") {
+            var p = event.data.params || {};
+            if (typeof p.sandbox === "string") inner.setAttribute("sandbox", p.sandbox);
+            var allowAttr = buildAllowAttribute(p.permissions);
+            if (allowAttr) inner.setAttribute("allow", allowAttr);
+            if (typeof p.html === "string") {
+              if (p.permissive) {
+                // WARNING: Permissive CSP — for dev/testing only. Do not use in production.
+                var permissiveCsp = [
+                  "default-src * 'unsafe-inline' 'unsafe-eval' data: blob: filesystem: about:",
+                  "script-src * 'unsafe-inline' 'unsafe-eval' data: blob:",
+                  "style-src * 'unsafe-inline' data: blob:",
+                  "img-src * data: blob: https: http:",
+                  "media-src * data: blob: https: http:",
+                  "font-src * data: blob: https: http:",
+                  "connect-src * data: blob: https: http: ws: wss: about:",
+                  "frame-src * data: blob: https: http: about:",
+                  "object-src * data: blob:",
+                  "base-uri *",
+                  "form-action *"
+                ].join("; ");
+                inner.srcdoc = injectCSP(p.html, permissiveCsp);
+              } else {
+                inner.srcdoc = injectCSP(p.html, buildCSP(p.csp));
+              }
+            }
+          } else {
+            // SECURITY: '*' targetOrigin — inner iframe origin varies per sandbox configuration.
+            if (inner && inner.contentWindow) inner.contentWindow.postMessage(event.data, "*");
+          }
+        } else if (event.source === inner.contentWindow) {
+          // SECURITY: '*' targetOrigin — host origin varies per environment (e.g., file://, app://).
+          window.parent.postMessage(event.data, "*");
+        }
+      });
+
+      window.parent.postMessage({
+        jsonrpc: "2.0",
+        method: "ui/notifications/sandbox-proxy-ready",
+        params: {}
+      }, "*");
+    </script>
+  </body>
+</html>`
+
+/**
+ * Register the mcp-sandbox:// scheme as privileged.
+ * MUST be called before app.whenReady().
+ */
+export function registerMcpSandboxScheme(): void {
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: 'mcp-sandbox',
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        corsEnabled: true,
+      },
+    },
+  ])
+}
+
+/**
+ * Set up the mcp-sandbox:// protocol handler.
+ * MUST be called after app.whenReady().
+ */
+export function setupMcpSandboxProtocol(): void {
+  protocol.handle('mcp-sandbox', (_request) => {
+    return new Response(PROXY_HTML, {
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        // SECURITY: Response header CSP mirrors the meta tag CSP in PROXY_HTML.
+        // Intentionally permissive — see comment above PROXY_HTML.
+        'Content-Security-Policy':
+          "default-src 'self'; img-src * data: blob: 'unsafe-inline'; media-src * blob: data:; font-src * blob: data:; script-src * 'wasm-unsafe-eval' 'unsafe-inline' 'unsafe-eval' blob: data:; style-src * blob: data: 'unsafe-inline'; connect-src * data: blob: about:; frame-src * blob: data:;",
+      },
+    })
+  })
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -428,6 +428,14 @@ const api: ElectronAPI = {
       ipcRenderer.removeListener(IPC_CHANNELS.NOTIFICATION_NAVIGATE, handler)
     }
   },
+  // MCP Widget tool/resource access
+  mcpWidgetCallTool: (workspaceId: string, sourceSlug: string, name: string, args: Record<string, unknown>) =>
+    ipcRenderer.invoke(IPC_CHANNELS.MCP_WIDGET_CALL_TOOL, workspaceId, sourceSlug, name, args),
+  mcpWidgetReadResource: (workspaceId: string, sourceSlug: string, uri: string) =>
+    ipcRenderer.invoke(IPC_CHANNELS.MCP_WIDGET_READ_RESOURCE, workspaceId, sourceSlug, uri),
+  mcpWidgetListResources: (workspaceId: string, sourceSlug: string) =>
+    ipcRenderer.invoke(IPC_CHANNELS.MCP_WIDGET_LIST_RESOURCES, workspaceId, sourceSlug),
+
   getGitBranch: (dirPath: string) =>
     ipcRenderer.invoke(IPC_CHANNELS.GET_GIT_BRANCH, dirPath),
 

--- a/apps/electron/src/renderer/components/app-shell/ChatDisplay.tsx
+++ b/apps/electron/src/renderer/components/app-shell/ChatDisplay.tsx
@@ -52,6 +52,7 @@ import { useTurnCardExpansion } from "@/hooks/useTurnCardExpansion"
 import type { SessionMeta } from "@/atoms/sessions"
 import { CHAT_LAYOUT } from "@/config/layout"
 import { flattenLabels } from "@craft-agent/shared/labels"
+import { McpAppWidgetStack } from "@craft-agent/ui/mcp-apps"
 
 // ============================================================================
 // Overlay State Types
@@ -1464,6 +1465,26 @@ export const ChatDisplay = React.forwardRef<ChatDisplayHandle, ChatDisplayProps>
                               consolidated: true, // Consolidated mode - group by file
                             })
                           }
+                        }}
+                      />
+                      <McpAppWidgetStack
+                        activities={turn.activities}
+                        onCallTool={(serverId, name, args) => {
+                          // Derive sourceSlug from serverId (same as the server name from mcp__{serverName}__{tool})
+                          return window.electronAPI.mcpWidgetCallTool(workspaceId || '', serverId, name, args)
+                        }}
+                        onReadResource={(serverId, uri) => {
+                          return window.electronAPI.mcpWidgetReadResource(workspaceId || '', serverId, uri)
+                        }}
+                        onListResources={(serverId) => {
+                          return window.electronAPI.mcpWidgetListResources(workspaceId || '', serverId)
+                        }}
+                        onSendFollowUp={(text) => {
+                          // Insert the follow-up text into the input
+                          // Use the same dispatch mechanism as other follow-up patterns
+                          window.dispatchEvent(new CustomEvent('craft:approve-plan', {
+                            detail: { text, sessionId: session?.id }
+                          }))
                         }}
                       />
                       </div>

--- a/apps/electron/src/renderer/index.html
+++ b/apps/electron/src/renderer/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' http://localhost:8097; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https: file: thumbnail:; connect-src 'self' https: ws://localhost:8097 http://localhost:8097; font-src 'self' https://fonts.gstatic.com; worker-src 'self' blob:; object-src 'self' file:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' http://localhost:8097; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https: file: thumbnail:; connect-src 'self' https: ws://localhost:8097 http://localhost:8097; font-src 'self' https://fonts.gstatic.com; worker-src 'self' blob:; object-src 'self' file:; frame-src mcp-sandbox:;">
   <title>Craft Agents</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/apps/electron/src/shared/types.ts
+++ b/apps/electron/src/shared/types.ts
@@ -723,6 +723,11 @@ export const IPC_CHANNELS = {
   // Git operations
   GET_GIT_BRANCH: 'git:getBranch',
 
+  // MCP Widget tool/resource access
+  MCP_WIDGET_CALL_TOOL: 'mcp:widget:callTool',
+  MCP_WIDGET_READ_RESOURCE: 'mcp:widget:readResource',
+  MCP_WIDGET_LIST_RESOURCES: 'mcp:widget:listResources',
+
   // Git Bash (Windows)
   GITBASH_CHECK: 'gitbash:check',
   GITBASH_BROWSE: 'gitbash:browse',
@@ -997,6 +1002,11 @@ export interface ElectronAPI {
 
   // Git operations
   getGitBranch(dirPath: string): Promise<string | null>
+
+  // MCP Widget tool/resource access
+  mcpWidgetCallTool(workspaceId: string, sourceSlug: string, name: string, args: Record<string, unknown>): Promise<unknown>
+  mcpWidgetReadResource(workspaceId: string, sourceSlug: string, uri: string): Promise<unknown>
+  mcpWidgetListResources(workspaceId: string, sourceSlug: string): Promise<{ resources: unknown[] }>
 
   // Git Bash (Windows)
   checkGitBash(): Promise<GitBashStatus>

--- a/packages/shared/src/agent/__tests__/tool-matching-meta.test.ts
+++ b/packages/shared/src/agent/__tests__/tool-matching-meta.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for _meta merging in extractToolResults.
+ *
+ * extractMcpMeta and mergeMetaIntoResult are private — tested through
+ * extractToolResults which is the public entry point.
+ */
+
+import { describe, it, expect, beforeEach } from 'bun:test'
+import {
+  ToolIndex,
+  extractToolResults,
+  type ToolResultBlock,
+  type ContentBlock,
+} from '../tool-matching'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeToolResultBlock(
+  toolUseId: string,
+  content: unknown = 'success',
+  isError = false,
+): ToolResultBlock {
+  return {
+    type: 'tool_result',
+    tool_use_id: toolUseId,
+    content,
+    is_error: isError,
+  }
+}
+
+/** Narrow an AgentEvent to a tool_result and return the result string */
+function getResultStr(events: ReturnType<typeof extractToolResults>, idx = 0): string {
+  const ev = events[idx]! as { type: 'tool_result'; result: string }
+  expect(ev.type).toBe('tool_result')
+  return ev.result
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('extractToolResults — _meta merging', () => {
+  let index: ToolIndex
+
+  beforeEach(() => {
+    index = new ToolIndex()
+  })
+
+  it('merges _meta from toolUseResultValue into MCP tool result (primary path)', () => {
+    index.register('toolu_1', 'mcp__my-server__render', {})
+
+    const blocks: ContentBlock[] = [
+      makeToolResultBlock('toolu_1', [{ type: 'text', text: '{"ok":true}' }]),
+    ]
+    const toolUseResultValue = {
+      content: [{ type: 'text', text: '{"ok":true}' }],
+      _meta: { 'mcp-use/widget': { type: 'mcpApps', html: '<div>hi</div>' } },
+    }
+
+    const events = extractToolResults(blocks, 'toolu_1', toolUseResultValue, index)
+    expect(events.length).toBeGreaterThanOrEqual(1)
+
+    const resultStr = getResultStr(events)
+    const parsed = JSON.parse(resultStr)
+    expect(parsed._meta).toBeDefined()
+    expect(parsed._meta['mcp-use/widget'].type).toBe('mcpApps')
+  })
+
+  it('does NOT merge _meta for non-MCP tools (primary path)', () => {
+    index.register('toolu_2', 'Read', { file_path: '/foo' })
+
+    const blocks: ContentBlock[] = [
+      makeToolResultBlock('toolu_2', [{ type: 'text', text: 'file contents' }]),
+    ]
+    const toolUseResultValue = {
+      content: [{ type: 'text', text: 'file contents' }],
+      _meta: { 'mcp-use/widget': { type: 'mcpApps', html: '<div>hi</div>' } },
+    }
+
+    const events = extractToolResults(blocks, 'toolu_2', toolUseResultValue, index)
+    expect(events.length).toBeGreaterThanOrEqual(1)
+
+    const resultStr = getResultStr(events)
+    // _meta should NOT be present because tool name doesn't start with mcp__
+    expect(resultStr).not.toContain('mcp-use/widget')
+  })
+
+  it('merges _meta in the fallback path (no content blocks, MCP tool)', () => {
+    index.register('toolu_3', 'mcp__server__tool', {})
+
+    // toolUseResultValue WITHOUT _meta at the top level — _meta is extracted
+    // separately by extractMcpMeta and merged back in by mergeMetaIntoResult.
+    // Use a simple string content so the original serialization won't contain _meta.
+    const toolUseResultValue = {
+      content: [{ type: 'text', text: 'hello' }],
+      _meta: { 'mcp-use/widget': { type: 'mcpApps', html: '<b>bold</b>' } },
+    }
+
+    // Empty content blocks → fallback path
+    const events = extractToolResults([], 'toolu_3', toolUseResultValue, index)
+    expect(events.length).toBeGreaterThanOrEqual(1)
+
+    const resultStr = getResultStr(events)
+    const parsed = JSON.parse(resultStr)
+    // _meta should be merged back in for MCP tools
+    expect(parsed._meta).toBeDefined()
+    expect(parsed._meta['mcp-use/widget'].html).toBe('<b>bold</b>')
+  })
+
+  it('does NOT double-merge _meta in fallback path for non-MCP tools', () => {
+    // For non-MCP tools in the fallback path, the serialized toolUseResultValue
+    // will naturally contain _meta (since we serialize the whole object), but
+    // mergeMetaIntoResult should NOT be called, meaning no double-merging occurs.
+    index.register('toolu_4', 'Bash', { command: 'ls' })
+
+    // Use a toolUseResultValue where _meta has a distinctive marker
+    const toolUseResultValue = {
+      output: 'some output',
+      _meta: { 'mcp-use/widget': { type: 'mcpApps', html: '<div/>' } },
+    }
+
+    const events = extractToolResults([], 'toolu_4', toolUseResultValue, index)
+    expect(events.length).toBeGreaterThanOrEqual(1)
+
+    const resultStr = getResultStr(events)
+    const parsed = JSON.parse(resultStr)
+
+    // The original _meta is present because the entire object was serialized,
+    // but mergeMetaIntoResult was NOT called (non-MCP tool) so the structure
+    // should match the original object exactly — no wrapping or duplication.
+    expect(parsed.output).toBe('some output')
+    expect(parsed._meta).toEqual({ 'mcp-use/widget': { type: 'mcpApps', html: '<div/>' } })
+  })
+
+  it('does not add _meta when toolUseResultValue has no _meta', () => {
+    index.register('toolu_5', 'mcp__server__tool', {})
+
+    const blocks: ContentBlock[] = [
+      makeToolResultBlock('toolu_5', [{ type: 'text', text: 'plain result' }]),
+    ]
+    const toolUseResultValue = {
+      content: [{ type: 'text', text: 'plain result' }],
+    }
+
+    const events = extractToolResults(blocks, 'toolu_5', toolUseResultValue, index)
+    const resultStr = getResultStr(events)
+    expect(resultStr).not.toContain('_meta')
+  })
+
+  it('merges _meta for MCP tool but not for non-MCP tool in same message', () => {
+    index.register('toolu_mcp', 'mcp__server__render', {})
+    index.register('toolu_read', 'Read', { file_path: '/x' })
+
+    const blocks: ContentBlock[] = [
+      makeToolResultBlock('toolu_mcp', [{ type: 'text', text: 'widget result' }]),
+      makeToolResultBlock('toolu_read', [{ type: 'text', text: 'file data' }]),
+    ]
+    const toolUseResultValue = {
+      content: [],
+      _meta: { 'mcp-use/widget': { type: 'mcpApps', html: '<div>w</div>' } },
+    }
+
+    const events = extractToolResults(blocks, null, toolUseResultValue, index)
+    const toolResults = events.filter(e => e.type === 'tool_result')
+    expect(toolResults).toHaveLength(2)
+
+    // MCP tool should have _meta merged
+    const mcpResult = (toolResults.find(e =>
+      (e as { toolUseId: string }).toolUseId === 'toolu_mcp'
+    )! as { result: string }).result
+    expect(mcpResult).toContain('mcp-use/widget')
+
+    // Non-MCP tool should NOT have _meta
+    const readResult = (toolResults.find(e =>
+      (e as { toolUseId: string }).toolUseId === 'toolu_read'
+    )! as { result: string }).result
+    expect(readResult).not.toContain('mcp-use/widget')
+  })
+})

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,6 +13,7 @@
     "./chat/TurnCard": "./src/components/chat/TurnCard.tsx",
     "./chat/turn-utils": "./src/components/chat/turn-utils.ts",
     "./markdown": "./src/components/markdown/index.ts",
+    "./mcp-apps": "./src/components/mcp-apps/index.ts",
     "./context": "./src/context/index.ts",
     "./styles": "./src/styles/index.css"
   },

--- a/packages/ui/src/components/mcp-apps/McpAppWidget.tsx
+++ b/packages/ui/src/components/mcp-apps/McpAppWidget.tsx
@@ -1,0 +1,189 @@
+/**
+ * McpAppWidget - Renders a single MCP Apps widget with AppBridge communication
+ *
+ * Creates a SandboxedIframe, wires up McpAppsHostBridge for JSON-RPC 2.0 protocol,
+ * and handles tool input/output delivery, size changes, and link opening.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { SandboxedIframe, type SandboxedIframeHandle } from './SandboxedIframe'
+import { McpAppsHostBridge, type HostContext } from './McpAppsHostBridge'
+import { Spinner } from '../ui'
+import { cn } from '../../lib/utils'
+
+export interface McpAppWidgetProps {
+  html: string
+  name: string
+  serverId: string
+  csp?: { connectDomains?: string[]; resourceDomains?: string[]; baseUriDomains?: string[] }
+  props?: Record<string, unknown>
+  /** Dev mode: use permissive CSP for the inner iframe */
+  dev?: boolean
+  toolInput?: Record<string, unknown>
+  toolOutput?: unknown
+  // Callbacks for host capabilities
+  onCallTool?: (name: string, args: Record<string, unknown>) => Promise<unknown>
+  onReadResource?: (uri: string) => Promise<unknown>
+  onListResources?: () => Promise<{ resources: unknown[] }>
+  onSendFollowUp?: (text: string) => void
+}
+
+const INIT_TIMEOUT_MS = 15000
+const DEFAULT_HEIGHT = 200
+
+export function McpAppWidget({
+  html,
+  name,
+  serverId,
+  csp,
+  dev,
+  toolInput,
+  toolOutput,
+  onCallTool,
+  onReadResource,
+  onListResources,
+  onSendFollowUp,
+}: McpAppWidgetProps) {
+  const sandboxRef = useRef<SandboxedIframeHandle>(null)
+  const bridgeRef = useRef<McpAppsHostBridge | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [iframeHeight, setIframeHeight] = useState(DEFAULT_HEIGHT)
+  const initSentRef = useRef(false)
+
+  // Refs for callback props — the bridge is created once but must always
+  // call through the latest callback to avoid stale closures.
+  const onCallToolRef = useRef(onCallTool)
+  const onReadResourceRef = useRef(onReadResource)
+  const onListResourcesRef = useRef(onListResources)
+  const onSendFollowUpRef = useRef(onSendFollowUp)
+
+  useEffect(() => {
+    onCallToolRef.current = onCallTool
+    onReadResourceRef.current = onReadResource
+    onListResourcesRef.current = onListResources
+    onSendFollowUpRef.current = onSendFollowUp
+  }, [onCallTool, onReadResource, onListResources, onSendFollowUp])
+
+  // Create bridge when proxy is ready
+  const handleProxyReady = useCallback(() => {
+    if (bridgeRef.current) return
+
+    const bridge = new McpAppsHostBridge({
+      sendMessage: (data) => sandboxRef.current?.postMessage(data),
+      hostInfo: { name: 'Craft Agents', version: '1.0.0' },
+      hostContext: {
+        theme: { mode: 'dark' },
+        displayMode: 'inline',
+        platform: 'desktop',
+      } satisfies HostContext,
+      hostCapabilities: {
+        openLinks: {},
+        serverTools: onCallToolRef.current ? {} : undefined,
+        serverResources: onReadResourceRef.current ? {} : undefined,
+        logging: {},
+      },
+      onCallTool: (...args) => onCallToolRef.current?.(...args),
+      onReadResource: (...args) => onReadResourceRef.current?.(...args),
+      onListResources: (...args) => onListResourcesRef.current?.(),
+      onMessage: (content) => {
+        // Widget is sending a message to the conversation
+        const params = content as { role?: string; content?: { type: string; text: string } }
+        if (params?.content?.text) {
+          onSendFollowUpRef.current?.(params.content.text)
+        }
+      },
+      onOpenLink: (url) => {
+        // Open link in default browser
+        const win = window as { electronAPI?: { openUrl?: (url: string) => void } }
+        if (win.electronAPI?.openUrl) {
+          win.electronAPI.openUrl(url)
+        } else {
+          window.open(url, '_blank', 'noopener,noreferrer')
+        }
+      },
+      onSizeChanged: (size) => {
+        if (size.height && size.height > 0) {
+          setIframeHeight(size.height)
+        }
+      },
+      onInitialized: () => {
+        setIsLoading(false)
+
+        // Send tool input and output after widget is initialized
+        if (!initSentRef.current) {
+          initSentRef.current = true
+          if (toolInput) {
+            bridge.sendToolInput(toolInput)
+          }
+          if (toolOutput) {
+            bridge.sendToolResult(toolOutput)
+          }
+        }
+      },
+    })
+
+    bridgeRef.current = bridge
+  }, [])
+
+  // Handle messages from the sandbox
+  const handleMessage = useCallback((event: MessageEvent) => {
+    bridgeRef.current?.handleMessage(event)
+  }, [])
+
+  // Timeout for initialization
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (isLoading) {
+        setError('Widget failed to initialize')
+        setIsLoading(false)
+      }
+    }, INIT_TIMEOUT_MS)
+    return () => clearTimeout(timer)
+  }, [isLoading])
+
+  // Cleanup
+  useEffect(() => {
+    return () => {
+      bridgeRef.current?.destroy()
+      bridgeRef.current = null
+    }
+  }, [])
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-border/30 overflow-hidden p-3 text-sm text-muted-foreground">
+        Failed to load widget: {name}
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-lg border border-border/30 overflow-hidden">
+      {/* Loading state */}
+      {isLoading && (
+        <div className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground">
+          <Spinner className="text-[10px]" />
+          <span>{name}</span>
+        </div>
+      )}
+
+      {/* Widget iframe */}
+      <SandboxedIframe
+        ref={sandboxRef}
+        html={html}
+        serverId={serverId}
+        csp={csp}
+        permissive={dev}
+        onProxyReady={handleProxyReady}
+        onMessage={handleMessage}
+        className={cn('w-full', isLoading && 'invisible h-0')}
+        style={{
+          height: isLoading ? 0 : iframeHeight,
+          transition: 'height 300ms ease-out',
+        }}
+        title={`MCP App: ${name}`}
+      />
+    </div>
+  )
+}

--- a/packages/ui/src/components/mcp-apps/McpAppWidgetStack.tsx
+++ b/packages/ui/src/components/mcp-apps/McpAppWidgetStack.tsx
@@ -1,0 +1,76 @@
+/**
+ * McpAppWidgetStack - Renders MCP Apps widgets below a TurnCard
+ *
+ * Filters activities for MCP Apps widget metadata, extracts widget data,
+ * and renders a vertical stack of McpAppWidget components.
+ */
+
+import { useMemo } from 'react'
+import type { ActivityItem } from '../chat/TurnCard'
+import { McpAppWidget } from './McpAppWidget'
+import { extractMcpAppWidget, deriveServerId, type McpAppWidgetData } from './mcp-app-utils'
+
+export interface McpAppWidgetStackProps {
+  activities: ActivityItem[]
+  // Pass through for tool/resource calls
+  onCallTool?: (serverId: string, name: string, args: Record<string, unknown>) => Promise<unknown>
+  onReadResource?: (serverId: string, uri: string) => Promise<unknown>
+  onListResources?: (serverId: string) => Promise<{ resources: unknown[] }>
+  onSendFollowUp?: (text: string) => void
+}
+
+export function McpAppWidgetStack({
+  activities,
+  onCallTool,
+  onReadResource,
+  onListResources,
+  onSendFollowUp,
+}: McpAppWidgetStackProps) {
+  // Extract MCP Apps widgets from activities
+  const widgets = useMemo(() => {
+    const result: (McpAppWidgetData & { serverId: string })[] = []
+    for (const activity of activities) {
+      const widget = extractMcpAppWidget(activity)
+      if (widget) {
+        result.push({
+          ...widget,
+          serverId: deriveServerId(activity),
+        })
+      }
+    }
+    return result
+  }, [activities])
+
+  if (widgets.length === 0) return null
+
+  return (
+    <div className="space-y-2 mt-2">
+      {widgets.map((widget) => (
+        <McpAppWidget
+          key={widget.activity.id}
+          html={widget.html}
+          name={widget.name}
+          serverId={widget.serverId}
+          csp={widget.csp}
+          props={widget.props}
+          dev={widget.dev}
+          toolInput={widget.toolInput}
+          toolOutput={widget.toolOutput}
+          onCallTool={onCallTool
+            ? (name, args) => onCallTool(widget.serverId, name, args)
+            : undefined
+          }
+          onReadResource={onReadResource
+            ? (uri) => onReadResource(widget.serverId, uri)
+            : undefined
+          }
+          onListResources={onListResources
+            ? () => onListResources(widget.serverId)
+            : undefined
+          }
+          onSendFollowUp={onSendFollowUp}
+        />
+      ))}
+    </div>
+  )
+}

--- a/packages/ui/src/components/mcp-apps/McpAppsHostBridge.ts
+++ b/packages/ui/src/components/mcp-apps/McpAppsHostBridge.ts
@@ -1,0 +1,239 @@
+/**
+ * McpAppsHostBridge - Host-side JSON-RPC 2.0 handler for MCP Apps protocol (SEP-1865)
+ *
+ * Handles communication between the host application and widget iframes
+ * via the SandboxedIframe's postMessage relay.
+ */
+
+export interface HostContext {
+  theme?: {
+    mode?: 'light' | 'dark'
+  }
+  displayMode?: 'inline' | 'pip' | 'fullscreen'
+  platform?: 'web' | 'desktop' | 'mobile'
+  locale?: string
+  timeZone?: string
+}
+
+export interface McpAppsHostBridgeOptions {
+  /** Send a message to the widget iframe via SandboxedIframe ref */
+  sendMessage: (data: unknown) => void
+  /** Host application info */
+  hostInfo: { name: string; version: string }
+  /** Initial host context */
+  hostContext: HostContext
+  /** Host capabilities advertised to the widget */
+  hostCapabilities: {
+    openLinks?: object
+    serverTools?: object
+    serverResources?: object
+    logging?: object
+  }
+  // Handler callbacks
+  onCallTool?: (name: string, args: Record<string, unknown>) => Promise<unknown>
+  onReadResource?: (uri: string) => Promise<unknown>
+  onListResources?: () => Promise<{ resources: unknown[] }>
+  onMessage?: (content: unknown) => void
+  onOpenLink?: (url: string) => void
+  onRequestDisplayMode?: (mode: string) => { mode: string }
+  onSizeChanged?: (size: { width?: number; height?: number }) => void
+  onInitialized?: () => void
+}
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0'
+  id: number | string
+  method: string
+  params?: unknown
+}
+
+interface JsonRpcNotification {
+  jsonrpc: '2.0'
+  method: string
+  params?: unknown
+}
+
+export class McpAppsHostBridge {
+  private options: McpAppsHostBridgeOptions
+
+  constructor(options: McpAppsHostBridgeOptions) {
+    this.options = options
+  }
+
+  /**
+   * Handle an incoming message from the widget iframe.
+   * Route to the appropriate handler based on the JSON-RPC method.
+   */
+  handleMessage(event: MessageEvent): void {
+    const data = event.data
+    if (!data || data.jsonrpc !== '2.0') return
+
+    // Handle requests (have an id, expect a response)
+    if ('id' in data && 'method' in data) {
+      this.handleRequest(data as JsonRpcRequest)
+      return
+    }
+
+    // Handle notifications (no id, no response needed)
+    if ('method' in data && !('id' in data)) {
+      this.handleNotification(data as JsonRpcNotification)
+      return
+    }
+  }
+
+  private async handleRequest(request: JsonRpcRequest): Promise<void> {
+    try {
+      let result: unknown
+
+      switch (request.method) {
+        case 'ui/initialize':
+          result = {
+            protocolVersion: '2025-03-26',
+            hostInfo: this.options.hostInfo,
+            hostContext: this.options.hostContext,
+            hostCapabilities: this.options.hostCapabilities,
+          }
+          break
+
+        case 'tools/call': {
+          const params = request.params as { name: string; arguments: Record<string, unknown> }
+          if (this.options.onCallTool) {
+            result = await this.options.onCallTool(params.name, params.arguments || {})
+          } else {
+            this.sendError(request.id, -32601, 'Tool calls not supported')
+            return
+          }
+          break
+        }
+
+        case 'resources/read': {
+          const params = request.params as { uri: string }
+          if (this.options.onReadResource) {
+            result = await this.options.onReadResource(params.uri)
+          } else {
+            this.sendError(request.id, -32601, 'Resource reading not supported')
+            return
+          }
+          break
+        }
+
+        case 'resources/list': {
+          if (this.options.onListResources) {
+            result = await this.options.onListResources()
+          } else {
+            this.sendError(request.id, -32601, 'Resource listing not supported')
+            return
+          }
+          break
+        }
+
+        case 'ui/message': {
+          this.options.onMessage?.(request.params)
+          result = {}
+          break
+        }
+
+        case 'ui/open-link': {
+          const params = request.params as { url: string }
+          this.options.onOpenLink?.(params.url)
+          result = {}
+          break
+        }
+
+        case 'ui/request-display-mode': {
+          const params = request.params as { mode: string }
+          if (this.options.onRequestDisplayMode) {
+            result = this.options.onRequestDisplayMode(params.mode)
+          } else {
+            result = { mode: 'inline' }
+          }
+          break
+        }
+
+        default:
+          this.sendError(request.id, -32601, `Method not found: ${request.method}`)
+          return
+      }
+
+      this.sendResponse(request.id, result)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Internal error'
+      this.sendError(request.id, -32603, message)
+    }
+  }
+
+  private handleNotification(notification: JsonRpcNotification): void {
+    switch (notification.method) {
+      case 'ui/notifications/size-changed': {
+        const params = notification.params as { width?: number; height?: number }
+        this.options.onSizeChanged?.(params)
+        break
+      }
+
+      case 'ui/notifications/initialized':
+        this.options.onInitialized?.()
+        break
+
+      case 'notifications/message':
+        // Console log forwarding from widget - just log it
+        break
+
+      default:
+        break
+    }
+  }
+
+  private sendResponse(id: number | string, result: unknown): void {
+    this.options.sendMessage({
+      jsonrpc: '2.0',
+      id,
+      result: result ?? {},
+    })
+  }
+
+  private sendError(id: number | string, code: number, message: string): void {
+    this.options.sendMessage({
+      jsonrpc: '2.0',
+      id,
+      error: { code, message },
+    })
+  }
+
+  /** Send tool input notification to widget */
+  sendToolInput(args: Record<string, unknown>): void {
+    this.options.sendMessage({
+      jsonrpc: '2.0',
+      method: 'ui/notifications/tool-input',
+      params: { arguments: args },
+    })
+  }
+
+  /** Send tool result notification to widget */
+  sendToolResult(result: unknown): void {
+    // If result is an object with content array, send directly
+    // Otherwise wrap in structuredContent
+    const params = (result && typeof result === 'object' && 'content' in (result as Record<string, unknown>))
+      ? result
+      : { structuredContent: result }
+    this.options.sendMessage({
+      jsonrpc: '2.0',
+      method: 'ui/notifications/tool-result',
+      params,
+    })
+  }
+
+  /** Update host context and notify widget */
+  setHostContext(context: Partial<HostContext>): void {
+    this.options.hostContext = { ...this.options.hostContext, ...context }
+    this.options.sendMessage({
+      jsonrpc: '2.0',
+      method: 'ui/notifications/host-context-changed',
+      params: context,
+    })
+  }
+
+  /** Cleanup */
+  destroy(): void {
+    // No persistent state to clean up
+  }
+}

--- a/packages/ui/src/components/mcp-apps/SandboxedIframe.tsx
+++ b/packages/ui/src/components/mcp-apps/SandboxedIframe.tsx
@@ -1,0 +1,162 @@
+/**
+ * SandboxedIframe - Double-Iframe Sandbox Component for MCP Apps (SEP-1865)
+ *
+ * Provides secure double-iframe architecture for rendering untrusted HTML:
+ * Host Page → Sandbox Proxy (mcp-sandbox:// origin) → Guest UI
+ *
+ * Adapted for Electron: uses mcp-sandbox://server-{serverId}/proxy.html
+ * instead of hostname-swapping, giving each server a unique origin.
+ */
+
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react'
+
+// SECURITY: allow-same-origin is required so the proxy iframe (mcp-sandbox:// origin)
+// can relay postMessages between the host and the inner guest iframe. The double-iframe
+// design isolates the actual guest UI in a separate inner iframe with its own sandbox
+// and CSP, so allow-same-origin on the outer proxy does not grant the guest same-origin.
+const IFRAME_SANDBOX_PERMISSIONS = 'allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox'
+
+export interface SandboxedIframeHandle {
+  postMessage: (data: unknown) => void
+  getIframeElement: () => HTMLIFrameElement | null
+}
+
+interface SandboxedIframeProps {
+  /** HTML content to render in the sandbox */
+  html: string | null
+  /** Server ID for unique origin isolation */
+  serverId: string
+  /** Sandbox attribute for the inner iframe */
+  sandbox?: string
+  /** CSP metadata from resource _meta.ui.csp (SEP-1865) */
+  csp?: {
+    connectDomains?: string[]
+    resourceDomains?: string[]
+    frameDomains?: string[]
+    baseUriDomains?: string[]
+  }
+  /** Permissions metadata from resource _meta.ui.permissions (SEP-1865) */
+  permissions?: {
+    camera?: object
+    microphone?: object
+    geolocation?: object
+    clipboardWrite?: object
+  }
+  /** Skip CSP injection entirely (for permissive/testing mode) */
+  permissive?: boolean
+  /** Callback when sandbox proxy is ready */
+  onProxyReady?: () => void
+  /** Callback for messages from guest UI */
+  onMessage: (event: MessageEvent) => void
+  /** CSS class for the outer iframe */
+  className?: string
+  /** Inline styles for the outer iframe */
+  style?: React.CSSProperties
+  /** Title for accessibility */
+  title?: string
+}
+
+export const SandboxedIframe = forwardRef<
+  SandboxedIframeHandle,
+  SandboxedIframeProps
+>(function SandboxedIframe(
+  {
+    html,
+    serverId,
+    sandbox = IFRAME_SANDBOX_PERMISSIONS,
+    csp,
+    permissions,
+    permissive,
+    onProxyReady,
+    onMessage,
+    className,
+    style,
+    title = 'MCP App Widget',
+  },
+  ref
+) {
+  const outerRef = useRef<HTMLIFrameElement>(null)
+  const [proxyReady, setProxyReady] = useState(false)
+
+  // Each server gets a unique origin via mcp-sandbox://server-{serverId}
+  const sandboxProxyUrl = `mcp-sandbox://server-${serverId}/proxy.html`
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      postMessage: (data: unknown) => {
+        // SECURITY: '*' targetOrigin used because mcp-sandbox://server-{serverId} origins
+        // vary per server. TODO: tighten to `mcp-sandbox://server-${serverId}` in a future pass.
+        outerRef.current?.contentWindow?.postMessage(data, '*')
+      },
+      getIframeElement: () => outerRef.current,
+    }),
+    []
+  )
+
+  const handleMessage = useCallback(
+    (event: MessageEvent) => {
+      if (event.source !== outerRef.current?.contentWindow) return
+
+      // Handle sandbox-specific messages
+      if (
+        event.data?.method === 'ui/notifications/sandbox-proxy-ready' ||
+        event.data?.type === 'sandbox-proxy-ready'
+      ) {
+        setProxyReady(true)
+        onProxyReady?.()
+        return
+      }
+
+      // Forward all other messages to parent handler
+      onMessage(event)
+    },
+    [onProxyReady, onMessage]
+  )
+
+  // Listen for messages from proxy
+  useEffect(() => {
+    window.addEventListener('message', handleMessage)
+    return () => window.removeEventListener('message', handleMessage)
+  }, [handleMessage])
+
+  // Send HTML to proxy when ready
+  useEffect(() => {
+    if (!proxyReady || !html || !outerRef.current?.contentWindow) return
+
+    // SECURITY: '*' targetOrigin — same rationale as postMessage above.
+    outerRef.current.contentWindow.postMessage(
+      {
+        jsonrpc: '2.0',
+        method: 'ui/notifications/sandbox-resource-ready',
+        params: {
+          html,
+          sandbox,
+          csp,
+          permissions,
+          permissive,
+        },
+      },
+      '*'
+    )
+  }, [proxyReady, html, sandbox, csp, permissions, permissive])
+
+  return (
+    <iframe
+      ref={outerRef}
+      src={sandboxProxyUrl}
+      className={className}
+      style={style}
+      title={title}
+      sandbox={sandbox}
+      allow="web-share"
+    />
+  )
+})

--- a/packages/ui/src/components/mcp-apps/__tests__/McpAppsHostBridge.test.ts
+++ b/packages/ui/src/components/mcp-apps/__tests__/McpAppsHostBridge.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for McpAppsHostBridge JSON-RPC message routing.
+ */
+
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { McpAppsHostBridge, type McpAppsHostBridgeOptions } from '../McpAppsHostBridge'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMessageEvent(data: unknown): MessageEvent {
+  return { data } as MessageEvent
+}
+
+function createBridge(overrides: Partial<McpAppsHostBridgeOptions> = {}) {
+  const sent: unknown[] = []
+  const options: McpAppsHostBridgeOptions = {
+    sendMessage: (data) => sent.push(data),
+    hostInfo: { name: 'TestHost', version: '1.0.0' },
+    hostContext: { theme: { mode: 'dark' }, displayMode: 'inline', platform: 'desktop' },
+    hostCapabilities: { openLinks: {}, logging: {} },
+    ...overrides,
+  }
+  const bridge = new McpAppsHostBridge(options)
+  return { bridge, sent }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('McpAppsHostBridge', () => {
+  describe('message routing', () => {
+    it('ignores non-JSON-RPC messages', () => {
+      const { bridge, sent } = createBridge()
+      bridge.handleMessage(makeMessageEvent({ type: 'random' }))
+      bridge.handleMessage(makeMessageEvent(null))
+      bridge.handleMessage(makeMessageEvent('string'))
+      expect(sent).toHaveLength(0)
+    })
+
+    it('ui/initialize returns host info and capabilities', async () => {
+      const { bridge, sent } = createBridge()
+      bridge.handleMessage(makeMessageEvent({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'ui/initialize',
+        params: {},
+      }))
+      // handleRequest is async, wait a tick
+      await new Promise(r => setTimeout(r, 10))
+      expect(sent).toHaveLength(1)
+      const response = sent[0] as Record<string, unknown>
+      expect(response.id).toBe(1)
+      const result = response.result as Record<string, unknown>
+      expect(result.protocolVersion).toBe('2025-03-26')
+      expect(result.hostInfo).toEqual({ name: 'TestHost', version: '1.0.0' })
+      expect(result.hostCapabilities).toBeDefined()
+    })
+
+    it('tools/call invokes onCallTool with correct args', async () => {
+      const calls: Array<{ name: string; args: Record<string, unknown> }> = []
+      const { bridge, sent } = createBridge({
+        onCallTool: async (name, args) => {
+          calls.push({ name, args })
+          return { result: 'ok' }
+        },
+      })
+      bridge.handleMessage(makeMessageEvent({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'my-tool', arguments: { x: 1 } },
+      }))
+      await new Promise(r => setTimeout(r, 10))
+      expect(calls).toHaveLength(1)
+      expect(calls[0]!.name).toBe('my-tool')
+      expect(calls[0]!.args).toEqual({ x: 1 })
+      const response = sent[0] as Record<string, unknown>
+      expect(response.id).toBe(2)
+      expect((response.result as Record<string, unknown>).result).toBe('ok')
+    })
+
+    it('tools/call returns error when no handler', async () => {
+      const { bridge, sent } = createBridge()
+      bridge.handleMessage(makeMessageEvent({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'tool', arguments: {} },
+      }))
+      await new Promise(r => setTimeout(r, 10))
+      expect(sent).toHaveLength(1)
+      const response = sent[0] as Record<string, unknown>
+      expect(response.error).toBeDefined()
+      expect((response.error as Record<string, unknown>).code).toBe(-32601)
+    })
+
+    it('resources/read invokes onReadResource', async () => {
+      const uris: string[] = []
+      const { bridge } = createBridge({
+        onReadResource: async (uri) => {
+          uris.push(uri)
+          return { contents: 'data' }
+        },
+      })
+      bridge.handleMessage(makeMessageEvent({
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'resources/read',
+        params: { uri: 'file:///test.txt' },
+      }))
+      await new Promise(r => setTimeout(r, 10))
+      expect(uris).toEqual(['file:///test.txt'])
+    })
+
+    it('resources/list invokes onListResources', async () => {
+      let called = false
+      const { bridge, sent } = createBridge({
+        onListResources: async () => {
+          called = true
+          return { resources: [{ uri: 'a' }] }
+        },
+      })
+      bridge.handleMessage(makeMessageEvent({
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'resources/list',
+        params: {},
+      }))
+      await new Promise(r => setTimeout(r, 10))
+      expect(called).toBe(true)
+      const response = sent[0] as Record<string, unknown>
+      expect((response.result as Record<string, unknown>).resources).toBeDefined()
+    })
+
+    it('ui/open-link invokes onOpenLink', async () => {
+      const urls: string[] = []
+      const { bridge } = createBridge({
+        onOpenLink: (url) => urls.push(url),
+      })
+      bridge.handleMessage(makeMessageEvent({
+        jsonrpc: '2.0',
+        id: 6,
+        method: 'ui/open-link',
+        params: { url: 'https://example.com' },
+      }))
+      await new Promise(r => setTimeout(r, 10))
+      expect(urls).toEqual(['https://example.com'])
+    })
+
+    it('ui/notifications/size-changed invokes onSizeChanged', () => {
+      const sizes: Array<{ width?: number; height?: number }> = []
+      const { bridge } = createBridge({
+        onSizeChanged: (size) => sizes.push(size),
+      })
+      bridge.handleMessage(makeMessageEvent({
+        jsonrpc: '2.0',
+        method: 'ui/notifications/size-changed',
+        params: { height: 300 },
+      }))
+      expect(sizes).toEqual([{ height: 300 }])
+    })
+
+    it('ui/notifications/initialized invokes onInitialized', () => {
+      let called = false
+      const { bridge } = createBridge({
+        onInitialized: () => { called = true },
+      })
+      bridge.handleMessage(makeMessageEvent({
+        jsonrpc: '2.0',
+        method: 'ui/notifications/initialized',
+        params: {},
+      }))
+      expect(called).toBe(true)
+    })
+
+    it('unknown method returns error -32601', async () => {
+      const { bridge, sent } = createBridge()
+      bridge.handleMessage(makeMessageEvent({
+        jsonrpc: '2.0',
+        id: 7,
+        method: 'unknown/method',
+        params: {},
+      }))
+      await new Promise(r => setTimeout(r, 10))
+      expect(sent).toHaveLength(1)
+      const response = sent[0] as Record<string, unknown>
+      expect((response.error as Record<string, unknown>).code).toBe(-32601)
+    })
+
+    it('handler exception returns error -32603', async () => {
+      const { bridge, sent } = createBridge({
+        onCallTool: async () => { throw new Error('boom') },
+      })
+      bridge.handleMessage(makeMessageEvent({
+        jsonrpc: '2.0',
+        id: 8,
+        method: 'tools/call',
+        params: { name: 'tool', arguments: {} },
+      }))
+      await new Promise(r => setTimeout(r, 10))
+      const response = sent[0] as Record<string, unknown>
+      expect((response.error as Record<string, unknown>).code).toBe(-32603)
+      expect((response.error as Record<string, unknown>).message).toBe('boom')
+    })
+  })
+
+  describe('outgoing messages', () => {
+    it('sendToolInput sends correct notification', () => {
+      const { bridge, sent } = createBridge()
+      bridge.sendToolInput({ foo: 'bar' })
+      expect(sent).toHaveLength(1)
+      const msg = sent[0] as Record<string, unknown>
+      expect(msg.jsonrpc).toBe('2.0')
+      expect(msg.method).toBe('ui/notifications/tool-input')
+      expect((msg.params as Record<string, unknown>).arguments).toEqual({ foo: 'bar' })
+    })
+
+    it('sendToolResult wraps non-content objects in structuredContent', () => {
+      const { bridge, sent } = createBridge()
+      bridge.sendToolResult({ data: 123 })
+      expect(sent).toHaveLength(1)
+      const msg = sent[0] as Record<string, unknown>
+      expect(msg.method).toBe('ui/notifications/tool-result')
+      expect((msg.params as Record<string, unknown>).structuredContent).toEqual({ data: 123 })
+    })
+
+    it('sendToolResult passes through objects with content key', () => {
+      const { bridge, sent } = createBridge()
+      bridge.sendToolResult({ content: [{ type: 'text', text: 'hi' }] })
+      expect(sent).toHaveLength(1)
+      const msg = sent[0] as Record<string, unknown>
+      expect((msg.params as Record<string, unknown>).content).toBeDefined()
+      expect((msg.params as Record<string, unknown>).structuredContent).toBeUndefined()
+    })
+  })
+})

--- a/packages/ui/src/components/mcp-apps/__tests__/mcp-app-utils.test.ts
+++ b/packages/ui/src/components/mcp-apps/__tests__/mcp-app-utils.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for mcp-app-utils: extractMcpAppWidget, hasMcpAppWidgets, deriveServerId
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { extractMcpAppWidget, hasMcpAppWidgets, deriveServerId } from '../mcp-app-utils'
+import type { ActivityItem } from '../../chat/TurnCard'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Never reset — the module-level widget cache in mcp-app-utils keys on
+// activity.id, so each test MUST use a globally unique ID.
+let idCounter = 0
+
+function makeActivityItem(overrides: Partial<ActivityItem> = {}): ActivityItem {
+  const id = `activity-${++idCounter}`
+  return {
+    id,
+    type: 'tool',
+    status: 'completed',
+    toolName: 'mcp__my-server__render',
+    toolUseId: `toolu_${idCounter}`,
+    timestamp: Date.now(),
+    ...overrides,
+  }
+}
+
+function makeWidgetContent(meta?: Record<string, unknown>): string {
+  return JSON.stringify({
+    content: [{ type: 'text', text: 'ok' }],
+    _meta: meta ?? {
+      'mcp-use/widget': {
+        type: 'mcpApps',
+        html: '<div>Hello</div>',
+        name: 'Test Widget',
+      },
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('extractMcpAppWidget', () => {
+  it('extracts widget from valid mcpApps activity', () => {
+    const activity = makeActivityItem({
+      content: makeWidgetContent(),
+    })
+    const result = extractMcpAppWidget(activity)
+    expect(result).not.toBeNull()
+    expect(result!.html).toBe('<div>Hello</div>')
+    expect(result!.name).toBe('Test Widget')
+  })
+
+  it('extracts widget from appsSdk type', () => {
+    const activity = makeActivityItem({
+      content: makeWidgetContent({
+        'mcp-use/widget': {
+          type: 'appsSdk',
+          html: '<div>SDK App</div>',
+          name: 'SDK Widget',
+        },
+      }),
+    })
+    const result = extractMcpAppWidget(activity)
+    expect(result).not.toBeNull()
+    expect(result!.html).toBe('<div>SDK App</div>')
+  })
+
+  it('returns null for non-tool activity', () => {
+    const activity = makeActivityItem({
+      type: 'thinking',
+      content: makeWidgetContent(),
+    })
+    expect(extractMcpAppWidget(activity)).toBeNull()
+  })
+
+  it('returns null when _meta is missing', () => {
+    const activity = makeActivityItem({
+      content: JSON.stringify({ content: [{ type: 'text', text: 'ok' }] }),
+    })
+    expect(extractMcpAppWidget(activity)).toBeNull()
+  })
+
+  it('returns null for malformed JSON content', () => {
+    const activity = makeActivityItem({ content: 'not json {{' })
+    expect(extractMcpAppWidget(activity)).toBeNull()
+  })
+
+  it('returns null for wrong widget type', () => {
+    const activity = makeActivityItem({
+      content: makeWidgetContent({
+        'mcp-use/widget': { type: 'other', html: '<div/>' },
+      }),
+    })
+    expect(extractMcpAppWidget(activity)).toBeNull()
+  })
+
+  it('uses CSP fallback from _meta.ui.csp', () => {
+    const activity = makeActivityItem({
+      content: JSON.stringify({
+        content: [],
+        _meta: {
+          'mcp-use/widget': { type: 'mcpApps', html: '<div/>' },
+          ui: { csp: { connectDomains: ['https://api.example.com'] } },
+        },
+      }),
+    })
+    const result = extractMcpAppWidget(activity)
+    expect(result).not.toBeNull()
+    expect(result!.csp?.connectDomains).toEqual(['https://api.example.com'])
+  })
+
+  it('uses props fallback from _meta["mcp-use/props"]', () => {
+    const activity = makeActivityItem({
+      content: JSON.stringify({
+        content: [],
+        _meta: {
+          'mcp-use/widget': { type: 'mcpApps', html: '<div/>' },
+          'mcp-use/props': { theme: 'dark' },
+        },
+      }),
+    })
+    const result = extractMcpAppWidget(activity)
+    expect(result).not.toBeNull()
+    expect(result!.props).toEqual({ theme: 'dark' })
+  })
+
+  it('caches positive results (same reference returned)', () => {
+    const activity = makeActivityItem({
+      content: makeWidgetContent(),
+    })
+    const first = extractMcpAppWidget(activity)
+    const second = extractMcpAppWidget(activity)
+    expect(first).toBe(second) // same reference
+  })
+})
+
+describe('hasMcpAppWidgets', () => {
+  it('returns true when at least one widget is present', () => {
+    const activities = [
+      makeActivityItem({ content: 'plain text' }),
+      makeActivityItem({ content: makeWidgetContent() }),
+    ]
+    expect(hasMcpAppWidgets(activities)).toBe(true)
+  })
+
+  it('returns false when no widgets are present', () => {
+    const activities = [
+      makeActivityItem({ content: 'plain text' }),
+      makeActivityItem({ content: JSON.stringify({ foo: 'bar' }) }),
+    ]
+    expect(hasMcpAppWidgets(activities)).toBe(false)
+  })
+})
+
+describe('deriveServerId', () => {
+  it('extracts server name from MCP tool pattern', () => {
+    const activity = makeActivityItem({ toolName: 'mcp__my-server__tool' })
+    expect(deriveServerId(activity)).toBe('my-server')
+  })
+
+  it('falls back for non-MCP tool names', () => {
+    const activity = makeActivityItem({ toolName: 'some-tool' })
+    expect(deriveServerId(activity)).toBe('some-tool')
+  })
+
+  it('returns "unknown" for empty tool name', () => {
+    const activity = makeActivityItem({ toolName: '' })
+    expect(deriveServerId(activity)).toBe('unknown')
+  })
+})

--- a/packages/ui/src/components/mcp-apps/index.ts
+++ b/packages/ui/src/components/mcp-apps/index.ts
@@ -1,0 +1,6 @@
+// MCP Apps widget components
+export { McpAppWidget } from './McpAppWidget'
+export { McpAppWidgetStack } from './McpAppWidgetStack'
+export { SandboxedIframe, type SandboxedIframeHandle } from './SandboxedIframe'
+export { McpAppsHostBridge, type McpAppsHostBridgeOptions } from './McpAppsHostBridge'
+export { extractMcpAppWidget, hasMcpAppWidgets, deriveServerId, type McpAppWidgetData } from './mcp-app-utils'

--- a/packages/ui/src/components/mcp-apps/mcp-app-utils.ts
+++ b/packages/ui/src/components/mcp-apps/mcp-app-utils.ts
@@ -1,0 +1,117 @@
+/**
+ * MCP App Widget Detection Utilities
+ *
+ * Extracts MCP Apps widget metadata from ActivityItem content JSON.
+ * Widgets are identified by _meta["mcp-use/widget"].type === "mcpApps".
+ */
+
+import type { ActivityItem } from '../chat/TurnCard'
+
+export interface McpAppWidgetData {
+  /** The widget HTML content */
+  html: string
+  /** Display name for the widget */
+  name: string
+  /** CSP metadata for iframe sandboxing */
+  csp?: {
+    connectDomains?: string[]
+    resourceDomains?: string[]
+    baseUriDomains?: string[]
+  }
+  /** Widget props from metadata */
+  props?: Record<string, unknown>
+  /** Resource URI from the tool result */
+  resourceUri?: string
+  /** Whether widget is in dev mode (use permissive CSP) */
+  dev?: boolean
+  /** Tool input arguments */
+  toolInput?: Record<string, unknown>
+  /** Tool output/result content */
+  toolOutput?: unknown
+  /** The source activity */
+  activity: ActivityItem
+}
+
+// Cache positive results only — null results are not cached because activity
+// content may not be available yet during streaming (tool_start arrives before
+// tool_result). Caching null would permanently block widget detection.
+const widgetCache = new Map<string, McpAppWidgetData>()
+
+/**
+ * Extract MCP Apps widget data from an activity item.
+ * Returns null if the activity is not an MCP Apps widget.
+ */
+export function extractMcpAppWidget(activity: ActivityItem): McpAppWidgetData | null {
+  const cached = widgetCache.get(activity.id)
+  if (cached) return cached
+
+  const result = extractMcpAppWidgetUncached(activity)
+  if (result) {
+    widgetCache.set(activity.id, result)
+  }
+  return result
+}
+
+function extractMcpAppWidgetUncached(activity: ActivityItem): McpAppWidgetData | null {
+  // Only process completed tool activities with content
+  if (activity.type !== 'tool' || !activity.content) return null
+
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(activity.content)
+  } catch {
+    return null
+  }
+
+  if (!parsed || typeof parsed !== 'object') return null
+
+  // Check for _meta["mcp-use/widget"]
+  const meta = parsed._meta as Record<string, unknown> | undefined
+  if (!meta) return null
+
+  const widgetMeta = meta['mcp-use/widget'] as Record<string, unknown> | undefined
+  if (!widgetMeta) return null
+  // Accept both "mcpApps" and "appsSdk" widget types
+  if (widgetMeta.type !== 'mcpApps' && widgetMeta.type !== 'appsSdk') return null
+
+  const html = widgetMeta.html as string | undefined
+  if (!html) return null
+
+  // CSP can be in _meta["mcp-use/widget"].csp or _meta.ui.csp
+  const uiMeta = meta.ui as Record<string, unknown> | undefined
+  const csp = (widgetMeta.csp || uiMeta?.csp) as McpAppWidgetData['csp'] | undefined
+
+  // Props can be in _meta["mcp-use/widget"].props or _meta["mcp-use/props"]
+  const props = (widgetMeta.props || meta['mcp-use/props']) as Record<string, unknown> | undefined
+
+  return {
+    html,
+    name: (widgetMeta.name as string) || activity.displayName || activity.toolName || 'MCP App',
+    csp,
+    props,
+    resourceUri: (widgetMeta.resourceUri || uiMeta?.resourceUri) as string | undefined,
+    dev: widgetMeta.dev === true,
+    toolInput: activity.toolInput,
+    toolOutput: parsed,
+    activity,
+  }
+}
+
+/**
+ * Check if any activities in the list contain MCP Apps widgets.
+ */
+export function hasMcpAppWidgets(activities: ActivityItem[]): boolean {
+  return activities.some(a => extractMcpAppWidget(a) !== null)
+}
+
+/**
+ * Derive a server ID from a tool name pattern like `mcp__{serverName}__{tool}`.
+ * Returns the serverName portion for origin isolation.
+ */
+export function deriveServerId(activity: ActivityItem): string {
+  const toolName = activity.toolName || ''
+  const match = toolName.match(/^mcp__([^_]+)__/)
+  if (match && match[1]) return match[1]
+  // Fallback to a hash of the tool name
+  return toolName.replace(/[^a-zA-Z0-9]/g, '-') || 'unknown'
+}


### PR DESCRIPTION
## Summary

Adds the MCP Apps widget system — allowing MCP servers to render interactive sandboxed HTML widgets inside the chat UI. 
Supports:
- MCP Apps and ChatGPT Apps protocols.
- This includes a custom `mcp-sandbox://`
- Electron protocol, a JSON-RPC host bridge for tool/resource access, and the React components that display widgets inline.

Built and tested against MCP servers built using MCP-Use MCP server.
See: https://mcp-use.com/docs/typescript/server/mcp-apps

## Changes

**Electron main process (`apps/electron/`)**
- Register `mcp-sandbox://` custom protocol for serving sandboxed HTML content
- Add IPC handlers for widget tool calls, resource reads, and resource listings
- Update CSP in `index.html` to allow `mcp-sandbox:` frame sources

**UI components (`packages/ui/`)**
- `McpAppWidget` / `McpAppWidgetStack` — render MCP App widgets in chat
- `SandboxedIframe` — sandboxed iframe wrapper with CSP enforcement
- `McpAppsHostBridge` — JSON-RPC bridge between host and sandboxed widgets
- Utility functions for detecting MCP App widgets and deriving server IDs

**Shared logic (`packages/shared/`)**
- Extend tool-matching to support MCP App widget metadata extraction

**Tests**
- Unit tests for `McpAppsHostBridge`, `mcp-app-utils`, and tool-matching metadata

## Testing

<!-- Author should fill in how they tested — e.g.: -->
- Ran `bun run typecheck:all` with no errors
- Verified widgets render in Electron dev mode with a sample MCP server
- All new unit tests pass (`bun test`)

To create a MCP App demo server:
```
npx create-mcp-use-app my-mcp-server --template mcp-apps
cd my-mcp-server
npm install
npm run dev
```
See:  https://mcp-use.com/docs/typescript/server/mcp-apps#quick-start

## Screenshots

<img width="722" height="932" alt="image" src="https://github.com/user-attachments/assets/837d1cc5-f31d-42d7-b9cd-bbfe265deca3" />
<img width="722" height="389" alt="image" src="https://github.com/user-attachments/assets/5d6cb88a-b549-45c4-b2fc-c7a60612bf21" />