### PR TITLE
feat: Add Amp CLI Agent backend and UI integration

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -90,6 +90,11 @@ const BUILT_IN_CONNECTION_TEMPLATES: Record<string, {
     providerType: 'copilot',
     authType: 'oauth',
   },
+  'amp': {
+    name: 'Amp CLI',
+    providerType: 'amp',
+    authType: 'external_cli',
+  },
 }
 
 /**
@@ -2764,6 +2769,24 @@ export function registerIpcHandlers(sessionManager: SessionManager, windowManage
     } catch (error) {
       ipcLog.error('Failed to clear Copilot credentials:', error)
       return { success: false }
+    }
+  })
+
+  // ============================================================
+  // Amp CLI
+  // ============================================================
+
+  // Check if Amp CLI is installed
+  ipcMain.handle(IPC_CHANNELS.CHECK_AMP_INSTALLED, async (): Promise<boolean> => {
+    try {
+      ipcLog.info('Checking if Amp CLI is installed...')
+      const { isAmpInstalled } = await import('@craft-agent/shared/agent/amp-agent')
+      const installed = await isAmpInstalled()
+      ipcLog.info(`Amp CLI installed: ${installed}`)
+      return installed
+    } catch (error) {
+      ipcLog.error('Failed to check Amp installation:', error)
+      return false
     }
   })
 

--- a/apps/electron/src/main/sessions.ts
+++ b/apps/electron/src/main/sessions.ts
@@ -8,6 +8,7 @@ import {
   CodexBackend,
   CodexAgent,
   CopilotAgent,
+  AmpAgent,
   detectProvider,
   resolveSessionConnection,
   providerTypeToAgentProvider,
@@ -2461,7 +2462,7 @@ export class SessionManager {
       }
 
       // Determine provider from connection or fall back to legacy authType
-      let provider: 'anthropic' | 'openai' | 'copilot'
+      let provider: 'anthropic' | 'openai' | 'copilot' | 'amp'
       let authType: LlmAuthType | undefined
 
       if (connection) {
@@ -2726,6 +2727,62 @@ export class SessionManager {
           await setupCopilotBridgeConfig(copilotConfigDir, enabledSources)
           copilotAgent.setSourceServers(mcpServers, apiServers, enabledSlugs)
         }
+      } else if (provider === 'amp') {
+        // Amp CLI backend - uses external Amp CLI process
+        const rawAmpModel = managed.model || connection?.defaultModel || 'amp-smart'
+        const ampModel = rawAmpModel
+
+        // Create per-session config directory for Amp
+        const sessionPath = getSessionStoragePath(managed.workspace.rootPath, managed.id)
+        const ampConfigDir = join(sessionPath, '.amp-config')
+        await mkdir(ampConfigDir, { recursive: true })
+
+        managed.agent = new AmpAgent({
+          provider: 'amp',
+          authType: authType || 'external_cli',
+          workspace: managed.workspace,
+          model: ampModel,
+          thinkingLevel: managed.thinkingLevel,
+          connectionSlug: connection?.slug,
+          session: {
+            id: managed.id,
+            workspaceRootPath: managed.workspace.rootPath,
+            sdkSessionId: managed.sdkSessionId,
+            createdAt: managed.lastMessageAt,
+            lastUsedAt: managed.lastMessageAt,
+            workingDirectory: managed.workingDirectory,
+            sdkCwd: managed.sdkCwd,
+            model: managed.model,
+            llmConnection: managed.llmConnection,
+          },
+          onSdkSessionIdUpdate: (sdkSessionId: string) => {
+            managed.sdkSessionId = sdkSessionId
+            sessionLog.info(`SDK session ID captured for ${managed.id}: ${sdkSessionId}`)
+            this.persistSession(managed)
+            sessionPersistenceQueue.flush(managed.id)
+          },
+          onSdkSessionIdCleared: () => {
+            managed.sdkSessionId = undefined
+            sessionLog.info(`SDK session ID cleared for ${managed.id} (resume recovery)`)
+            this.persistSession(managed)
+            sessionPersistenceQueue.flush(managed.id)
+          },
+          getRecoveryMessages: () => {
+            const relevantMessages = managed.messages
+              .filter(m => m.role === 'user' || m.role === 'assistant')
+              .filter(m => !m.isIntermediate)
+              .slice(-6)
+            return relevantMessages.map(m => ({
+              type: m.role as 'user' | 'assistant',
+              content: m.content,
+            }))
+          },
+        })
+        sessionLog.info(`Created Amp agent for session ${managed.id} (model: ${ampModel})${managed.sdkSessionId ? ' (resuming)' : ''}`)
+
+        // Wire up debug callback for Amp agent logging
+        const ampAgent = managed.agent as AmpAgent
+        ampAgent.onDebug = (msg: string) => sessionLog.info(msg)
       } else {
         // Claude backend - uses Anthropic SDK
         // Set auth credentials for this session's connection BEFORE creating the agent.

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -195,6 +195,9 @@ const api: ElectronAPI = {
     return () => ipcRenderer.removeListener(IPC_CHANNELS.COPILOT_DEVICE_CODE, handler)
   },
 
+  // Amp CLI
+  checkAmpInstalled: () => ipcRenderer.invoke(IPC_CHANNELS.CHECK_AMP_INSTALLED),
+
   // Settings - API Setup
   setupLlmConnection: (setup: LlmConnectionSetup) =>
     ipcRenderer.invoke(IPC_CHANNELS.SETUP_LLM_CONNECTION, setup),

--- a/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
+++ b/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
@@ -316,6 +316,7 @@ export function FreeFormInput({
       'Anthropic': [],
       'OpenAI': [],
       'GitHub Copilot': [],
+      'Amp': [],
     }
     for (const conn of llmConnections) {
       const provider = conn.providerType || 'anthropic'
@@ -326,6 +327,8 @@ export function FreeFormInput({
         groups['OpenAI'].push(conn)
       } else if (provider === 'copilot') {
         groups['GitHub Copilot'].push(conn)
+      } else if (provider === 'amp') {
+        groups['Amp'].push(conn)
       }
     }
     // Return only non-empty groups

--- a/apps/electron/src/renderer/components/onboarding/APISetupStep.tsx
+++ b/apps/electron/src/renderer/components/onboarding/APISetupStep.tsx
@@ -1,16 +1,17 @@
 import { useState } from "react"
 import { cn } from "@/lib/utils"
-import { Check, CreditCard, Key, Cpu } from "lucide-react"
+import { Check, CreditCard, Key, Cpu, Terminal } from "lucide-react"
 import { StepFormLayout, BackButton, ContinueButton } from "./primitives"
 import type { LlmAuthType, LlmProviderType } from "@craft-agent/shared/config/llm-connections"
 
 /** Provider segment for the segmented control */
