### PR TITLE
fix(electron): persist default color theme to config

### DIFF
--- a/apps/electron/src/renderer/context/ThemeContext.tsx
+++ b/apps/electron/src/renderer/context/ThemeContext.tsx
@@ -349,6 +349,12 @@ export function ThemeProvider({
   const setColorTheme = useCallback((newTheme: string) => {
     setColorThemeState(newTheme)
     saveTheme({ mode, colorTheme: newTheme, font })
+    // Persist app-level default theme to ~/.craft-agent/config.json
+    if (window.electronAPI?.setColorTheme) {
+      window.electronAPI.setColorTheme(newTheme).catch((error) => {
+        console.error('Failed to persist color theme to config.json:', error)
+      })
+    }
     if (!isExternalUpdate.current && window.electronAPI?.broadcastThemePreferences) {
       window.electronAPI.broadcastThemePreferences({ mode, colorTheme: newTheme, font })
     }


### PR DESCRIPTION
  ## Background

  While following the official documentation, I tried to let Craft Agent modify its own color theme.
  The theme appeared to change in the UI, but the change was not actually persisted as the app-level
  default.

  That led me to investigate, and I found that changing the color theme in `ThemeContext` only updated
  local state/preferences and broadcasted updates, but did not persist the default theme to `~/.craft-
  agent/config.json`.

  ## What this PR changes

  - In `ThemeProvider.setColorTheme`, call `window.electronAPI.setColorTheme(newTheme)` after saving
  theme preferences.
  - Add error handling/logging for failed persistence.

  ## Why this fix is needed

  Without this persistence call, theme changes triggered in-app (including agent-driven changes) may not
  survive as the global default configuration.

  ## Verification

  - Change color theme in app.
  - Confirm `setColorTheme` path is triggered.
  - Confirm default theme is written to `~/.craft-agent/config.json`.
  - Restart app and verify theme remains consistent.