### PR TITLE
feat(usage-monitor): Add Claude usage monitoring with 5-hour rolling window widget

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -15,7 +15,7 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "build:main": "source ../../.env 2>/dev/null || true; esbuild src/main/index.ts --bundle --platform=node --format=cjs --outfile=dist/main.cjs --external:electron --define:process.env.GOOGLE_OAUTH_CLIENT_ID=\\\"${GOOGLE_OAUTH_CLIENT_ID:-}\\\" --define:process.env.GOOGLE_OAUTH_CLIENT_SECRET=\\\"${GOOGLE_OAUTH_CLIENT_SECRET:-}\\\" --define:process.env.SLACK_OAUTH_CLIENT_ID=\\\"${SLACK_OAUTH_CLIENT_ID:-}\\\" --define:process.env.SLACK_OAUTH_CLIENT_SECRET=\\\"${SLACK_OAUTH_CLIENT_SECRET:-}\\\" --define:process.env.MICROSOFT_OAUTH_CLIENT_ID=\\\"${MICROSOFT_OAUTH_CLIENT_ID:-}\\\"",
+    "build:main": "source ../../.env 2>/dev/null || true; esbuild src/main/index.ts --bundle --platform=node --format=cjs --outfile=dist/main.cjs --external:electron --external:ccusage --external:ccusage/data-loader --define:process.env.GOOGLE_OAUTH_CLIENT_ID=\\\"${GOOGLE_OAUTH_CLIENT_ID:-}\\\" --define:process.env.GOOGLE_OAUTH_CLIENT_SECRET=\\\"${GOOGLE_OAUTH_CLIENT_SECRET:-}\\\" --define:process.env.SLACK_OAUTH_CLIENT_ID=\\\"${SLACK_OAUTH_CLIENT_ID:-}\\\" --define:process.env.SLACK_OAUTH_CLIENT_SECRET=\\\"${SLACK_OAUTH_CLIENT_SECRET:-}\\\" --define:process.env.MICROSOFT_OAUTH_CLIENT_ID=\\\"${MICROSOFT_OAUTH_CLIENT_ID:-}\\\"",
     "build:main:win": "esbuild src/main/index.ts --bundle --platform=node --format=cjs --outfile=dist/main.cjs --external:electron",
     "build:preload": "esbuild src/preload/index.ts --bundle --platform=node --format=cjs --outfile=dist/preload.cjs --external:electron",
     "build:renderer": "vite build",
@@ -49,6 +49,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@tanstack/react-table": "^8.21.3",
     "chrono-node": "^2.9.0",
+    "ccusage": "^15.9.2",
     "cmdk": "^1.1.1",
     "electron-log": "^5.4.3",
     "electron-updater": "^6.7.3",