-export type ProviderSegment = 'anthropic' | 'openai' | 'copilot'
+export type ProviderSegment = 'anthropic' | 'openai' | 'copilot' | 'amp'
 
 const SEGMENT_LABELS: Record<ProviderSegment, string> = {
   anthropic: 'Claude',
   openai: 'Codex',
   copilot: 'GitHub Copilot',
+  amp: 'Amp',
 }
 
 const BetaBadge = () => (
@@ -21,8 +22,9 @@ const BetaBadge = () => (
 
 const SEGMENT_DESCRIPTIONS: Record<ProviderSegment, React.ReactNode> = {
   anthropic: <>Use Claude Agent SDK as the main agent.<br />Configure with your Claude subscription or API key.</>,
-  openai: <>Use Codex CLI as the main agent.<BetaBadge /><br />Configure with your ChatGPT subscription or OpenAI API key.</>,
+  openai: <>Use Codex CLI as the main agent.<BetaBadge /><br />Configure with your ChatGPT Plus subscription or OpenAI API key.</>,
   copilot: <>Use Copilot Agent as the main agent.<BetaBadge /><br />Configure with your GitHub Copilot subscription.</>,
+  amp: <>Use Amp CLI as the main agent.<BetaBadge /><br />Multi-model frontier agent with Oracle and subagents.</>,
 }
 
 /**
@@ -41,6 +43,7 @@ export type ApiSetupMethod =
   | 'chatgpt_oauth'
   | 'openai_api_key'
   | 'copilot_oauth'
+  | 'amp_cli'
 
 /**
  * Map ApiSetupMethod to the underlying LLM connection types.
@@ -60,6 +63,8 @@ export function apiSetupMethodToConnectionTypes(method: ApiSetupMethod): {
       return { providerType: 'openai', authType: 'api_key' };
     case 'copilot_oauth':
       return { providerType: 'copilot', authType: 'oauth' };
+    case 'amp_cli':
+      return { providerType: 'amp', authType: 'external_cli' };
   }
 }
 
@@ -106,6 +111,13 @@ const API_SETUP_OPTIONS: ApiSetupOption[] = [
     description: 'Use your GitHub Copilot subscription.',
     icon: <Cpu className="size-4" />,
     providerType: 'copilot',
+  },
+  {
+    id: 'amp_cli',
+    name: 'Amp CLI',
+    description: 'Multi-model frontier coding agent. Install from ampcode.com',
+    icon: <Terminal className="size-4" />,
+    providerType: 'amp',
   },
 ]
 
@@ -187,7 +199,7 @@ function ProviderSegmentedControl({
   activeSegment: ProviderSegment
   onSegmentChange: (segment: ProviderSegment) => void
 }) {
-  const segments: ProviderSegment[] = ['anthropic', 'openai', 'copilot']
+  const segments: ProviderSegment[] = ['anthropic', 'openai', 'copilot', 'amp']
 
   return (
     <div className="flex rounded-xl bg-foreground/[0.03] p-1 mb-4">

--- a/apps/electron/src/renderer/components/onboarding/CredentialsStep.tsx
+++ b/apps/electron/src/renderer/components/onboarding/CredentialsStep.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useEffect, useState } from "react"
-import { Check, ExternalLink } from "lucide-react"
+import { Check, ExternalLink, Terminal, CheckCircle2, XCircle, Loader2 } from "lucide-react"
 import type { ApiSetupMethod } from "./APISetupStep"
 import { StepFormLayout, BackButton, ContinueButton } from "./primitives"
 import {
@@ -51,10 +51,25 @@ export function CredentialsStep({
   const isCopilotOAuth = apiSetupMethod === 'copilot_oauth'
   const isAnthropicApiKey = apiSetupMethod === 'anthropic_api_key'
   const isOpenAiApiKey = apiSetupMethod === 'openai_api_key'
+  const isAmpCli = apiSetupMethod === 'amp_cli'
   const isApiKey = isAnthropicApiKey || isOpenAiApiKey
 
   // Copilot device code clipboard handling
   const [copiedCode, setCopiedCode] = useState(false)
+
+  // Amp CLI installation status
+  const [ampStatus, setAmpStatus] = useState<'checking' | 'installed' | 'not_installed'>('checking')
+
+  // Check Amp installation on mount (only when Amp is selected)
+  useEffect(() => {
+    if (isAmpCli) {
+      window.electronAPI.checkAmpInstalled().then((installed: boolean) => {
+        setAmpStatus(installed ? 'installed' : 'not_installed')
+      }).catch(() => {
+        setAmpStatus('not_installed')
+      })
+    }
+  }, [isAmpCli])
 
   // Auto-copy device code to clipboard when it appears
   useEffect(() => {
@@ -75,6 +90,107 @@ export function CredentialsStep({
         setTimeout(() => setCopiedCode(false), 2000)
       })
     }
+  }
+
+  // --- Amp CLI flow (external CLI auth) ---
+  if (isAmpCli) {
+    const handleOpenAmpInstall = () => {
+      window.electronAPI.openUrl('https://ampcode.com/install')
+    }
+
+    const handleRefreshCheck = () => {
+      setAmpStatus('checking')
+      window.electronAPI.checkAmpInstalled().then((installed: boolean) => {
+        setAmpStatus(installed ? 'installed' : 'not_installed')
+      }).catch(() => {
+        setAmpStatus('not_installed')
+      })
+    }
+
+    return (
+      <StepFormLayout
+        title="Set up Amp CLI"
+        description="Amp is a frontier coding agent with multi-model support."
+        actions={
+          <>
+            <BackButton onClick={onBack} />
+            <ContinueButton
+              onClick={() => onSubmit({ apiKey: '' })}
+              disabled={ampStatus !== 'installed'}
+            >
+              Continue
+            </ContinueButton>
+          </>
+        }
+      >
+        <div className="space-y-4">
+          {/* Status indicator */}
+          <div className="rounded-xl bg-foreground-2 p-4">
+            <div className="flex items-center gap-3">
+              {ampStatus === 'checking' && (
+                <>
+                  <Loader2 className="size-5 text-muted-foreground animate-spin" />
+                  <span className="text-sm text-muted-foreground">Checking for Amp CLI...</span>
+                </>
+              )}
+              {ampStatus === 'installed' && (
+                <>
+                  <CheckCircle2 className="size-5 text-success" />
+                  <span className="text-sm text-success">Amp CLI is installed and ready!</span>
+                </>
+              )}
+              {ampStatus === 'not_installed' && (
+                <>
+                  <XCircle className="size-5 text-destructive" />
+                  <span className="text-sm text-destructive">Amp CLI not found</span>
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* Installation instructions */}
+          {ampStatus === 'not_installed' && (
+            <div className="rounded-xl border border-border p-4 space-y-3">
+              <p className="text-sm text-muted-foreground">
+                Install Amp CLI by running this command in your terminal:
+              </p>
+              <code className="block bg-background rounded-lg p-3 text-sm font-mono text-foreground">
+                curl -fsSL https://ampcode.com/install.sh | bash
+              </code>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={handleOpenAmpInstall}
+                  className="flex items-center gap-2 text-sm text-primary hover:underline"
+                >
+                  <ExternalLink className="size-3" />
+                  Open ampcode.com/install
+                </button>
+                <span className="text-muted-foreground">·</span>
+                <button
+                  type="button"
+                  onClick={handleRefreshCheck}
+                  className="text-sm text-primary hover:underline"
+                >
+                  Refresh
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Features list */}
+          <div className="rounded-xl bg-foreground-2 p-4">
+            <p className="text-xs text-muted-foreground mb-2 font-medium">Amp features:</p>
+            <ul className="text-xs text-muted-foreground space-y-1">
+              <li>• Multi-model: Opus 4.6, GPT-5.2 Codex, and more</li>
+              <li>• Three modes: Smart, Rush, and Deep reasoning</li>
+              <li>• Oracle for complex analysis and review</li>
+              <li>• Subagents for parallel task execution</li>
+            </ul>
+          </div>
+        </div>
+      </StepFormLayout>
+    )
   }
 
   // --- ChatGPT OAuth flow (native browser OAuth) ---

--- a/apps/electron/src/renderer/hooks/useOnboarding.ts
+++ b/apps/electron/src/renderer/hooks/useOnboarding.ts
@@ -84,6 +84,7 @@ const BASE_SLUG_FOR_METHOD: Record<ApiSetupMethod, string> = {
   chatgpt_oauth: 'codex',
   openai_api_key: 'codex-api',
   copilot_oauth: 'copilot',
+  amp_cli: 'amp',
 }
 
 /**
@@ -147,6 +148,11 @@ function apiSetupMethodToConnectionSetup(
       return {
         slug,
         credential: options.credential,
+      }
+    case 'amp_cli':
+      return {
+        slug,
+        // Amp CLI doesn't need credentials - auth is handled by the CLI itself
       }
   }
 }
@@ -216,7 +222,8 @@ export function useOnboarding({
         console.error('[Onboarding] Save failed:', result.error)
         setState(s => ({
           ...s,
-          completionStatus: 'saving',
+          step: 'credentials',
+          credentialStatus: 'error',
           errorMessage: result.error || 'Failed to save configuration',
         }))
       }
@@ -224,6 +231,8 @@ export function useOnboarding({
       console.error('[Onboarding] handleSaveConfig error:', error)
       setState(s => ({
         ...s,
+        step: 'credentials',
+        credentialStatus: 'error',
         errorMessage: error instanceof Error ? error.message : 'Failed to save configuration',
       }))
     }
@@ -294,8 +303,20 @@ export function useOnboarding({
     setState(s => ({ ...s, credentialStatus: 'validating', errorMessage: undefined }))
 
     const isOpenAiFlow = state.apiSetupMethod === 'openai_api_key'
+    const isAmpFlow = state.apiSetupMethod === 'amp_cli'
 
     try {
+      // Amp CLI flow - no credentials needed, just save the connection config
+      if (isAmpFlow) {
+        await handleSaveConfig('', {})
+        setState(s => ({
+          ...s,
+          credentialStatus: 'success',
+          step: 'complete',
+        }))
+        return
+      }
+
       // API key validation differs by provider:
       // - OpenAI flow: API key is always required
       // - Anthropic flow: API key required for hosted providers, optional for Ollama/local

--- a/apps/electron/src/renderer/pages/settings/AiSettingsPage.tsx
+++ b/apps/electron/src/renderer/pages/settings/AiSettingsPage.tsx
@@ -178,6 +178,7 @@ function ConnectionRow({ connection, isLastConnection, onRenameClick, onDelete, 
       case 'openai_compat': parts.push('OpenAI Compatible'); break
       case 'bedrock': parts.push('AWS Bedrock'); break
       case 'vertex': parts.push('Google Vertex'); break
+      case 'amp': parts.push('Amp CLI'); break
       default: parts.push(provider || 'Unknown')
     }
 
@@ -426,6 +427,7 @@ function WorkspaceOverrideCard({ workspace, llmConnections, onSettingsChange }: 
                     description: conn.providerType === 'anthropic' ? 'Anthropic' :
                                  conn.providerType === 'openai' ? 'OpenAI' :
                                  conn.providerType === 'copilot' ? 'GitHub Copilot' :
+                                 conn.providerType === 'amp' ? 'Amp CLI' :
                                  conn.providerType || 'Unknown',
                   })),
                 ]}
@@ -747,6 +749,7 @@ export default function AiSettingsPage() {
                                    conn.providerType === 'openai_compat' ? 'OpenAI Compatible' :
                                    conn.providerType === 'bedrock' ? 'AWS Bedrock' :
                                    conn.providerType === 'vertex' ? 'Google Vertex' :
+                                   conn.providerType === 'amp' ? 'Amp CLI' :
                                    conn.providerType || 'Unknown',
                     }))}
                   />

--- a/apps/electron/src/shared/types.ts
+++ b/apps/electron/src/shared/types.ts
@@ -704,6 +704,9 @@ export const IPC_CHANNELS = {
   COPILOT_LOGOUT: 'copilot:logout',
   COPILOT_DEVICE_CODE: 'copilot:deviceCode',
 
+  // Amp CLI
+  CHECK_AMP_INSTALLED: 'amp:checkInstalled',
+
   // Settings - API Setup
   SETUP_LLM_CONNECTION: 'settings:setupLlmConnection',
   SETTINGS_TEST_API_CONNECTION: 'settings:testApiConnection',
@@ -999,6 +1002,9 @@ export interface ElectronAPI {
   getCopilotAuthStatus(connectionSlug: string): Promise<{ authenticated: boolean }>
   copilotLogout(connectionSlug: string): Promise<{ success: boolean }>
   onCopilotDeviceCode(callback: (data: { userCode: string; verificationUri: string }) => void): () => void
+
+  // Amp CLI
+  checkAmpInstalled(): Promise<boolean>
 
   /** Unified LLM connection setup */
   setupLlmConnection(setup: LlmConnectionSetup): Promise<{ success: boolean; error?: string }>

--- a/bun.lock
+++ b/bun.lock
@@ -82,7 +82,7 @@
     },
     "apps/electron": {
       "name": "@craft-agent/electron",
-      "version": "0.4.3",
+      "version": "0.4.6",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/shared": "workspace:*",
@@ -118,32 +118,9 @@
         "vaul": "^1.1.2",
       },
     },
