### PR TITLE
docs: add debug logging + WSL2 OAuth troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ craft-agents --debug
 
 ```powershell
 # Windows (PowerShell) - from the install directory
-.\"Craft Agents.exe\" --debug
+& ".\Craft Agents.exe" --debug
 ```
 
 You can also set the `CRAFT_DEBUG=1` environment variable


### PR DESCRIPTION
Fixes #165

## Summary
Adds a Troubleshooting section to the README to make it easier to:
- find & enable debug logs (dev vs packaged builds, `--debug`, and the startup log path line)
- understand how `CRAFT_DEBUG=1` relates to `--debug` in the desktop app
- complete Claude Max / Pro OAuth on WSL2 (including `wslu` and WSLg notes)

## Changes
- README: new **Troubleshooting > Debug Logging** section (macOS/Linux/Windows examples)
- README: new **Troubleshooting > WSL2 Notes** for OAuth `shell.openExternal` behavior
- README: clarify that desktop `--debug` also enables `CRAFT_DEBUG`

## Verification
- `markdownlint` on README: existing lint warnings in file; this change does not introduce new ones in the added section
- `bun run lint`: passes (warnings only)

No runtime/code behavior changes — docs only.