--- a/apps/electron/src/main/usage-monitor.ts
+++ b/apps/electron/src/main/usage-monitor.ts
@@ -1,0 +1,265 @@
+import { existsSync, watch } from 'fs';
+import type { FSWatcher } from 'fs';
+import { join } from 'path';
+import type { WindowManager } from './window-manager';
+import { IPC_CHANNELS, type UsageMonitorSnapshot } from '../shared/types';
+import { loadUsageMonitorConfig } from '@craft-agent/shared/config';
+
+type CcusageLoader = {
+  getClaudePaths: () => string[];
+  loadSessionBlockData: () => Promise<unknown>;
+};
+
+let ccusageLoader: CcusageLoader | null = null;
+
+async function getCcusageLoader(): Promise<CcusageLoader> {
+  if (!ccusageLoader) {
+    ccusageLoader = await import('ccusage/data-loader');
+  }
+  return ccusageLoader;
+}
+
+const WINDOW_MS = 5 * 60 * 60 * 1000;
+const POLL_INTERVAL_MS = 30 * 1000;
+const DEBOUNCE_MS = 200;
+
+function getClaudeProjectsDirs(baseDirs: string[]): string[] {
+  return baseDirs
+    .map(base => join(base, 'projects'))
+    .filter(dir => existsSync(dir));
+}
+
+function parseBlockTimestampMs(value: unknown): number | null {
+  if (value instanceof Date) {
+    const ms = value.getTime();
+    return Number.isNaN(ms) ? null : ms;
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+}
+
+function getBlockTokenTotal(block: any): number {
+  if (typeof block?.totalTokens === 'number') return block.totalTokens;
+  const tokenCounts = block?.tokenCounts ?? block?.token_counts;
+  if (tokenCounts) {
+    const input = typeof tokenCounts?.inputTokens === 'number' ? tokenCounts.inputTokens : 0;
+    const output = typeof tokenCounts?.outputTokens === 'number' ? tokenCounts.outputTokens : 0;
+    const cacheCreate = typeof tokenCounts?.cacheCreationInputTokens === 'number' ? tokenCounts.cacheCreationInputTokens : 0;
+    const cacheRead = typeof tokenCounts?.cacheReadInputTokens === 'number' ? tokenCounts.cacheReadInputTokens : 0;
+    return input + output + cacheCreate + cacheRead;
+  }
+
+  const input = typeof block?.inputTokens === 'number' ? block.inputTokens : 0;
+  const output = typeof block?.outputTokens === 'number' ? block.outputTokens : 0;
+  const cacheCreate = typeof block?.cacheCreationTokens === 'number' ? block.cacheCreationTokens : 0;
+  const cacheRead = typeof block?.cacheReadTokens === 'number' ? block.cacheReadTokens : 0;
+  const fallbackTotal = input + output + cacheCreate + cacheRead;
+  if (fallbackTotal > 0) return fallbackTotal;
+
+  if (Array.isArray(block?.entries)) {
+    let total = 0;
+    for (const entry of block.entries) {
+      const usage = entry?.usage;
+      if (!usage) continue;
+      total += (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0) +
+        (usage.cacheCreationInputTokens ?? 0) + (usage.cacheReadInputTokens ?? 0);
+    }
+    return total;
+  }
+
+  return 0;
+}
+
+function getBlockStartMs(block: any): number | null {
+  return (
+    parseBlockTimestampMs(block?.blockStart) ??
+    parseBlockTimestampMs(block?.startTime) ??
+    parseBlockTimestampMs(block?.start_time) ??
+    null
+  );
+}
+
+function getBlockEndMs(block: any): number | null {
+  return (
+    parseBlockTimestampMs(block?.blockEnd) ??
+    parseBlockTimestampMs(block?.endTime) ??
+    parseBlockTimestampMs(block?.end_time) ??
+    null
+  );
+}
+
+async function computeUsageSnapshot(): Promise<UsageMonitorSnapshot> {
+  const { getClaudePaths, loadSessionBlockData } = await getCcusageLoader();
+  const baseDirs = getClaudePaths();
+  const projectsDirs = getClaudeProjectsDirs(baseDirs);
+  const { plan, limits } = loadUsageMonitorConfig();
+  const derivedLimits = {
+    pro: limits.pro,
+    max5: limits.pro * 5,
+    max20: limits.pro * 20,
+  };
+  const limit = plan === 'max20' ? derivedLimits.max20 : plan === 'max5' ? derivedLimits.max5 : derivedLimits.pro;
+
+  if (baseDirs.every(dir => !existsSync(dir))) {
+    return {
+      status: 'missing',
+      totalTokens: 0,
+      windowMs: WINDOW_MS,
+      oldestTimestampMs: null,
+      resetAtMs: null,
+      plan,
+      limit,
+    };
+  }
+
+  if (projectsDirs.length === 0) {
+    return {
+      status: 'unavailable',
+      totalTokens: 0,
+      windowMs: WINDOW_MS,
+      oldestTimestampMs: null,
+      resetAtMs: null,
+      plan,
+      limit,
+    };
+  }
+
+  let blocks: any[] = [];
+  try {
+    const result = await loadSessionBlockData();
+    if (Array.isArray(result)) {
+      blocks = result;
+    } else if (result && typeof result === 'object') {
+      const candidate = (result as { blocks?: any[]; data?: any[] }).blocks ?? (result as { data?: any[] }).data;
+      blocks = Array.isArray(candidate) ? candidate : [];
+    }
+  } catch {
+    return {
+      status: 'unavailable',
+      totalTokens: 0,
+      windowMs: WINDOW_MS,
+      oldestTimestampMs: null,
+      resetAtMs: null,
+      plan,
+      limit,
+    };
+  }
+
+  if (!Array.isArray(blocks) || blocks.length === 0) {
+    return {
+      status: 'ok',
+      totalTokens: 0,
+      windowMs: WINDOW_MS,
+      oldestTimestampMs: null,
+      resetAtMs: null,
+      plan,
+      limit,
+    };
+  }
+
+  const inferredLimit = limit;
+  const activeBlock = blocks.find(block => block?.isActive && !block?.isGap) ??
+    blocks.find(block => !block?.isGap) ??
+    blocks[blocks.length - 1];
+  const totalTokens = getBlockTokenTotal(activeBlock);
+  const oldestTimestampMs = getBlockStartMs(activeBlock);
+  const resetAtMs =
+    parseBlockTimestampMs(activeBlock?.usageLimitResetTime) ??
+    getBlockEndMs(activeBlock);
+
+  return {
+    status: 'ok',
+    totalTokens,
+    windowMs: WINDOW_MS,
+    oldestTimestampMs,
+    resetAtMs,
+    plan,
+    limit: inferredLimit,
+  };
+}
+
+export class UsageMonitorService {
+  private windowManager: WindowManager;
+  private watchers: FSWatcher[] = [];
+  private pollInterval: NodeJS.Timeout | null = null;
+  private debounceTimer: NodeJS.Timeout | null = null;
+  private lastSnapshotKey: string | null = null;
+
+  constructor(windowManager: WindowManager) {
+    this.windowManager = windowManager;
+  }
+
+  start(): void {
+    void this.refreshAndBroadcast();
+    void this.startWatcherOrPolling();
+  }
+
+  async getSnapshot(): Promise<UsageMonitorSnapshot> {
+    return computeUsageSnapshot();
+  }
+
+  async refreshAndBroadcast(): Promise<void> {
+    const snapshot = await computeUsageSnapshot();
+    const key = JSON.stringify(snapshot);
+    if (key !== this.lastSnapshotKey) {
+      this.lastSnapshotKey = key;
+      this.windowManager.broadcastToAll(IPC_CHANNELS.USAGE_MONITOR_STATS_CHANGED, snapshot);
+    }
+  }
+
+  private async startWatcherOrPolling(): Promise<void> {
+    try {
+      const { getClaudePaths } = await getCcusageLoader();
+      const baseDirs = getClaudePaths();
+      const projectsDirs = getClaudeProjectsDirs(baseDirs);
+      if (projectsDirs.length === 0) {
+        this.startPolling();
+        return;
+      }
+
+      for (const dir of projectsDirs) {
+        const watcher = watch(dir, { recursive: true }, (_eventType, filename) => {
+          if (filename && !filename.endsWith('.jsonl')) return;
+          this.scheduleRefresh();
+        });
+        watcher.on('error', () => {
+          this.stopWatcher();
+          this.startPolling();
+        });
+        this.watchers.push(watcher);
+      }
+    } catch {
+      this.startPolling();
+    }
+  }
+
+  private scheduleRefresh(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      void this.refreshAndBroadcast();
+    }, DEBOUNCE_MS);
+  }
+
+  private startPolling(): void {
+    if (this.pollInterval) return;
+    this.pollInterval = setInterval(() => {
+      void this.refreshAndBroadcast();
+    }, POLL_INTERVAL_MS);
+  }
+
+  private stopWatcher(): void {
+    for (const watcher of this.watchers) {
+      watcher.close();
+    }
+    this.watchers = [];
+  }
+}
+
+export function createUsageMonitorService(windowManager: WindowManager): UsageMonitorService {
+  return new UsageMonitorService(windowManager);
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -374,6 +374,37 @@ const api: ElectronAPI = {
     ipcRenderer.invoke(IPC_CHANNELS.NOTIFICATION_GET_ENABLED) as Promise<boolean>,
   setNotificationsEnabled: (enabled: boolean) =>
     ipcRenderer.invoke(IPC_CHANNELS.NOTIFICATION_SET_ENABLED, enabled),
+  // Usage Monitor
+  getUsageMonitorSnapshot: () =>
+    ipcRenderer.invoke(IPC_CHANNELS.USAGE_MONITOR_GET_SNAPSHOT),
+  onUsageMonitorStatsChanged: (callback: (snapshot: import('../shared/types').UsageMonitorSnapshot) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, snapshot: import('../shared/types').UsageMonitorSnapshot) => {
+      callback(snapshot)
+    }
+    ipcRenderer.on(IPC_CHANNELS.USAGE_MONITOR_STATS_CHANGED, handler)
+    return () => {
+      ipcRenderer.removeListener(IPC_CHANNELS.USAGE_MONITOR_STATS_CHANGED, handler)
+    }
+  },
+  getUsageMonitorConfig: () =>
+    ipcRenderer.invoke(IPC_CHANNELS.USAGE_MONITOR_GET_CONFIG),
+  setUsageMonitorPlan: (plan: 'pro' | 'max5' | 'max20') =>
+    ipcRenderer.invoke(IPC_CHANNELS.USAGE_MONITOR_SET_PLAN, plan),
+  setUsageMonitorProLimit: (limit: number) =>
+    ipcRenderer.invoke(IPC_CHANNELS.USAGE_MONITOR_SET_PRO_LIMIT, limit),
+  getUsageMonitorEnabled: () =>
+    ipcRenderer.invoke(IPC_CHANNELS.USAGE_MONITOR_GET_ENABLED),
+  setUsageMonitorEnabled: (enabled: boolean) =>
+    ipcRenderer.invoke(IPC_CHANNELS.USAGE_MONITOR_SET_ENABLED, enabled),
+  onUsageMonitorConfigChanged: (callback: (config: import('../shared/types').UsageMonitorConfigPayload) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, config: import('../shared/types').UsageMonitorConfigPayload) => {
+      callback(config)
+    }
+    ipcRenderer.on(IPC_CHANNELS.USAGE_MONITOR_CONFIG_CHANGED, handler)
+    return () => {
+      ipcRenderer.removeListener(IPC_CHANNELS.USAGE_MONITOR_CONFIG_CHANGED, handler)
+    }
+  },
   updateBadgeCount: (count: number) =>
     ipcRenderer.invoke(IPC_CHANNELS.BADGE_UPDATE, count),
   clearBadgeCount: () =>

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -67,6 +67,7 @@ import { WorkspaceSwitcher } from "./WorkspaceSwitcher"
 import { SessionList } from "./SessionList"
 import { MainContentPanel } from "./MainContentPanel"
 import { LeftSidebar } from "./LeftSidebar"