-    "apps/marketing": {
-      "name": "@craft-agent/marketing",
-      "version": "0.4.3",
-      "dependencies": {
-        "@craft-agent/ui": "workspace:*",
-        "@paper-design/shaders-react": "^0.0.70",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-router-dom": "^7.13.0",
-        "shiki": "^3.21.0",
-        "three": "^0.170.0",
-      },
-      "devDependencies": {
-        "@tailwindcss/vite": "^4.1.18",
-        "@types/react": "^18.3.0",
-        "@types/react-dom": "^18.3.0",
-        "@types/three": "^0.170.0",
-        "@vitejs/plugin-react": "^5.1.2",
-        "tailwindcss": "^4.1.18",
-        "typescript": "^5.0.0",
-        "vite": "^6.2.4",
-      },
-    },
     "apps/viewer": {
       "name": "@craft-agent/viewer",
-      "version": "0.4.3",
+      "version": "0.4.6",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/ui": "workspace:*",
@@ -170,7 +147,7 @@
     },
     "packages/bridge-mcp-server": {
       "name": "@craft-agent/bridge-mcp-server",
-      "version": "0.4.3",
+      "version": "0.4.6",
       "bin": {
         "bridge-mcp-server": "./dist/index.js",
       },
@@ -183,11 +160,11 @@
     },
     "packages/codex-types": {
       "name": "@craft-agent/codex-types",
-      "version": "0.4.3",
+      "version": "0.4.6",
     },
     "packages/core": {
       "name": "@craft-agent/core",
-      "version": "0.4.3",
+      "version": "0.4.6",
       "devDependencies": {
         "@types/uuid": "^11.0.0",
       },
@@ -199,7 +176,7 @@
     },
     "packages/mermaid": {
       "name": "@craft-agent/mermaid",
-      "version": "0.4.3",
+      "version": "0.4.6",
       "dependencies": {
         "elkjs": "^0.11.0",
       },
@@ -209,7 +186,7 @@
     },
     "packages/session-mcp-server": {
       "name": "@craft-agent/session-mcp-server",
-      "version": "0.4.3",
+      "version": "0.4.6",
       "bin": {
         "session-mcp-server": "./dist/index.js",
       },
@@ -224,7 +201,7 @@
     },
     "packages/session-tools-core": {
       "name": "@craft-agent/session-tools-core",
-      "version": "0.4.3",
+      "version": "0.4.6",
       "dependencies": {
         "@craft-agent/mermaid": "workspace:*",
         "gray-matter": "^4.0.3",
@@ -236,7 +213,7 @@
     },
     "packages/shared": {
       "name": "@craft-agent/shared",
-      "version": "0.4.3",
+      "version": "0.4.6",
       "dependencies": {
         "@craft-agent/codex-types": "workspace:*",
         "@craft-agent/core": "workspace:*",
@@ -262,7 +239,7 @@
     },
     "packages/ui": {
       "name": "@craft-agent/ui",
-      "version": "0.4.3",
+      "version": "0.4.6",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/mermaid": "workspace:*",
@@ -471,8 +448,6 @@
     "@craft-agent/core": ["@craft-agent/core@workspace:packages/core"],
 
     "@craft-agent/electron": ["@craft-agent/electron@workspace:apps/electron"],
-
-    "@craft-agent/marketing": ["@craft-agent/marketing@workspace:apps/marketing"],
 
     "@craft-agent/mermaid": ["@craft-agent/mermaid@workspace:packages/mermaid"],
 
@@ -1138,8 +1113,6 @@
 
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
-    "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
-
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -1202,19 +1175,13 @@
 
     "@types/shell-quote": ["@types/shell-quote@1.7.5", "", {}, "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw=="],
 
-    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
-
     "@types/tedious": ["@types/tedious@4.0.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
-
-    "@types/three": ["@types/three@0.170.0", "", { "dependencies": { "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": "*", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~0.18.1" } }, "sha512-CUm2uckq+zkCY7ZbFpviRttY+6f9fvwm6YqSqPfA5K22s9w7R4VnA3rzJse8kHVvuzLcTx+CjNCs2NYe0QFAyg=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
     "@types/verror": ["@types/verror@1.10.11", "", {}, "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg=="],
-
-    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
@@ -1245,8 +1212,6 @@
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.1.2", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.53", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ=="],
-
-    "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
 
@@ -2204,8 +2169,6 @@
 
     "merge-refs": ["merge-refs@2.0.0", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg=="],
 
-    "meshoptimizer": ["meshoptimizer@0.18.1", "", {}, "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw=="],
-
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
@@ -2522,10 +2485,6 @@
 
     "react-resizable-panels": ["react-resizable-panels@3.0.6", "", { "peerDependencies": { "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew=="],
 
-    "react-router": ["react-router@7.13.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw=="],
-
-    "react-router-dom": ["react-router-dom@7.13.0", "", { "dependencies": { "react-router": "7.13.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g=="],
-
     "react-simple-code-editor": ["react-simple-code-editor@0.14.1", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-BR5DtNRy+AswWJECyA17qhUDvrrCZ6zXOCfkQY5zSmb96BVUbpVAv03WpcjcwtCwiLbIANx3gebHOcXYn1EHow=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
@@ -2625,8 +2584,6 @@
     "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -2759,8 +2716,6 @@
     "temp-file": ["temp-file@3.4.0", "", { "dependencies": { "async-exit-hook": "^2.0.1", "fs-extra": "^10.0.0" } }, "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg=="],
 
     "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
-
-    "three": ["three@0.170.0", "", {}, "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ=="],
 
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
 
@@ -2993,8 +2948,6 @@
     "@babel/highlight/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "@craft-agent/bridge-mcp-server/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
-
-    "@craft-agent/marketing/@paper-design/shaders-react": ["@paper-design/shaders-react@0.0.70", "", { "dependencies": { "@paper-design/shaders": "0.0.70" }, "peerDependencies": { "@types/react": "^18 || ^19", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-9DkZXcyehorsZzyWnYV3OOO1i7rF7a5CkasjKJ1h1tLlY3JJLUEX9W+gZz7JgWHyvCimUu0OSq1sbHTb2OntRw=="],
 
     "@craft-agent/session-mcp-server/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
 
@@ -3270,8 +3223,6 @@
 
     "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
-    "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
-
     "read-pkg-up/find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "^2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
 
     "readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
@@ -3327,8 +3278,6 @@
     "@babel/highlight/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
 
     "@craft-agent/bridge-mcp-server/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
-
-    "@craft-agent/marketing/@paper-design/shaders-react/@paper-design/shaders": ["@paper-design/shaders@0.0.70", "", {}, "sha512-d9LQcmPoEm3+Y6Vuz7cvsnSelfTM5QD63yQ3ddLM7QGYfoSjbQiU38kzjA4O3oCQ6zv23o/IGvGA8k9S/L+kZw=="],
 
     "@craft-agent/session-mcp-server/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/packages/shared/src/agent/amp-agent.ts
+++ b/packages/shared/src/agent/amp-agent.ts
@@ -1,0 +1,605 @@
+/**
+ * Amp Backend (Amp CLI)
+ *
+ * Agent backend implementation using the Amp CLI from ampcode.com.
+ * Wraps the Amp CLI via subprocess with JSON streaming I/O.
+ *
+ * Auth is handled by Amp's native auth system (ampcode.com/install).
+ * Tokens are stored by Amp CLI, not in our credential store.
+ *
+ * Key features:
+ * - Multi-model support (Opus 4.6, GPT-5.2 Codex, etc.)
+ * - Three modes: smart, rush, deep
+ * - Thread persistence and sharing
+ * - Oracle for complex reasoning
+ * - Subagents for parallel tasks
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createInterface, type Interface as ReadlineInterface } from 'node:readline';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+
+import type { AgentEvent } from '@craft-agent/core/types';
+import type { FileAttachment } from '../utils/files.ts';
+import type { ThinkingLevel } from './thinking-levels.ts';
+import { type PermissionMode, shouldAllowToolInMode } from './mode-manager.ts';
+
+import type {
+  BackendConfig,
+  ChatOptions,
+  SdkMcpServerConfig,
+} from './backend/types.ts';
+import { AbortReason } from './backend/types.ts';
+
+import { BaseAgent } from './base-agent.ts';
+import type { Workspace } from '../config/storage.ts';
+
+import { AmpEventAdapter, type AmpStreamMessage } from './backend/amp/event-adapter.ts';
+import { EventQueue } from './backend/event-queue.ts';
+
+import { getSystemPrompt } from '../prompts/system.ts';
+import { getCredentialManager } from '../credentials/manager.ts';
+import { getSessionPlansPath, getSessionPath } from '../sessions/storage.ts';
+import { parseError, type AgentError } from './errors.ts';
+
+/**
+ * Amp mode type - determines model selection and behavior.
+ * - smart: uses Claude Opus 4.6 for maximum capability
+ * - rush: faster, cheaper, suitable for small tasks
+ * - deep: deep reasoning with GPT-5.2 Codex
+ */
+type AmpMode = 'smart' | 'rush' | 'deep';
+
+/**
+ * Map our model IDs to Amp modes.
+ */
+const MODEL_TO_AMP_MODE: Record<string, AmpMode> = {
+  'amp-smart': 'smart',
+  'amp-rush': 'rush',
+  'amp-deep': 'deep',
+};
+
+/**
+ * Map thinking levels to Amp modes as fallback.
+ */
+const THINKING_TO_AMP_MODE: Record<ThinkingLevel, AmpMode> = {
+  off: 'rush',
+  think: 'smart',
+  max: 'deep',
+};
+
+/**
+ * Map Amp tool names to our permission system's PascalCase names.
+ */
+const AMP_TOOL_NAME_MAP: Record<string, string> = {
+  bash: 'Bash',
+  read: 'Read',
+  write: 'Write',
+  edit: 'Edit',
+  glob: 'Glob',
+  grep: 'Grep',
+  web_fetch: 'WebFetch',
+  web_search: 'WebSearch',
+  task: 'Task',
+  mcp: 'Mcp',
+};
+
+/**
+ * Resolve the Amp CLI binary path.
+ * Checks common installation locations.
+ */
+export function resolveAmpBinary(configPath?: string): { path: string; source: string } | null {
+  if (configPath && existsSync(configPath)) {
+    return { path: configPath, source: 'config' };
+  }
+
+  const possiblePaths = [
+    join(homedir(), '.local', 'bin', 'amp'),
+    '/usr/local/bin/amp',
+    '/opt/homebrew/bin/amp',
+  ];
+
+  for (const p of possiblePaths) {
+    if (existsSync(p)) {
+      return { path: p, source: 'system' };
+    }
+  }
+
+  return { path: 'amp', source: 'PATH' };
+}
+
+/**
+ * Check if Amp CLI is installed and accessible.
+ */
+export async function isAmpInstalled(): Promise<boolean> {
+  const commonPaths = [
+    join(homedir(), '.local', 'bin', 'amp'),
+    '/usr/local/bin/amp',
+    '/opt/homebrew/bin/amp',
+  ];
+
+  for (const ampPath of commonPaths) {
+    if (existsSync(ampPath)) {
+      return true;
+    }
+  }
+
+  return new Promise((resolve) => {
+    const proc = spawn('amp', ['--version'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: true,
+      timeout: 5000,
+    });
+
+    proc.on('error', () => resolve(false));
+    proc.on('close', (code) => resolve(code === 0));
+  });
+}
+
+/**
+ * Get Amp CLI version string.
+ */
+export async function getAmpVersion(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const proc = spawn('amp', ['--version'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: true,
+    });
+
+    let output = '';
+    proc.stdout?.on('data', (data) => { output += data.toString(); });
+
+    proc.on('error', () => resolve(null));
+    proc.on('close', (code) => {
+      if (code === 0) {
+        resolve(output.trim().split('\n')[0] || null);
+      }
+      resolve(null);
+    });
+  });
+}
+
+/**
+ * Backend implementation using the Amp CLI.
+ *
+ * Communication with Amp CLI:
+ * - Spawns `amp --execute --stream-json --stream-json-input` subprocess
+ * - Sends user messages as JSON on stdin
+ * - Receives streaming JSON events on stdout
+ * - Thread continuity via `amp threads continue`
+ */
+export class AmpAgent extends BaseAgent {
+  private ampProcess: ChildProcess | null = null;
+  private ampStdoutReader: ReadlineInterface | null = null;
+  private ampThreadId: string | null = null;
+
+  private _isProcessing: boolean = false;
+  private abortReason?: AbortReason;
+
+  private adapter: AmpEventAdapter;
+  private eventQueue = new EventQueue();
+
+  private pendingPermissions: Map<string, {
+    resolve: (allowed: boolean) => void;
+    toolName: string;
+  }> = new Map();
+
+  private currentUserMessage: string = '';
+  private sourceMcpServers: Record<string, SdkMcpServerConfig> = {};
+  private sourceApiServers: Record<string, unknown> = {};
+  private ampBinaryPath: string;
+
+  /** Called when Amp auth is required */
+  onAmpAuthRequired: ((reason: string) => void) | null = null;
+
+  constructor(config: BackendConfig) {
+    const defaultModel = 'amp-smart';
+    super({ ...config, model: config.model || defaultModel }, defaultModel, 200_000);
+
+    this.adapter = new AmpEventAdapter();
+
+    // only use sdkSessionId if it's a valid Amp thread ID (starts with "T-")
+    const candidateThreadId = config.session?.sdkSessionId || null;
+    this.ampThreadId = this.isValidAmpThreadId(candidateThreadId) ? candidateThreadId : null;
+
+    if (candidateThreadId && !this.ampThreadId) {
+      this.debug(`Ignoring non-Amp session ID: ${candidateThreadId}`);
+    }
+
+    // resolve amp binary
+    const resolved = resolveAmpBinary(config.ampPath);
+    this.ampBinaryPath = resolved?.path || 'amp';
+    this.debug(`Amp binary resolved: ${this.ampBinaryPath} (source: ${resolved?.source || 'fallback'})`);
+
+    if (!config.isHeadless) {
+      this.startConfigWatcher();
+    }
+  }
+
+  /**
+   * Check if a string is a valid Amp thread ID.
+   * Amp thread IDs have the format: T-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+   */
+  private isValidAmpThreadId(id: string | null | undefined): boolean {
+    if (!id) return false;
+    return id.startsWith('T-') && id.length > 3;
+  }
+
+  protected override debug(message: string): void {
+    this.onDebug?.(`[Amp] ${message}`);
+  }
+
+  /**
+   * Get Amp mode from model ID or thinking level.
+   */
+  private getAmpMode(): AmpMode {
+    if (this._model && MODEL_TO_AMP_MODE[this._model]) {
+      return MODEL_TO_AMP_MODE[this._model];
+    }
+    return THINKING_TO_AMP_MODE[this._thinkingLevel] || 'smart';
+  }
+
+  /**
+   * Spawn a new Amp CLI subprocess for a chat turn.
+   * Each message spawns a fresh process with --stream-json-input for multi-turn support.
+   */
+  private spawnAmpProcess(): ChildProcess {
+    // kill existing process if any
+    if (this.ampProcess && !this.ampProcess.killed) {
+      this.ampProcess.kill();
+      this.ampProcess = null;
+    }
+
+    const args: string[] = [];
+
+    // thread continuation if we have a thread ID
+    if (this.ampThreadId) {
+      args.push('threads', 'continue', this.ampThreadId);
+    }
+
+    // core flags for streaming JSON I/O
+    args.push('--execute');
+    args.push('--stream-json');
+    args.push('--stream-json-input');
+    args.push('--stream-json-thinking');
+
+    // use dangerously-allow-all since we handle permissions ourselves
+    args.push('--dangerously-allow-all');
+
+    // resolve full binary path if needed
+    let binaryPath = this.ampBinaryPath;
+    if (binaryPath === 'amp') {
+      // try common locations
+      const commonPaths = [
+        join(homedir(), '.local', 'bin', 'amp'),
+        '/usr/local/bin/amp',
+        '/opt/homebrew/bin/amp',
+      ];
+      for (const p of commonPaths) {
+        if (existsSync(p)) {
+          binaryPath = p;
+          break;
+        }
+      }
+    }
+
+    this.debug(`Spawning Amp: ${binaryPath} ${args.join(' ')}`);
+    this.debug(`Working directory: ${this.workingDirectory}`);
+
+    const proc = spawn(binaryPath, args, {
+      cwd: this.workingDirectory,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        PATH: `${join(homedir(), '.local', 'bin')}:/usr/local/bin:/opt/homebrew/bin:${process.env.PATH || ''}`,
+      },
+    });
+
+    this.ampProcess = proc;
+
+    if (proc.stdout) {
+      this.ampStdoutReader = createInterface({
+        input: proc.stdout,
+        crlfDelay: Infinity,
+      });
+    }
+
+    proc.stderr?.on('data', (data) => {
+      const msg = data.toString().trim();
+      if (msg) {
+        this.debug(`stderr: ${msg}`);
+      }
+    });
+
+    proc.on('close', (code) => {
+      this.debug(`Amp process exited with code ${code}`);
+      this.ampProcess = null;
+      this.ampStdoutReader = null;
+    });
+
+    proc.on('error', (err) => {
+      this.debug(`Amp process error: ${err.message}`);
+      if (err.message.includes('ENOENT')) {
+        this.onAmpAuthRequired?.('Amp CLI not found. Please install from ampcode.com/install');
+      }
+    });
+
+    return proc;
+  }
+
+  async *chat(
+    messageParam: string,
+    attachments?: FileAttachment[],
+    options?: ChatOptions
+  ): AsyncGenerator<AgentEvent> {
+    let message = messageParam;
+
+    this._isProcessing = true;
+    this.abortReason = undefined;
+    this.eventQueue.reset();
+    this.currentUserMessage = message;
+    this.adapter.startTurn();
+
+    try {
+      const proc = this.spawnAmpProcess();
+
+      // build context parts
+      const sourceContext = this.sourceManager.formatSourceState();
+      const contextParts = this.promptBuilder.buildContextParts(
+        { plansFolderPath: getSessionPlansPath(this.config.workspace.rootPath, this._sessionId) },
+        sourceContext
+      );
+
+      // process attachments
+      const attachmentParts: string[] = [];
+      for (const att of attachments || []) {
+        if (att.mimeType?.startsWith('image/') && (att.storedPath || att.path)) {
+          attachmentParts.push(`[Attached image: ${att.name}]\n[Stored at: ${att.storedPath || att.path}]`);
+        } else if (att.mimeType === 'application/pdf' && att.storedPath) {
+          attachmentParts.push(`[Attached PDF: ${att.name}]\n[Stored at: ${att.storedPath}]`);
+        } else if (att.storedPath) {
+          let pathInfo = `[Attached file: ${att.name}]\n[Stored at: ${att.storedPath}]`;
+          if (att.markdownPath) {
+            pathInfo += `\n[Markdown version: ${att.markdownPath}]`;
+          }
+          attachmentParts.push(pathInfo);
+        }
+      }
+
+      // extract skill content
+      const { skillContents, cleanMessage: effectiveMessage } = this.extractSkillContent(message);
+
+      // combine message parts
+      const messageParts = [
+        ...skillContents,
+        ...contextParts,
+        ...attachmentParts,
+        effectiveMessage,
+      ].filter(Boolean);
+      const fullMessage = messageParts.join('\n\n');
+
+      // build JSON input message per Amp's streaming JSON input format
+      const inputMessage = {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: fullMessage }],
+        },
+      };
+
+      this.debug(`Sending message: ${fullMessage.substring(0, 100)}...`);
+
+      // write message to stdin
+      if (proc.stdin) {
+        const jsonLine = JSON.stringify(inputMessage) + '\n';
+        proc.stdin.write(jsonLine);
+        this.debug(`Wrote ${jsonLine.length} bytes to stdin`);
+      }
+
+      // wait a bit for process to start processing
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // process streaming output
+      if (this.ampStdoutReader) {
+        this.debug('Starting to read stdout...');
+
+        for await (const line of this.ampStdoutReader) {
+          if (!line.trim()) continue;
+
+          this.debug(`Received line: ${line.substring(0, 200)}`);
+
+          try {
+            const msg = JSON.parse(line) as AmpStreamMessage;
+
+            // capture thread ID from session info
+            if (msg.session_id && !this.ampThreadId) {
+              this.ampThreadId = msg.session_id;
+              this.config.onSdkSessionIdUpdate?.(msg.session_id);
+              this.debug(`Thread ID captured: ${msg.session_id}`);
+            }
+
+            // track usage/cost
+            if (msg.cost_usd !== undefined) {
+              const estimatedTokens = Math.round((msg.cost_usd / 0.01) * 1000);
+              this.usageTracker.recordMessageUsage({
+                inputTokens: estimatedTokens,
+                outputTokens: 0,
+                cacheReadTokens: 0,
+                cacheCreationTokens: 0,
+              });
+            }
+
+            // handle errors (can be object or string)
+            if (msg.error) {
+              const typedError = this.parseAmpError(msg.error);
+              if (typedError.code === 'invalid_credentials') {
+                this.onAmpAuthRequired?.(typedError.message);
+              }
+              yield { type: 'typed_error', error: typedError };
+              continue;
+            }
+
+            // handle result errors (is_error flag or error_during_execution subtype)
+            if (msg.type === 'result' && (msg.is_error || msg.subtype === 'error_during_execution')) {
+              const errorStr = typeof msg.error === 'string' ? msg.error : (msg.result || 'Unknown Amp error');
+              const typedError = this.parseAmpError(errorStr);
+              yield { type: 'typed_error', error: typedError };
+              this.eventQueue.complete();
+              break;
+            }
+
+            // adapt message to AgentEvents
+            for (const event of this.adapter.adaptMessage(msg)) {
+              this.eventQueue.enqueue(event);
+            }
+
+            // check for completion
+            if (msg.type === 'result' || msg.message?.stop_reason) {
+              this.debug('Received completion signal');
+              this.eventQueue.complete();
+              break;
+            }
+          } catch (parseError) {
+            this.debug(`Failed to parse JSON line: ${line}`);
+          }
+        }
+      }
+
+      yield* this.eventQueue.drain();
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('abort')) {
+        if (this.abortReason === AbortReason.PlanSubmitted) {
+          return;
+        }
+        if (this.abortReason === AbortReason.AuthRequest) {
+          return;
+        }
+        return;
+      }
+
+      const errorObj = error instanceof Error ? error : new Error(String(error));
+      this.debug(`Chat error: ${errorObj.message}`);
+      const typedError = this.parseAmpError({ code: 'unknown', message: errorObj.message });
+
+      yield { type: 'typed_error', error: typedError };
+      yield { type: 'complete' };
+    } finally {
+      this._isProcessing = false;
+      // close stdin to signal end of input
+      if (this.ampProcess?.stdin) {
+        this.ampProcess.stdin.end();
+      }
+    }
+  }
+
+  private parseAmpError(error: { code?: string; message: string } | string): AgentError {
+    const errorMessage = typeof error === 'string' ? error.toLowerCase() : error.message.toLowerCase();
+    const errorCode = typeof error === 'string' ? undefined : error.code;
+
+    if (errorMessage.includes('not authenticated') ||
+        errorMessage.includes('login') ||
+        errorMessage.includes('sign in') ||
+        errorCode === 'auth_required') {
+      return {
+        code: 'invalid_credentials',
+        title: 'Amp Authentication Required',
+        message: 'Please run `amp` in your terminal to sign in.',
+        actions: [
+          { key: 'r', label: 'Retry', action: 'retry' },
+        ],
+        canRetry: false,
+      };
+    }
+
+    if (errorMessage.includes('rate limit') || errorCode === 'rate_limited') {
+      return {
+        code: 'rate_limited',
+        title: 'Rate Limited',
+        message: 'Amp rate limit reached. Please wait a moment.',
+        actions: [
+          { key: 'r', label: 'Retry', action: 'retry' },
+        ],
+        canRetry: true,
+      };
+    }
+
+    if (errorMessage.includes('credit') || errorMessage.includes('billing') || 
+        errorMessage.includes('paid credits') || errorMessage.includes('402') ||
+        errorMessage.includes('ampcode.com/pay') || errorCode === 'insufficient_credits') {
+      return {
+        code: 'insufficient_credits',
+        title: 'Amp Credits Required',
+        message: 'Amp\'s execute mode requires paid credits. The free tier only works in interactive mode. Add credits at ampcode.com/pay',
+        actions: [
+          { key: 'o', label: 'Add Credits', action: 'open_url' },
+        ],
+        canRetry: false,
+      };
+    }
+
+    return {
+      code: 'api_error',
+      title: 'Amp Error',
+      message: error.message || 'An unknown error occurred',
+      actions: [
+        { key: 'r', label: 'Retry', action: 'retry' },
+      ],
+      canRetry: true,
+    };
+  }
+
+  // BaseAgent interface implementations
+
+  override get isProcessing(): boolean {
+    return this._isProcessing;
+  }
+
+  override async abort(): Promise<void> {
+    if (this.ampProcess && !this.ampProcess.killed) {
+      this.ampProcess.kill('SIGTERM');
+    }
+    this._isProcessing = false;
+    this.eventQueue.complete();
+  }
+
+  override forceAbort(reason?: AbortReason): void {
+    this.abortReason = reason;
+    if (this.ampProcess && !this.ampProcess.killed) {
+      this.ampProcess.kill('SIGKILL');
+    }
+    this._isProcessing = false;
+    this.eventQueue.complete();
+  }
+
+  override async resolvePermission(requestId: string, allowed: boolean): Promise<void> {
+    const pending = this.pendingPermissions.get(requestId);
+    if (pending) {
+      pending.resolve(allowed);
+      this.pendingPermissions.delete(requestId);
+    }
+  }
+
+  override setSourceServers(
+    mcpServers: Record<string, SdkMcpServerConfig>,
+    apiServers: Record<string, unknown>,
+    slugs: string[]
+  ): void {
+    this.sourceMcpServers = mcpServers;
+    this.sourceApiServers = apiServers;
+    this.sourceManager.setEnabledSlugs(slugs);
+  }
+
+  override async dispose(): Promise<void> {
+    if (this.ampProcess && !this.ampProcess.killed) {
+      this.ampProcess.kill();
+    }
+    this.ampProcess = null;
+    this.ampStdoutReader = null;
+    await super.dispose();
+  }
+}
+
+/** @deprecated Use AmpAgent instead */
+export { AmpAgent as AmpBackend };

--- a/packages/shared/src/agent/backend/amp/event-adapter.ts
+++ b/packages/shared/src/agent/backend/amp/event-adapter.ts
@@ -1,0 +1,280 @@
+/**
+ * Amp Event Adapter
+ *
+ * Maps Amp CLI streaming JSON messages to Craft Agent's AgentEvent format.
+ * This enables the AmpAgent to emit events compatible with the existing UI.
+ *
+ * Amp CLI outputs one JSON object per line when using --stream-json flag.
+ * Message types include: user, assistant, system, result
+ * Content block types: text, tool_use, tool_result, thinking
+ */
+
+import type { AgentEvent } from '@craft-agent/core/types';
+import { BaseEventAdapter } from '../base-event-adapter.ts';
+
+// ============================================================
+// Types
+// ============================================================
+
+/**
+ * Amp streaming JSON message structure.
+ */
+export interface AmpStreamMessage {
+  type: 'user' | 'assistant' | 'system' | 'result';
+  subtype?: string;
+  message?: {
+    role: string;
+    content: AmpContentBlock[];
+    stop_reason?: string;
+  };
+  session_id?: string;
+  cost_usd?: number;
+  duration_ms?: number;
+  is_delta?: boolean;
+  is_error?: boolean;
+  num_turns?: number;
+  result?: string;
+  error?: {
+    code: string;
+    message: string;
+  } | string;
+}
+
+export interface AmpContentBlock {
+  type: 'text' | 'tool_use' | 'tool_result' | 'thinking';
+  text?: string;
+  id?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+  tool_use_id?: string;
+  content?: string;
+  is_error?: boolean;
+  thinking?: string;
+}
+
+/**
+ * Map Amp tool names to PascalCase names used by our UI.
+ */
+const AMP_TOOL_NAME_MAP: Record<string, string> = {
+  bash: 'Bash',
+  read: 'Read',
+  write: 'Write',
+  edit: 'Edit',
+  glob: 'Glob',
+  grep: 'Grep',
+  web_fetch: 'WebFetch',
+  web_search: 'WebSearch',
+  task: 'Task',
+  mcp: 'Mcp',
+  oracle: 'Oracle',
+  librarian: 'Librarian',
+  painter: 'Painter',
+};
+
+// ============================================================
+// AmpEventAdapter
+// ============================================================
+
+/**
+ * Adapts Amp CLI streaming JSON messages to AgentEvent format.
+ */
+export class AmpEventAdapter extends BaseEventAdapter {
+  // track active tool calls by ID
+  private activeToolCalls: Map<string, { name: string; input: Record<string, unknown> }> = new Map();
+
+  // accumulated text for delta messages
+  private accumulatedText: string = '';
+
+  // turn tracking
+  private turnStartEmitted: boolean = false;
+
+  constructor() {
+    super('AmpEventAdapter');
+  }
+
+  /**
+   * Subclass hook called during startTurn() for resetting provider-specific state.
+   */
+  protected override onTurnStart(): void {
+    this.activeToolCalls.clear();
+    this.accumulatedText = '';
+    this.turnStartEmitted = false;
+  }
+
+  /**
+   * Map a single Amp streaming message to AgentEvents.
+   */
+  *adaptMessage(msg: AmpStreamMessage): Generator<AgentEvent> {
+    // handle errors (can be object or string)
+    if (msg.error) {
+      const errorMessage = typeof msg.error === 'string' ? msg.error : msg.error.message;
+      yield {
+        type: 'error',
+        message: errorMessage,
+      };
+      return;
+    }
+
+    // handle result messages - check for errors
+    if (msg.type === 'result') {
+      if (msg.is_error || msg.subtype === 'error_during_execution') {
+        // parse error message for credit/payment issues
+        const errorStr = typeof msg.error === 'string' ? msg.error : (msg.result || 'Unknown error');
+
+        // check for paid credits requirement
+        if (errorStr.includes('paid credits') || errorStr.includes('402') || errorStr.includes('ampcode.com/pay')) {
+          yield {
+            type: 'typed_error',
+            error: {
+              code: 'insufficient_credits',
+              title: 'Amp Credits Required',
+              message: 'Amp\'s execute mode requires paid credits. The free tier only works in interactive mode.',
+              details: [
+                'Add credits at ampcode.com/pay',
+                'Or use Amp interactively in your terminal',
+              ],
+              actions: [
+                { key: 'o', label: 'Open Amp Pay', action: 'open_url', url: 'https://ampcode.com/pay' },
+              ],
+              canRetry: false,
+            },
+          };
+        } else {
+          yield {
+            type: 'error',
+            message: errorStr,
+          };
+        }
+      }
+      yield { type: 'complete' };
+      return;
+    }
+
+    // handle system messages (usually session info)
+    if (msg.type === 'system') {
+      // system messages don't produce UI events
+      return;
+    }
+
+    // handle assistant messages with content
+    if (msg.type === 'assistant' && msg.message?.content) {
+      for (const block of msg.message.content) {
+        yield* this.adaptContentBlock(block, msg.is_delta);
+      }
+
+      // check for stop reason (turn complete)
+      if (msg.message.stop_reason === 'end_turn') {
+        yield { type: 'complete' };
+      }
+    }
+  }
+
+  /**
+   * Adapt a single content block to AgentEvents.
+   */
+  private *adaptContentBlock(block: AmpContentBlock, isDelta?: boolean): Generator<AgentEvent> {
+    switch (block.type) {
+      case 'text':
+        if (block.text) {
+          if (isDelta) {
+            // streaming delta - emit as text_delta
+            yield {
+              type: 'text_delta',
+              text: block.text,
+            };
+            this.accumulatedText += block.text;
+          } else {
+            // complete text block
+            yield {
+              type: 'text_complete',
+              text: block.text,
+            };
+          }
+        }
+        break;
+
+      case 'thinking':
+        if (block.thinking) {
+          // thinking blocks are emitted as text_delta with a prefix
+          // the UI will render them differently based on context
+          yield {
+            type: 'text_delta',
+            text: block.thinking,
+          };
+        }
+        break;
+
+      case 'tool_use':
+        if (block.id && block.name) {
+          const normalizedName = this.normalizeToolName(block.name);
+          const input = block.input || {};
+
+          // track active tool call
+          this.activeToolCalls.set(block.id, { name: normalizedName, input });
+
+          yield this.createToolStart(
+            block.id,
+            normalizedName,
+            input,
+            undefined, // intent
+            normalizedName, // displayName
+          );
+        }
+        break;
+
+      case 'tool_result':
+        if (block.tool_use_id) {
+          const toolCall = this.activeToolCalls.get(block.tool_use_id);
+          const toolName = toolCall?.name || 'Unknown';
+
+          yield this.createToolResult(
+            block.tool_use_id,
+            toolName,
+            block.content || '',
+            block.is_error || false,
+          );
+
+          // clean up tracked tool call
+          this.activeToolCalls.delete(block.tool_use_id);
+        }
+        break;
+    }
+  }
+
+  /**
+   * Normalize Amp tool names to our PascalCase convention.
+   */
+  private normalizeToolName(name: string): string {
+    const lower = name.toLowerCase();
+
+    // check direct mapping
+    if (AMP_TOOL_NAME_MAP[lower]) {
+      return AMP_TOOL_NAME_MAP[lower];
+    }
+
+    // handle MCP tool names (format: mcp__servername__toolname)
+    if (lower.startsWith('mcp__')) {
+      const parts = name.split('__');
+      if (parts.length >= 3) {
+        return `MCP:${parts[1]}:${parts[2]}`;
+      }
+    }
+
+    // fallback: capitalize first letter
+    return name.charAt(0).toUpperCase() + name.slice(1);
+  }
+
+  /**
+   * Get accumulated text from delta messages.
+   */
+  getAccumulatedText(): string {
+    return this.accumulatedText;
+  }
+
+  /**
+   * Reset accumulated text.
+   */
+  resetAccumulatedText(): void {
+    this.accumulatedText = '';
+  }
+}

--- a/packages/shared/src/agent/backend/amp/index.ts
+++ b/packages/shared/src/agent/backend/amp/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Amp Backend Module
+ *
+ * Exports for the Amp CLI agent backend implementation.
+ */
+
+// Re-export AmpAgent from its location
+export { AmpAgent, AmpBackend, resolveAmpBinary, isAmpInstalled, getAmpVersion } from '../../amp-agent.ts';
+export { AmpEventAdapter } from './event-adapter.ts';

--- a/packages/shared/src/agent/backend/factory.ts
+++ b/packages/shared/src/agent/backend/factory.ts
@@ -18,6 +18,7 @@ import type { AgentBackend, BackendConfig, AgentProvider, LlmProviderType, LlmAu
 import { ClaudeAgent } from '../claude-agent.ts';
 import { CodexAgent } from '../codex-agent.ts';
 import { CopilotAgent } from '../copilot-agent.ts';
+import { AmpAgent } from '../amp-agent.ts';
 import {
   getLlmConnection,
   getDefaultLlmConnection,
@@ -91,6 +92,11 @@ export function createBackend(config: BackendConfig): AgentBackend {
       // Auth is handled via GitHub OAuth
       return new CopilotAgent(config);
 
+    case 'amp':
+      // AmpAgent implements AgentBackend directly
+      // Auth is handled by Amp CLI's native auth system
+      return new AmpAgent(config);
+
     default:
       throw new Error(`Unknown provider: ${config.provider}`);
   }
@@ -108,7 +114,7 @@ export const createAgent = createBackend;
  * @returns Array of provider identifiers that have working implementations
  */
 export function getAvailableProviders(): AgentProvider[] {
-  return ['anthropic', 'openai', 'copilot'];
+  return ['anthropic', 'openai', 'copilot', 'amp'];
 }
 
 /**
@@ -152,6 +158,10 @@ export function providerTypeToAgentProvider(providerType: LlmProviderType): Agen
     // GitHub Copilot backend
     case 'copilot':
       return 'copilot';
+
+    // Amp CLI backend
+    case 'amp':
+      return 'amp';
 
     default:
       // Exhaustive check

--- a/packages/shared/src/agent/backend/index.ts
+++ b/packages/shared/src/agent/backend/index.ts
@@ -70,9 +70,11 @@ export { EventQueue } from './event-queue.ts';
 export { ClaudeEventAdapter } from './claude/event-adapter.ts';
 export { CodexEventAdapter } from './codex/event-adapter.ts';
 export { CopilotEventAdapter } from './copilot/event-adapter.ts';
+export { AmpEventAdapter } from './amp/event-adapter.ts';
 
 // Agent implementations
 // All agents implement AgentBackend directly
 export { ClaudeAgent } from '../claude-agent.ts';
 export { CodexAgent, CodexBackend } from '../codex-agent.ts';
 export { CopilotAgent, CopilotBackend } from '../copilot-agent.ts';
+export { AmpAgent, AmpBackend, resolveAmpBinary, isAmpInstalled, getAmpVersion } from '../amp-agent.ts';

--- a/packages/shared/src/agent/backend/types.ts
+++ b/packages/shared/src/agent/backend/types.ts
@@ -421,4 +421,10 @@ export interface BackendConfig {
    * would otherwise be clobbered by concurrent sessions mutating process.env.
    */
   envOverrides?: Record<string, string>;
+
+  /**
+   * Path to the Amp CLI binary (AmpAgent only).
+   * If not set, defaults to searching common paths and then 'amp' in PATH.
+   */
+  ampPath?: string;
 }

--- a/packages/shared/src/agent/index.ts
+++ b/packages/shared/src/agent/index.ts
@@ -6,6 +6,9 @@ export { CodexAgent, CodexBackend } from './codex-agent.ts';
 
 // Export CopilotAgent for direct use
 export { CopilotAgent, CopilotBackend, resolveCopilotModelId } from './copilot-agent.ts';
+
+// Export AmpAgent for direct use
+export { AmpAgent, AmpBackend, resolveAmpBinary, isAmpInstalled, getAmpVersion } from './amp-agent.ts';
 export * from './errors.ts';
 export * from './options.ts';
 

--- a/packages/shared/src/config/llm-connections.ts
+++ b/packages/shared/src/config/llm-connections.ts
@@ -11,6 +11,7 @@ import {
   type ModelDefinition,
   ANTHROPIC_MODELS,
   OPENAI_MODELS,
+  AMP_MODELS,
 } from './models';
 
 // ============================================================
@@ -28,6 +29,7 @@ import {
  * - 'bedrock': AWS Bedrock (Claude models via AWS)
  * - 'vertex': Google Vertex AI (Claude models via GCP)
  * - 'copilot': GitHub Copilot (via @github/copilot-sdk)
+ * - 'amp': Amp CLI (ampcode.com)
  */
 export type LlmProviderType =
   | 'anthropic'
@@ -36,7 +38,8 @@ export type LlmProviderType =
   | 'openai_compat'
   | 'bedrock'
   | 'vertex'
-  | 'copilot';
+  | 'copilot'
+  | 'amp';
 
 /**
  * @deprecated Use LlmProviderType instead. Kept for migration compatibility.
@@ -60,6 +63,9 @@ export type LlmConnectionType = 'anthropic' | 'openai' | 'openai-compat';
  * - 'service_account_file': GCP-style JSON file upload
  * - 'environment': Auto-detect from environment variables
  *
+ * External CLI auth:
+ * - 'external_cli': Auth managed by external CLI tool (e.g., Amp)
+ *
  * No auth:
  * - 'none': No authentication required (local models like Ollama)
  */
@@ -71,6 +77,7 @@ export type LlmAuthType =
   | 'bearer_token'
   | 'service_account_file'
   | 'environment'
+  | 'external_cli'
   | 'none';
 
 /**
@@ -276,6 +283,7 @@ export function authTypeToCredentialStorageType(authType: LlmAuthType): LlmCrede
       return 'service_account';
     case 'environment':
     case 'none':
+    case 'external_cli':
       return null;
   }
 }
@@ -366,6 +374,10 @@ export function getModelsForProviderType(providerType: LlmProviderType): ModelDe
     return []; // Copilot models are dynamic — fetched via listModels(), no hardcoded fallbacks
   }
 
+  if (providerType === 'amp') {
+    return AMP_MODELS;
+  }
+
   // Anthropic, Bedrock, Vertex all use Claude models
   return ANTHROPIC_MODELS;
 }
@@ -387,6 +399,7 @@ export function getDefaultModelsForConnection(providerType: LlmProviderType): Ar
   ];
   if (providerType === 'openai') return OPENAI_MODELS;
   if (providerType === 'copilot') return []; // Dynamic — fetched via listModels()
+  if (providerType === 'amp') return AMP_MODELS;
   if (providerType === 'anthropic_compat') return [
     'anthropic/claude-opus-4.6',
     'anthropic/claude-sonnet-4.5',
@@ -482,6 +495,7 @@ export function isValidProviderAuthCombination(
     bedrock: ['bearer_token', 'iam_credentials', 'environment'],
     vertex: ['oauth', 'service_account_file', 'environment'],
     copilot: ['oauth'],
+    amp: ['external_cli'],
   };
 
   return validCombinations[providerType]?.includes(authType) ?? false;

--- a/packages/shared/src/config/models.ts
+++ b/packages/shared/src/config/models.ts
@@ -17,7 +17,7 @@
 /**
  * Provider identifier for AI backends.
  */
-export type ModelProvider = 'anthropic' | 'openai' | 'copilot';
+export type ModelProvider = 'anthropic' | 'openai' | 'copilot' | 'amp';
 
 /**
  * Full model definition with capabilities and costs.
@@ -115,6 +115,36 @@ export const MODEL_REGISTRY: ModelDefinition[] = [
   // No hardcoded entries — models are discovered at runtime via client.listModels()
   // and stored on the connection. See fetchAndStoreCopilotModels() in ipc.ts.
   // ----------------------------------------
+
+  // ----------------------------------------
+  // Amp Models (via Amp CLI)
+  // Amp auto-selects models based on mode (smart, rush, deep).
+  // These entries represent the modes as pseudo-models for UI consistency.
+  // ----------------------------------------
+  {
+    id: 'amp-smart',
+    name: 'Amp Smart',
+    shortName: 'Smart',
+    description: 'Best models for maximum capability (Opus 4.6)',
+    provider: 'amp',
+    contextWindow: 200_000,
+  },
+  {
+    id: 'amp-rush',
+    name: 'Amp Rush',
+    shortName: 'Rush',
+    description: 'Fast mode for small tasks',
+    provider: 'amp',
+    contextWindow: 200_000,
+  },
+  {
+    id: 'amp-deep',
+    name: 'Amp Deep',
+    shortName: 'Deep',
+    description: 'Deep reasoning with GPT-5.2 Codex',
+    provider: 'amp',
+    contextWindow: 256_000,
+  },
 ];
 
 // ============================================
@@ -136,6 +166,9 @@ export const OPENAI_MODELS = getModelsByProvider('openai');
 
 /** All GitHub Copilot models */
 export const COPILOT_MODELS = getModelsByProvider('copilot');
+
+/** All Amp models */
+export const AMP_MODELS = getModelsByProvider('amp');
 
 /**
  * Legacy compatibility export.
@@ -173,6 +206,9 @@ export const DEFAULT_CODEX_MODEL = getModelIdByShortName('Codex');
 
 /** Default model for Copilot connections — no hardcoded default; models come from listModels() */
 export const DEFAULT_COPILOT_MODEL: string | undefined = undefined;
+
+/** Default model for Amp connections (Smart mode is the default) */
+export const DEFAULT_AMP_MODEL = 'amp-smart';
 
 // ============================================
 // UTILITY MODELS

--- a/packages/shared/src/credentials/manager.ts
+++ b/packages/shared/src/credentials/manager.ts
@@ -455,6 +455,7 @@ export class CredentialManager {
       // No credentials needed
       case 'none':
       case 'environment':
+      case 'external_cli':
         return true;
 
       // API key variants - all use the same storage


### PR DESCRIPTION
Amp Code (https://ampcode.com/manual) support has been added. In addition to Claude, Codex, and Copilot, Amp is now supported here. To use this, you need to have an https://ampcode.com account and have it installed as a CLI on your PC (if it's not already installed, instructions are provided in the onboard section). You can then use the credits you've loaded on https://ampcode.com to use the agents.