+import { UsageMonitorWidget } from "./UsageMonitorWidget"
 import { useSession } from "@/hooks/useSession"
 import { ensureSessionMessagesLoadedAtom } from "@/atoms/sessions"
 import { AppShellProvider, type AppShellContextType } from "@/context/AppShellContext"
@@ -2052,7 +2053,14 @@ function AppShellContent({
                     },
                     // --- Separator ---
                     { id: "separator:skills-settings", type: "separator" },
-                    // --- Settings ---
+                  ]}
+                />
+                <UsageMonitorWidget />
+                <LeftSidebar
+                  isCollapsed={false}
+                  getItemProps={getSidebarItemProps}
+                  focusedItemId={focusedSidebarItemId}
+                  links={[
                     {
                       id: "nav:settings",
                       title: "Settings",

--- a/apps/electron/src/renderer/components/app-shell/UsageMonitorWidget.tsx
+++ b/apps/electron/src/renderer/components/app-shell/UsageMonitorWidget.tsx
@@ -1,0 +1,96 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+import type { UsageMonitorConfigPayload, UsageMonitorSnapshot } from "../../../shared/types"
+
+interface UsageMonitorWidgetProps {
+  className?: string
+}
+
+function formatTimeRemaining(ms: number): string {
+  const totalMinutes = Math.max(0, Math.floor(ms / 60000))
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  return `${hours} hr ${minutes} min`
+}
+
+function getUsageColor(percent: number): { bar: string; text: string } {
+  if (percent >= 100) return { bar: "bg-destructive", text: "text-destructive" }
+  if (percent > 90) return { bar: "bg-destructive", text: "text-destructive" }
+  if (percent >= 70) return { bar: "bg-warning", text: "text-warning" }
+  return { bar: "bg-success", text: "text-success" }
+}
+
+export function UsageMonitorWidget({ className }: UsageMonitorWidgetProps) {
+  const [enabled, setEnabled] = React.useState(true)
+  const [snapshot, setSnapshot] = React.useState<UsageMonitorSnapshot | null>(null)
+
+  const refreshSnapshot = React.useCallback(async () => {
+    const [enabledValue, nextSnapshot] = await Promise.all([
+      window.electronAPI.getUsageMonitorEnabled(),
+      window.electronAPI.getUsageMonitorSnapshot(),
+    ])
+    setEnabled(enabledValue)
+    setSnapshot(nextSnapshot)
+  }, [])
+
+  React.useEffect(() => {
+    refreshSnapshot()
+    const unsubscribeStats = window.electronAPI.onUsageMonitorStatsChanged(setSnapshot)
+    const unsubscribeConfig = window.electronAPI.onUsageMonitorConfigChanged((config: UsageMonitorConfigPayload) => {
+      setEnabled(config.enabled)
+      setSnapshot((prev) => {
+        if (!prev) return prev
+        const limit = config.plan === "max5" ? config.limits.max5
+                     : config.plan === "max20" ? config.limits.max20
+                     : config.limits.pro
+        return {
+          ...prev,
+          plan: config.plan,
+          limit,
+        }
+      })
+    })
+    return () => {
+      unsubscribeStats()
+      unsubscribeConfig()
+    }
+  }, [refreshSnapshot])
+
+  if (!enabled) return null
+  if (!snapshot) return null
+  if (snapshot.status === "missing") return null
+
+  const percentRaw = snapshot.limit > 0 ? (snapshot.totalTokens / snapshot.limit) * 100 : 0
+  const percentSafe = Number.isFinite(percentRaw) ? percentRaw : 0
+  const percentClamped = Math.min(100, Math.max(0, Math.round(percentSafe)))
+  const { bar, text } = getUsageColor(percentClamped)
+  const resetAt = snapshot.resetAtMs
+  const remainingLabel = resetAt ? formatTimeRemaining(Math.max(0, resetAt - Date.now())) : "--:--"
+
+  return (
+    <div className={cn("px-2 pb-2", className)}>
+      <div className="rounded-[8px] border border-foreground/5 bg-background/70 px-2.5 py-2 shadow-minimal">
+        <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+          <span>Usage</span>
+          <span className="uppercase">{snapshot.plan}</span>
+        </div>
+        <div className="mt-2 h-1.5 rounded-full bg-foreground/10 overflow-hidden">
+          <div
+            className={cn(
+              "h-full rounded-full transition-all",
+              bar,
+              percentClamped >= 100 && "animate-pulse"
+            )}
+            style={{ width: `${percentClamped}%` }}
+          />
+        </div>
+        <div className={cn("mt-2 text-[11px]", snapshot.status === "unavailable" ? "text-muted-foreground" : text)}>
+          {snapshot.status === "unavailable"
+            ? "Usage unavailable"
+            : `${percentClamped}% Used - Resets in ${remainingLabel}`}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/settings/SettingsRow.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsRow.tsx
@@ -61,7 +61,7 @@ export function SettingsRow({
       <div className="flex-1 min-w-0">
         <div className={settingsUI.label}>{label}</div>
         {description && (
-          <div className={cn(settingsUI.description, settingsUI.labelDescriptionGap, 'truncate')}>
+          <div className={cn(settingsUI.description, settingsUI.labelDescriptionGap, 'whitespace-pre-wrap')}>
             {description}
           </div>
         )}

--- a/apps/electron/src/shared/types.ts
+++ b/apps/electron/src/shared/types.ts
@@ -670,6 +670,16 @@ export const IPC_CHANNELS = {
   NOTIFICATION_GET_ENABLED: 'notification:getEnabled',
   NOTIFICATION_SET_ENABLED: 'notification:setEnabled',
 
+  // Usage Monitor
+  USAGE_MONITOR_GET_SNAPSHOT: 'usageMonitor:getSnapshot',
+  USAGE_MONITOR_STATS_CHANGED: 'usageMonitor:statsChanged',  // Broadcast: UsageMonitorSnapshot
+  USAGE_MONITOR_GET_CONFIG: 'usageMonitor:getConfig',
+  USAGE_MONITOR_SET_PLAN: 'usageMonitor:setPlan',
+  USAGE_MONITOR_SET_PRO_LIMIT: 'usageMonitor:setProLimit',
+  USAGE_MONITOR_GET_ENABLED: 'usageMonitor:getEnabled',
+  USAGE_MONITOR_SET_ENABLED: 'usageMonitor:setEnabled',
+  USAGE_MONITOR_CONFIG_CHANGED: 'usageMonitor:configChanged',  // Broadcast: UsageMonitorConfig
+
   BADGE_UPDATE: 'badge:update',
   BADGE_CLEAR: 'badge:clear',
   BADGE_SET_ICON: 'badge:setIcon',
@@ -711,6 +721,22 @@ export interface ToolIconMapping {
   /** Data URL of the icon (e.g., data:image/png;base64,...) */
   iconDataUrl: string
   commands: string[]
+}
+
+export interface UsageMonitorSnapshot {
+  status: 'ok' | 'missing' | 'unavailable'
+  totalTokens: number
+  windowMs: number
+  oldestTimestampMs: number | null
+  resetAtMs: number | null
+  plan: 'pro' | 'max5' | 'max20'
+  limit: number
+}
+
+export interface UsageMonitorConfigPayload {
+  plan: 'pro' | 'max5' | 'max20'
+  limits: { pro: number; max5: number; max20: number }
+  enabled: boolean
 }
 
 // Type-safe IPC API exposed to renderer
@@ -928,6 +954,16 @@ export interface ElectronAPI {
   showNotification(title: string, body: string, workspaceId: string, sessionId: string): Promise<void>
   getNotificationsEnabled(): Promise<boolean>
   setNotificationsEnabled(enabled: boolean): Promise<void>
+
+  // Usage Monitor
+  getUsageMonitorSnapshot(): Promise<UsageMonitorSnapshot>
+  onUsageMonitorStatsChanged(callback: (snapshot: UsageMonitorSnapshot) => void): () => void
+  getUsageMonitorConfig(): Promise<UsageMonitorConfigPayload>
+  setUsageMonitorPlan(plan: 'pro' | 'max5' | 'max20'): Promise<void>
+  setUsageMonitorProLimit(limit: number): Promise<void>
+  getUsageMonitorEnabled(): Promise<boolean>
+  setUsageMonitorEnabled(enabled: boolean): Promise<void>
+  onUsageMonitorConfigChanged(callback: (config: UsageMonitorConfigPayload) => void): () => void
 
   updateBadgeCount(count: number): Promise<void>
   clearBadgeCount(): Promise<void>

--- a/packages/shared/src/config/config-defaults-schema.ts
+++ b/packages/shared/src/config/config-defaults-schema.ts
@@ -13,6 +13,7 @@ export interface ConfigDefaults {
   defaults: {
     authType: AuthType;
     notificationsEnabled: boolean;
+    usageMonitorEnabled: boolean;
     colorTheme: string;
   };
   workspaceDefaults: {
@@ -35,6 +36,7 @@ export const BUNDLED_CONFIG_DEFAULTS: ConfigDefaults = {
   defaults: {
     authType: 'api_key',
     notificationsEnabled: true,
+    usageMonitorEnabled: true,
     colorTheme: 'default',
   },
   workspaceDefaults: {

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -2,6 +2,7 @@ export * from './models.ts';
 export * from './preferences.ts';
 export * from './storage.ts';
 export * from './theme.ts';
+export * from './usage-monitor.ts';
 export * from './validators.ts';
 export {
   ConfigWatcher,

--- a/packages/shared/src/config/storage.ts
+++ b/packages/shared/src/config/storage.ts
@@ -42,6 +42,8 @@ export interface StoredConfig {
   model?: string;
   // Notifications
   notificationsEnabled?: boolean;  // Desktop notifications for task completion (default: true)
+  // Usage Monitor
+  usageMonitorEnabled?: boolean;  // Sidebar usage monitor (default: true)
   // Appearance
   colorTheme?: string;  // ID of selected preset theme (e.g., 'dracula', 'nord'). Default: 'default'
   // Auto-update
@@ -249,6 +251,29 @@ export function setNotificationsEnabled(enabled: boolean): void {
   const config = loadStoredConfig();
   if (!config) return;
   config.notificationsEnabled = enabled;
+  saveConfig(config);
+}
+
+/**
+ * Get whether the Usage Monitor is enabled.
+ * Defaults to true if not set.
+ */
+export function getUsageMonitorEnabled(): boolean {
+  const config = loadStoredConfig();
+  if (config?.usageMonitorEnabled !== undefined) {
+    return config.usageMonitorEnabled;
+  }
+  const defaults = loadConfigDefaults();
+  return defaults.defaults.usageMonitorEnabled ?? true;
+}
+
+/**
+ * Set whether the Usage Monitor is enabled.
+ */
+export function setUsageMonitorEnabled(enabled: boolean): void {
+  const config = loadStoredConfig();
+  if (!config) return;
+  config.usageMonitorEnabled = enabled;
   saveConfig(config);
 }
 

--- a/packages/shared/src/config/usage-monitor.ts
+++ b/packages/shared/src/config/usage-monitor.ts
@@ -1,0 +1,89 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { CONFIG_DIR } from './paths.ts';
+import { ensureConfigDir } from './storage.ts';
+
+export type UsageMonitorPlan = 'pro' | 'max5' | 'max20';
+
+export const DEFAULT_PRO_LIMIT = 5_500_000;
+
+export interface UsageMonitorConfig {
+  plan: UsageMonitorPlan;
+  limits: {
+    pro: number;
+  };
+}
+
+const USAGE_MONITOR_FILE = join(CONFIG_DIR, 'usage-monitor.json');
+const DEFAULT_CONFIG: UsageMonitorConfig = {
+  plan: 'pro',
+  limits: {
+    pro: DEFAULT_PRO_LIMIT,
+  },
+};
+
+function sanitizeConfig(raw: unknown): UsageMonitorConfig {
+  const config = (raw && typeof raw === 'object' ? raw : {}) as Partial<UsageMonitorConfig>;
+  const plan = config.plan === 'max5' || config.plan === 'max20' ? config.plan : 'pro';
+  const limits = {
+    pro: typeof config.limits?.pro === 'number' && config.limits.pro > 0 ? config.limits.pro : DEFAULT_CONFIG.limits.pro,
+  };
+  return {
+    plan,
+    limits,
+  };
+}
+
+export function loadUsageMonitorConfig(): UsageMonitorConfig {
+  try {
+    if (!existsSync(USAGE_MONITOR_FILE)) {
+      ensureConfigDir();
+      writeFileSync(USAGE_MONITOR_FILE, JSON.stringify(DEFAULT_CONFIG, null, 2), 'utf-8');
+      return DEFAULT_CONFIG;
+    }
+    const content = readFileSync(USAGE_MONITOR_FILE, 'utf-8');
+    const parsed = JSON.parse(content);
+    const sanitized = sanitizeConfig(parsed);
+    return sanitized;
+  } catch {
+    return DEFAULT_CONFIG;
+  }
+}
+
+export function saveUsageMonitorConfig(config: UsageMonitorConfig): void {
+  ensureConfigDir();
+  writeFileSync(USAGE_MONITOR_FILE, JSON.stringify(config, null, 2), 'utf-8');
+}
+
+export function getUsageMonitorPlan(): UsageMonitorPlan {
+  return loadUsageMonitorConfig().plan;
+}
+
+export function setUsageMonitorPlan(plan: UsageMonitorPlan): void {
+  const current = loadUsageMonitorConfig();
+  saveUsageMonitorConfig({
+    ...current,
+    plan: plan === 'max5' || plan === 'max20' ? plan : 'pro',
+  });
+}
+
+export function getUsageMonitorLimits(): { pro: number; max5: number; max20: number } {
+  const { limits } = loadUsageMonitorConfig();
+  return {
+    pro: limits.pro,
+    max5: limits.pro * 5,
+    max20: limits.pro * 20,
+  };
+}
+
+export function setUsageMonitorProLimit(limit: number): void {
+  const current = loadUsageMonitorConfig();
+  const nextLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : DEFAULT_PRO_LIMIT;
+  saveUsageMonitorConfig({
+    ...current,
+    limits: {
+      ...current.limits,
+      pro: nextLimit,
+    },
+  });
+}

--- a/scripts/electron-build-main.ts
+++ b/scripts/electron-build-main.ts
@@ -131,6 +131,8 @@ async function main(): Promise<void> {
       "--format=cjs",
       "--outfile=apps/electron/dist/main.cjs",
       "--external:electron",
+      "--external:ccusage",
+      "--external:ccusage/data-loader",
       ...buildDefines,
     ],
     cwd: ROOT_DIR,


### PR DESCRIPTION
Fixes https://github.com/lukilabs/craft-agents-oss/issues/83
Fixes https://github.com/lukilabs/craft-agents-oss/issues/163


## Summary
Adds a usage monitor widget to the sidebar that displays Claude token consumption in a rolling 5-hour window. Users can configure plan types (Pro, Max 5h, Max 20h) and customize token limits through the settings page.

## Changes

### Core Functionality
- **Usage Monitor Service** (`apps/electron/src/main/usage-monitor.ts`): Polls Claude usage data via `ccusage` library, watches for file changes, and broadcasts snapshots to renderer
- **Widget Component** (`apps/electron/src/renderer/components/app-shell/UsageMonitorWidget.tsx`): Displays real-time progress bar with token usage, plan type, and time until reset
- **Configuration Module** (`packages/shared/src/config/usage-monitor.ts`): Persists plan selection and custom limits with validation

### Settings Integration
- **Settings Page**: Added usage monitor configuration section with plan dropdown, enable/disable toggle, and editable Pro limit
- **Settings Row**: Changed description styling from `truncate` to `whitespace-pre-wrap` to support multi-line limit descriptions

### IPC & Types
- **IPC Handlers**: 7 new channels for getting/setting usage config, subscribing to stats/config changes
- **Type Definitions**: Added `UsageMonitorSnapshot` and `UsageMonitorConfigPayload` interfaces with `'pro' | 'max5' | 'max20'` plan types
- **Preload Bridge**: Exposed usage monitor API to renderer process

### Infrastructure
- **Dependencies**: Added `ccusage@^15.9.2` for reading Claude usage data
- **Build Config**: Marked `ccusage` as external in esbuild to prevent bundling
- **Config Schema**: Added `usageMonitorEnabled: boolean` default (true) to app config

### UI Integration
- Widget positioned in sidebar between skill links and settings
- Progress bar color-coded: green (<70%), yellow (70-90%), red (>90%)
- Displays plan type badge and countdown timer until 5-hour window resets

## Testing

### Manual Testing
- ✅ Verified widget displays correct token usage from Claude data directory
- ✅ Tested plan switching (Pro/Max 5h/Max 20h) updates displayed limit
- ✅ Confirmed custom Pro limit persists across app restarts
- ✅ Validated enable/disable toggle hides/shows widget
- ✅ Checked progress bar color changes at thresholds
- ✅ Verified real-time updates when new usage data is written
- ✅ Tested fallback to polling when file watching unavailable

### Type Safety
- ✅ Fixed type mismatch between snapshot and config plan types
- ✅ All plan values use consistent `'pro' | 'max5' | 'max20'` union type
- ✅ Widget correctly handles all three plan types with proper limit calculation

### Edge Cases
- Widget hidden when usage data directory missing
- Graceful fallback to defaults if config file corrupted
- Handles null reset timestamps (displays "--:--")
- Prevents negative percentages and clamping to 0-100%

## Screenshots
<img width="220" height="835" alt="image" src="https://github.com/user-attachments/assets/ed0e93a1-e4cb-4140-861a-865b13f68249" />
<img width="750" height="807" alt="image" src="https://github.com/user-attachments/assets/37bec398-66fb-4dfe-a973-db2d6f0840dc" />