### PR TITLE
Add web server implementation for remote access

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@craft-agent/web",
+  "version": "0.4.8",
+  "description": "Web-based app for Craft Agents (remotely accessible)",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "dev": "concurrently \"bun run dev:server\" \"bun run dev:client\"",
+    "dev:server": "bun --watch src/server/index.ts",
+    "dev:client": "vite dev --config vite.config.ts",
+    "build": "bun run build:client && bun run build:server",
+    "build:client": "vite build --config vite.config.ts",
+    "build:server": "esbuild src/server/index.ts --bundle --platform=node --format=esm --outfile=dist/server.js --external:better-sqlite3 --external:fsevents",
+    "start": "bun run build && node dist/server.js",
+    "preview": "bun run build && node dist/server.js"
+  },
+  "dependencies": {
+    "@craft-agent/core": "workspace:*",
+    "@craft-agent/shared": "workspace:*",
+    "@craft-agent/ui": "workspace:*",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
+    "@paper-design/shaders-react": "^0.0.69",
+    "@pierre/diffs": "^1.0.4",
+    "@radix-ui/react-context-menu": "^2.2.16",
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-switch": "^1.2.6",
+    "@sentry/react": "^10.36.0",
+    "@tanstack/react-table": "^8.21.3",
+    "chrono-node": "^2.9.0",
+    "cmdk": "^1.1.1",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "jotai-family": "^1.0.1",
+    "motion": "^12.23.26",
+    "multer": "^1.4.5-lts.1",
+    "next-themes": "^0.4.6",
+    "react": "^18.3.1",
+    "react-day-picker": "^9.13.0",
+    "react-dom": "^18.3.1",
+    "react-pdf": "^10.3.0",
+    "react-simple-code-editor": "^0.14.1",
+    "remark": "^15.0.1",
+    "sonner": "^2.0.7",
+    "strip-markdown": "^6.0.0",
+    "unist-util-visit": "^5.0.0",
+    "vaul": "^1.1.2",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/multer": "^1.4.11",
+    "@types/ws": "^8.5.13"
+  }
+}

--- a/apps/web/src/client/api.ts
+++ b/apps/web/src/client/api.ts
@@ -1,0 +1,965 @@
+/**
+ * Web client API implementation.
+ * Implements the ElectronAPI interface using HTTP fetch and WebSocket,
+ * replacing the Electron IPC mechanism for the web app.
+ */
+
+// ============================================================
+// HTTP Client
+// ============================================================
+
+const API_BASE = '/api'
+
+async function apiGet<T>(path: string, params?: Record<string, string>): Promise<T> {
+  const url = new URL(`${API_BASE}${path}`, window.location.origin)
+  if (params) {
+    Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v))
+  }
+  const res = await fetch(url.toString())
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Request failed' }))
+    throw new Error(err.error || `HTTP ${res.status}`)
+  }
+  return res.json()
+}
+
+async function apiPost<T>(path: string, body?: unknown): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Request failed' }))
+    throw new Error(err.error || `HTTP ${res.status}`)
+  }
+  return res.json()
+}
+
+async function apiPut<T>(path: string, body?: unknown): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Request failed' }))
+    throw new Error(err.error || `HTTP ${res.status}`)
+  }
+  return res.json()
+}
+
+async function apiDelete<T>(path: string): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, { method: 'DELETE' })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Request failed' }))
+    throw new Error(err.error || `HTTP ${res.status}`)
+  }
+  return res.json()
+}
+
+async function apiPatch<T>(path: string, body?: unknown): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Request failed' }))
+    throw new Error(err.error || `HTTP ${res.status}`)
+  }
+  return res.json()
+}
+
+// ============================================================
+// WebSocket Event System
+// ============================================================
+
+type EventCallback = (payload: unknown) => void
+
+class WebSocketClient {
+  private ws: WebSocket | null = null
+  private listeners: Map<string, Set<EventCallback>> = new Map()
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectDelay = 1000
+
+  connect(): void {
+    const wsUrl = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws`
+
+    try {
+      this.ws = new WebSocket(wsUrl)
+
+      this.ws.onopen = () => {
+        console.log('[WS] Connected to Craft Agents server')
+        this.reconnectDelay = 1000 // Reset backoff on success
+      }
+
+      this.ws.onmessage = (event) => {
+        try {
+          const msg = JSON.parse(event.data)
+          const { type, payload } = msg
+          const channelListeners = this.listeners.get(type)
+          if (channelListeners) {
+            for (const cb of channelListeners) {
+              try { cb(payload) } catch (err) {
+                console.error('[WS] Listener error:', err)
+              }
+            }
+          }
+        } catch (err) {
+          console.error('[WS] Parse error:', err)
+        }
+      }
+
+      this.ws.onclose = () => {
+        console.log('[WS] Connection closed, reconnecting...')
+        this.scheduleReconnect()
+      }
+
+      this.ws.onerror = (err) => {
+        console.error('[WS] Error:', err)
+      }
+    } catch (err) {
+      console.error('[WS] Connect error:', err)
+      this.scheduleReconnect()
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer) return
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      this.reconnectDelay = Math.min(this.reconnectDelay * 2, 30000)
+      this.connect()
+    }, this.reconnectDelay)
+  }
+
+  on(channel: string, callback: EventCallback): () => void {
+    if (!this.listeners.has(channel)) {
+      this.listeners.set(channel, new Set())
+    }
+    this.listeners.get(channel)!.add(callback)
+    return () => {
+      this.listeners.get(channel)?.delete(callback)
+    }
+  }
+}
+
+const wsClient = new WebSocketClient()
+wsClient.connect()
+
+// ============================================================
+// ElectronAPI Implementation
+// ============================================================
+
+// IPC channel constants (mirrored from shared/types.ts)
+const IPC = {
+  SESSION_EVENT: 'session:event',
+  SYSTEM_THEME_CHANGED: 'theme:systemChanged',
+  SOURCES_CHANGED: 'sources:changed',
+  SKILLS_CHANGED: 'skills:changed',
+  STATUSES_CHANGED: 'statuses:changed',
+  LABELS_CHANGED: 'labels:changed',
+  LLM_CONNECTIONS_CHANGED: 'LLM_Connection:changed',
+  THEME_APP_CHANGED: 'theme:appChanged',
+  DEFAULT_PERMISSIONS_CHANGED: 'permissions:defaultsChanged',
+  THEME_PREFERENCES_CHANGED: 'theme:preferencesChanged',
+  THEME_WORKSPACE_THEME_CHANGED: 'theme:workspaceThemeChanged',
+  SESSION_FILES_CHANGED: 'sessions:filesChanged',
+  COPILOT_DEVICE_CODE: 'copilot:deviceCode',
+  UPDATE_AVAILABLE: 'update:available',
+  UPDATE_DOWNLOAD_PROGRESS: 'update:downloadProgress',
+  DEEP_LINK_NAVIGATE: 'deeplink:navigate',
+  NOTIFICATION_NAVIGATE: 'notification:navigate',
+  WINDOW_CLOSE_REQUESTED: 'window:closeRequested',
+  MENU_NEW_CHAT: 'menu:newChat',
+  MENU_OPEN_SETTINGS: 'menu:openSettings',
+  MENU_KEYBOARD_SHORTCUTS: 'menu:keyboardShortcuts',
+  MENU_TOGGLE_FOCUS_MODE: 'menu:toggleFocusMode',
+  MENU_TOGGLE_SIDEBAR: 'menu:toggleSidebar',
+}
+
+export const webElectronAPI = {
+  // ============================================================
+  // Session Management
+  // ============================================================
+
+  getSessions: () => apiGet<any[]>('/sessions'),
+
+  getSessionMessages: (sessionId: string) =>
+    apiGet<any | null>(`/sessions/${sessionId}`),
+
+  createSession: (workspaceId: string, options?: any) =>
+    apiPost<any>('/sessions', { workspaceId, options }),
+
+  createSubSession: (workspaceId: string, parentSessionId: string, options?: any) =>
+    apiPost<any>(`/sessions/${parentSessionId}/sub-sessions`, { workspaceId, options }),
+
+  deleteSession: (sessionId: string) =>
+    apiDelete<void>(`/sessions/${sessionId}`).then(() => undefined),
+
+  sendMessage: async (sessionId: string, message: string, attachments?: any[], storedAttachments?: any[], options?: any) => {
+    await apiPost(`/sessions/${sessionId}/messages`, { message, attachments, storedAttachments, options })
+  },
+
+  cancelProcessing: (sessionId: string, silent?: boolean) =>
+    apiPost<void>(`/sessions/${sessionId}/cancel`, { silent }).then(() => undefined),
+
+  killShell: (sessionId: string, shellId: string) =>
+    apiPost<{ success: boolean; error?: string }>(`/sessions/${sessionId}/kill-shell`, { shellId }),
+
+  getTaskOutput: (taskId: string) =>
+    apiGet<any>(`/tasks/${taskId}/output`).then((r: any) => r.output),
+
+  respondToPermission: (sessionId: string, requestId: string, allowed: boolean, alwaysAllow: boolean) =>
+    apiPost<{ success: boolean }>(`/sessions/${sessionId}/permission`, { requestId, allowed, alwaysAllow })
+      .then((r: any) => r.success),
+
+  respondToCredential: (sessionId: string, requestId: string, response: any) =>
+    apiPost<{ success: boolean }>(`/sessions/${sessionId}/credential`, { requestId, response })
+      .then((r: any) => r.success),
+
+  sessionCommand: (sessionId: string, command: any) =>
+    apiPost<any>(`/sessions/${sessionId}/command`, { command }),
+
+  getPendingPlanExecution: (sessionId: string) =>
+    apiGet<any>(`/sessions/${sessionId}/pending-plan`),
+
+  // ============================================================
+  // Workspace Management
+  // ============================================================
+
+  getWorkspaces: () => apiGet<any[]>('/workspaces'),
+
+  createWorkspace: (folderPath: string, name: string) =>
+    apiPost<any>('/workspaces', { folderPath, name }),
+
+  checkWorkspaceSlug: (slug: string) =>
+    apiGet<{ exists: boolean; path: string }>('/workspaces/check-slug', { slug }),
+
+  // ============================================================
+  // Window Management (web-adapted)
+  // ============================================================
+
+  getWindowWorkspace: async () => {
+    const r = await apiGet<{ workspaceId: string | null }>('/workspaces/window')
+    return r.workspaceId
+  },
+
+  getWindowMode: async () => {
+    const r = await apiGet<{ mode: string }>('/window/mode')
+    return r.mode
+  },
+
+  openWorkspace: (workspaceId: string) =>
+    apiPost<void>('/window/open-workspace', { workspaceId }).then(() => undefined),
+
+  openSessionInNewWindow: (_workspaceId: string, _sessionId: string) =>
+    Promise.resolve(), // No multi-window in web
+
+  switchWorkspace: (workspaceId: string) =>
+    apiPost<void>('/workspaces/switch', { workspaceId }).then(() => undefined),
+
+  closeWindow: () =>
+    apiPost<void>('/window/close').then(() => undefined),
+
+  confirmCloseWindow: () =>
+    apiPost<void>('/window/close').then(() => undefined),
+
+  onCloseRequested: (callback: () => void): (() => void) => {
+    return wsClient.on(IPC.WINDOW_CLOSE_REQUESTED, () => callback())
+  },
+
+  setTrafficLightsVisible: (_visible: boolean) =>
+    apiPost<void>('/window/traffic-lights').then(() => undefined),
+
+  // ============================================================
+  // Event Listeners
+  // ============================================================
+
+  onSessionEvent: (callback: (event: any) => void): (() => void) => {
+    return wsClient.on(IPC.SESSION_EVENT, (payload) => callback(payload as any))
+  },
+
+  // ============================================================
+  // File Operations
+  // ============================================================
+
+  readFile: (path: string) =>
+    apiGet<{ content: string }>('/files/read', { path }).then((r: any) => r.content),
+
+  readFileBinary: async (path: string): Promise<Uint8Array> => {
+    const r = await apiGet<{ base64: string }>('/files/read-binary', { path })
+    const binary = atob(r.base64)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+    return bytes
+  },
+
+  readFileDataUrl: (path: string) =>
+    apiGet<{ dataUrl: string }>('/files/read-data-url', { path }).then((r: any) => r.dataUrl),
+
+  openFileDialog: async (): Promise<string[]> => {
+    // Web: use HTML file input (handled client-side)
+    return new Promise((resolve) => {
+      const input = document.createElement('input')
+      input.type = 'file'
+      input.multiple = true
+      input.onchange = () => {
+        // We can't get real paths in web, return empty (caller handles actual files)
+        resolve([])
+      }
+      input.click()
+    })
+  },
+
+  readFileAttachment: (path: string) =>
+    apiPost<any | null>('/files/attachment', { path }),
+
+  storeAttachment: (sessionId: string, attachment: any) =>
+    apiPost<any>('/files/store-attachment', { sessionId, attachment }),
+
+  generateThumbnail: async (_base64: string, _mimeType: string): Promise<string | null> => {
+    return null // Not available in web
+  },
+
+  searchFiles: (basePath: string, query: string) =>
+    apiGet<any[]>('/files/search', { basePath, query }),
+
+  debugLog: (...args: unknown[]) => {
+    apiPost('/debug/log', { args }).catch(() => {})
+  },
+
+  // ============================================================
+  // Theme
+  // ============================================================
+
+  getSystemTheme: async (): Promise<boolean> => {
+    // Use browser media query instead of server
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+  },
+
+  onSystemThemeChange: (callback: (isDark: boolean) => void): (() => void) => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = (e: MediaQueryListEvent) => callback(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  },
+
+  // ============================================================
+  // System
+  // ============================================================
+
+  getVersions: () => ({
+    node: 'web',
+    chrome: navigator.userAgent,
+    electron: 'n/a',
+  }),
+
+  getHomeDir: () =>
+    apiGet<{ homeDir: string }>('/system/home-dir').then((r: any) => r.homeDir),
+
+  isDebugMode: () =>
+    apiGet<{ isDebugMode: boolean }>('/system/debug-mode').then((r: any) => r.isDebugMode),
+
+  // ============================================================
+  // Auto-update (stubs for web)
+  // ============================================================
+
+  checkForUpdates: () =>
+    apiPost<any>('/update/check'),
+
+  getUpdateInfo: () =>
+    apiGet<any>('/update/info'),
+
+  installUpdate: () =>
+    apiPost<void>('/update/install').then(() => undefined),
+
+  dismissUpdate: (_version: string) =>
+    apiPost<void>('/update/dismiss', { version: _version }).then(() => undefined),
+
+  getDismissedUpdateVersion: () =>
+    apiGet<{ version: string | null }>('/update/dismissed').then((r: any) => r.version),
+
+  onUpdateAvailable: (callback: (info: any) => void): (() => void) => {
+    return wsClient.on(IPC.UPDATE_AVAILABLE, (payload) => callback(payload as any))
+  },
+
+  onUpdateDownloadProgress: (callback: (progress: number) => void): (() => void) => {
+    return wsClient.on(IPC.UPDATE_DOWNLOAD_PROGRESS, (payload) => callback(payload as number))
+  },
+
+  // ============================================================
+  // Release Notes
+  // ============================================================
+
+  getReleaseNotes: () =>
+    apiGet<{ notes: string }>('/release-notes').then((r: any) => r.notes),
+
+  getLatestReleaseVersion: () =>
+    apiGet<{ version: string | undefined }>('/release-notes/latest-version').then((r: any) => r.version),
+
+  // ============================================================
+  // Shell Operations (web-adapted)
+  // ============================================================
+
+  openUrl: async (url: string) => {
+    window.open(url, '_blank', 'noopener,noreferrer')
+  },
+
+  openFile: async (path: string) => {
+    // Can't open native files in web
+    console.warn('openFile not supported in web mode:', path)
+  },
+
+  showInFolder: async (path: string) => {
+    // Can't show in folder in web
+    console.warn('showInFolder not supported in web mode:', path)
+  },
+
+  // ============================================================
+  // Menu Event Listeners (web: keyboard shortcuts only)
+  // ============================================================
+
+  onMenuNewChat: (callback: () => void): (() => void) => {
+    return wsClient.on(IPC.MENU_NEW_CHAT, () => callback())
+  },
+
+  onMenuOpenSettings: (callback: () => void): (() => void) => {
+    return wsClient.on(IPC.MENU_OPEN_SETTINGS, () => callback())
+  },
+
+  onMenuKeyboardShortcuts: (callback: () => void): (() => void) => {
+    return wsClient.on(IPC.MENU_KEYBOARD_SHORTCUTS, () => callback())
+  },
+
+  onMenuToggleFocusMode: (callback: () => void): (() => void) => {
+    return wsClient.on(IPC.MENU_TOGGLE_FOCUS_MODE, () => callback())
+  },
+
+  onMenuToggleSidebar: (callback: () => void): (() => void) => {
+    return wsClient.on(IPC.MENU_TOGGLE_SIDEBAR, () => callback())
+  },
+
+  // ============================================================
+  // Deep Link (web: not applicable)
+  // ============================================================
+
+  onDeepLinkNavigate: (callback: (nav: any) => void): (() => void) => {
+    return wsClient.on(IPC.DEEP_LINK_NAVIGATE, (payload) => callback(payload as any))
+  },
+
+  // ============================================================
+  // Auth
+  // ============================================================
+
+  showLogoutConfirmation: async (): Promise<boolean> => {
+    return window.confirm('Are you sure you want to log out?')
+  },
+
+  showDeleteSessionConfirmation: async (name: string): Promise<boolean> => {
+    return window.confirm(`Are you sure you want to delete "${name}"?`)
+  },
+
+  logout: () =>
+    apiPost<void>('/auth/logout').then(() => undefined),
+
+  getCredentialHealth: () =>
+    apiGet<any>('/auth/credential-health'),
+
+  // ============================================================
+  // Onboarding
+  // ============================================================
+
+  getAuthState: () =>
+    apiGet<any>('/auth/state').then((r: any) => r.authState),
+
+  getSetupNeeds: () =>
+    apiGet<any>('/auth/state').then((r: any) => r.setupNeeds),
+
+  startWorkspaceMcpOAuth: (mcpUrl: string) =>
+    apiPost<any>('/auth/mcp/start', { mcpUrl }),
+
+  startClaudeOAuth: () =>
+    apiPost<{ success: boolean; authUrl?: string; error?: string }>('/auth/claude/start'),
+
+  exchangeClaudeCode: (code: string, connectionSlug: string) =>
+    apiPost<any>('/auth/claude/exchange', { code, connectionSlug }),
+
+  hasClaudeOAuthState: () =>
+    apiGet<{ hasState: boolean }>('/auth/claude/has-state').then((r: any) => r.hasState),
+
+  clearClaudeOAuthState: () =>
+    apiPost<{ success: boolean }>('/auth/claude/clear-state'),
+
+  // ChatGPT OAuth (stubs - web redirect flow needed)
+  startChatGptOAuth: (_connectionSlug: string) =>
+    Promise.resolve({ success: false, error: 'ChatGPT OAuth not available in web mode' }),
+
+  cancelChatGptOAuth: () =>
+    Promise.resolve({ success: true }),
+
+  getChatGptAuthStatus: (_connectionSlug: string) =>
+    Promise.resolve({ authenticated: false }),
+
+  chatGptLogout: (_connectionSlug: string) =>
+    Promise.resolve({ success: true }),
+
+  // GitHub Copilot OAuth
+  startCopilotOAuth: (_connectionSlug: string) =>
+    Promise.resolve({ success: false, error: 'Copilot OAuth not available in web mode' }),
+
+  cancelCopilotOAuth: () =>
+    Promise.resolve({ success: true }),
+
+  getCopilotAuthStatus: (_connectionSlug: string) =>
+    Promise.resolve({ authenticated: false }),
+
+  copilotLogout: (_connectionSlug: string) =>
+    Promise.resolve({ success: true }),
+
+  onCopilotDeviceCode: (callback: (data: { userCode: string; verificationUri: string }) => void): (() => void) => {
+    return wsClient.on(IPC.COPILOT_DEVICE_CODE, (payload) => callback(payload as any))
+  },
+
+  // ============================================================
+  // Settings - LLM Connection Setup
+  // ============================================================
+
+  setupLlmConnection: (setup: any) =>
+    apiPost<{ success: boolean; error?: string }>('/settings/setup-llm-connection', setup),
+
+  testApiConnection: (apiKey: string, baseUrl?: string, models?: string[]) =>
+    apiPost<{ success: boolean; error?: string; modelCount?: number }>('/settings/test-api-connection', { apiKey, baseUrl, models }),
+
+  testOpenAiConnection: (apiKey: string, baseUrl?: string, models?: string[]) =>
+    apiPost<{ success: boolean; error?: string }>('/settings/test-openai-connection', { apiKey, baseUrl, models }),
+
+  // ============================================================
+  // Session Model
+  // ============================================================
+
+  getSessionModel: (sessionId: string, workspaceId: string) =>
+    apiGet<{ model: string | null }>(`/sessions/${sessionId}/model`, { workspaceId })
+      .then((r: any) => r.model),
+
+  setSessionModel: (sessionId: string, workspaceId: string, model: string | null, connection?: string) =>
+    apiPost<void>(`/sessions/${sessionId}/model`, { workspaceId, model, connection }).then(() => undefined),
+
+  // ============================================================
+  // Workspace Settings
+  // ============================================================
+
+  getWorkspaceSettings: (workspaceId: string) =>
+    apiGet<any | null>(`/workspaces/${workspaceId}/settings`),
+
+  updateWorkspaceSetting: (workspaceId: string, key: string, value: any) =>
+    apiPatch<void>(`/workspaces/${workspaceId}/settings`, { key, value }).then(() => undefined),
+
+  // ============================================================
+  // Folder Dialog (web-adapted)
+  // ============================================================
+
+  openFolderDialog: async (): Promise<string | null> => {
+    // Web: can't open folder picker dialog natively
+    // Return null - the UI should handle this gracefully
+    return null
+  },
+
+  // ============================================================
+  // Preferences
+  // ============================================================
+
+  readPreferences: () =>
+    apiGet<{ content: string; exists: boolean; path: string }>('/preferences'),
+
+  writePreferences: (content: string) =>
+    apiPut<{ success: boolean; error?: string }>('/preferences', { content }),
+
+  // ============================================================
+  // Session Drafts
+  // ============================================================
+
+  getDraft: (sessionId: string) =>
+    apiGet<{ draft: string | null }>(`/drafts/${sessionId}`).then((r: any) => r.draft),
+
+  setDraft: (sessionId: string, text: string) =>
+    apiPut<void>(`/drafts/${sessionId}`, { text }).then(() => undefined),
+
+  deleteDraft: (sessionId: string) =>
+    apiDelete<void>(`/drafts/${sessionId}`).then(() => undefined),
+
+  getAllDrafts: () =>
+    apiGet<Record<string, string>>('/drafts'),
+
+  // ============================================================
+  // Session Files
+  // ============================================================
+
+  getSessionFiles: (sessionId: string) =>
+    apiGet<any[]>(`/sessions/${sessionId}/files`),
+
+  getSessionNotes: (sessionId: string) =>
+    apiGet<{ content: string }>(`/sessions/${sessionId}/notes`).then((r: any) => r.content),
+
+  setSessionNotes: (sessionId: string, content: string) =>
+    apiPut<void>(`/sessions/${sessionId}/notes`, { content }).then(() => undefined),
+
+  watchSessionFiles: (_sessionId: string) =>
+    Promise.resolve(),
+
+  unwatchSessionFiles: () =>
+    Promise.resolve(),
+
+  onSessionFilesChanged: (callback: (sessionId: string) => void): (() => void) => {
+    return wsClient.on(IPC.SESSION_FILES_CHANGED, (payload) => callback(payload as string))
+  },
+
+  // ============================================================
+  // Sources
+  // ============================================================
+
+  getSources: (workspaceId: string) =>
+    apiGet<any[]>(`/workspaces/${workspaceId}/sources`),
+
+  createSource: (workspaceId: string, config: any) =>
+    apiPost<any>(`/workspaces/${workspaceId}/sources`, config),
+
+  deleteSource: (workspaceId: string, sourceSlug: string) =>
+    apiDelete<void>(`/workspaces/${workspaceId}/sources/${sourceSlug}`).then(() => undefined),
+
+  startSourceOAuth: (_workspaceId: string, _sourceSlug: string) =>
+    Promise.resolve({ success: false, error: 'OAuth not available in web mode' }),
+
+  saveSourceCredentials: (workspaceId: string, sourceSlug: string, credential: string) =>
+    apiPost<void>(`/workspaces/${workspaceId}/sources/${sourceSlug}/save-credentials`, { credential })
+      .then(() => undefined),
+
+  getSourcePermissionsConfig: (workspaceId: string, sourceSlug: string) =>
+    apiGet<any | null>(`/workspaces/${workspaceId}/sources/${sourceSlug}/permissions`),
+
+  getWorkspacePermissionsConfig: (workspaceId: string) =>
+    apiGet<any | null>(`/workspaces/${workspaceId}/permissions`),
+
+  getDefaultPermissionsConfig: () =>
+    apiGet<any>('/permissions/defaults'),
+
+  getMcpTools: (workspaceId: string, sourceSlug: string) =>
+    apiGet<any>(`/workspaces/${workspaceId}/sources/${sourceSlug}/mcp-tools`),
+
+  // ============================================================
+  // Session Content Search
+  // ============================================================
+
+  searchSessionContent: (workspaceId: string, query: string, searchId?: string) =>
+    apiPost<any[]>('/sessions/search', { workspaceId, query, searchId }),
+
+  // ============================================================
+  // Sources Change Listener
+  // ============================================================
+
+  onSourcesChanged: (callback: (sources: any[]) => void): (() => void) => {
+    return wsClient.on(IPC.SOURCES_CHANGED, (payload) => callback(payload as any[]))
+  },
+
+  onDefaultPermissionsChanged: (callback: () => void): (() => void) => {
+    return wsClient.on(IPC.DEFAULT_PERMISSIONS_CHANGED, () => callback())
+  },
+
+  // ============================================================
+  // Skills
+  // ============================================================
+
+  getSkills: (workspaceId: string, workingDirectory?: string) => {
+    const params: Record<string, string> = {}
+    if (workingDirectory) params.workingDirectory = workingDirectory
+    return apiGet<any[]>(`/workspaces/${workspaceId}/skills`, params)
+  },
+
+  getSkillFiles: (workspaceId: string, skillSlug: string) =>
+    apiGet<any[]>(`/workspaces/${workspaceId}/skills/${skillSlug}/files`),
+
+  deleteSkill: (workspaceId: string, skillSlug: string) =>
+    apiDelete<void>(`/workspaces/${workspaceId}/skills/${skillSlug}`).then(() => undefined),
+
+  openSkillInEditor: (_workspaceId: string, _skillSlug: string) =>
+    Promise.resolve(), // Not available in web
+
+  openSkillInFinder: (_workspaceId: string, _skillSlug: string) =>
+    Promise.resolve(), // Not available in web
+
+  onSkillsChanged: (callback: (skills: any[]) => void): (() => void) => {
+    return wsClient.on(IPC.SKILLS_CHANGED, (payload) => callback(payload as any[]))
+  },
+
+  // ============================================================
+  // Statuses
+  // ============================================================
+
+  listStatuses: (workspaceId: string) =>
+    apiGet<any[]>(`/workspaces/${workspaceId}/statuses`),
+
+  reorderStatuses: (workspaceId: string, orderedIds: string[]) =>
+    apiPost<void>(`/workspaces/${workspaceId}/statuses/reorder`, { orderedIds }).then(() => undefined),
+
+  onStatusesChanged: (callback: (workspaceId: string) => void): (() => void) => {
+    return wsClient.on(IPC.STATUSES_CHANGED, (payload) => callback(payload as string))
+  },
+
+  // ============================================================
+  // Labels
+  // ============================================================
+
+  listLabels: (workspaceId: string) =>
+    apiGet<any[]>(`/workspaces/${workspaceId}/labels`),
+
+  createLabel: (workspaceId: string, input: any) =>
+    apiPost<any>(`/workspaces/${workspaceId}/labels`, input),
+
+  deleteLabel: (workspaceId: string, labelId: string) =>
+    apiDelete<{ stripped: number }>(`/workspaces/${workspaceId}/labels/${labelId}`),
+
+  onLabelsChanged: (callback: (workspaceId: string) => void): (() => void) => {
+    return wsClient.on(IPC.LABELS_CHANGED, (payload) => callback(payload as string))
+  },
+
+  onLlmConnectionsChanged: (callback: () => void): (() => void) => {
+    return wsClient.on(IPC.LLM_CONNECTIONS_CHANGED, () => callback())
+  },
+
+  // ============================================================
+  // Views
+  // ============================================================
+
+  listViews: (workspaceId: string) =>
+    apiGet<any[]>(`/workspaces/${workspaceId}/views`),
+
+  saveViews: (workspaceId: string, views: any[]) =>
+    apiPut<void>(`/workspaces/${workspaceId}/views`, views).then(() => undefined),
+
+  // ============================================================
+  // Workspace Image
+  // ============================================================
+
+  readWorkspaceImage: (workspaceId: string, relativePath: string) =>
+    apiGet<{ data: string }>(`/workspaces/${workspaceId}/image`, { path: relativePath })
+      .then((r: any) => r.data),
+
+  writeWorkspaceImage: (workspaceId: string, relativePath: string, base64: string, mimeType: string) =>
+    apiPost<void>(`/workspaces/${workspaceId}/image`, { relativePath, base64, mimeType })
+      .then(() => undefined),
+
+  // ============================================================
+  // Tool Icon Mappings
+  // ============================================================
+
+  getToolIconMappings: () =>
+    apiGet<any[]>('/tool-icons'),
+
+  // ============================================================
+  // Theme
+  // ============================================================
+
+  getAppTheme: () =>
+    apiGet<any | null>('/theme/app'),
+
+  loadPresetThemes: () =>
+    apiGet<any[]>('/theme/presets'),
+
+  loadPresetTheme: (themeId: string) =>
+    apiGet<any | null>(`/theme/presets/${themeId}`),
+
+  getColorTheme: () =>
+    apiGet<{ theme: string }>('/theme/color').then((r: any) => r.theme),
+
+  setColorTheme: (themeId: string) =>
+    apiPost<void>('/theme/color', { themeId }).then(() => undefined),
+
+  getWorkspaceColorTheme: (workspaceId: string) =>
+    apiGet<{ theme: string | null }>(`/theme/workspace/${workspaceId}`).then((r: any) => r.theme),
+
+  setWorkspaceColorTheme: (workspaceId: string, themeId: string | null) =>
+    apiPost<void>(`/theme/workspace/${workspaceId}`, { themeId }).then(() => undefined),
+
+  getAllWorkspaceThemes: () =>
+    apiGet<Record<string, string | undefined>>('/theme/all-workspace-themes'),
+
+  onAppThemeChange: (callback: (theme: any) => void): (() => void) => {
+    return wsClient.on(IPC.THEME_APP_CHANGED, (payload) => callback(payload as any))
+  },
+
+  // ============================================================
+  // Logo URL
+  // ============================================================
+
+  getLogoUrl: (_serviceUrl: string, _provider?: string) =>
+    Promise.resolve<string | null>(null),
+
+  // ============================================================
+  // Notifications
+  // ============================================================
+
+  showNotification: (title: string, body: string, workspaceId: string, sessionId: string) =>
+    apiPost<void>('/notifications/show', { title, body, workspaceId, sessionId }).then(() => undefined),
+
+  getNotificationsEnabled: () =>
+    apiGet<{ value: boolean }>('/settings/notifications-enabled').then((r: any) => r.value),
+
+  setNotificationsEnabled: (enabled: boolean) =>
+    apiPost<void>('/settings/notifications-enabled', { enabled }).then(() => undefined),
+
+  // ============================================================
+  // Input Settings
+  // ============================================================
+
+  getAutoCapitalisation: () =>
+    apiGet<{ value: boolean }>('/settings/auto-capitalisation').then((r: any) => r.value),
+
+  setAutoCapitalisation: (enabled: boolean) =>
+    apiPost<void>('/settings/auto-capitalisation', { enabled }).then(() => undefined),
+
+  getSendMessageKey: () =>
+    apiGet<{ value: 'enter' | 'cmd-enter' }>('/settings/send-message-key').then((r: any) => r.value),
+
+  setSendMessageKey: (key: 'enter' | 'cmd-enter') =>
+    apiPost<void>('/settings/send-message-key', { key }).then(() => undefined),
+
+  getSpellCheck: () =>
+    apiGet<{ value: boolean }>('/settings/spell-check').then((r: any) => r.value),
+
+  setSpellCheck: (enabled: boolean) =>
+    apiPost<void>('/settings/spell-check', { enabled }).then(() => undefined),
+
+  // ============================================================
+  // Power Settings
+  // ============================================================
+
+  getKeepAwakeWhileRunning: () =>
+    apiGet<{ value: boolean }>('/settings/keep-awake').then((r: any) => r.value),
+
+  setKeepAwakeWhileRunning: (enabled: boolean) =>
+    apiPost<void>('/settings/keep-awake', { enabled }).then(() => undefined),
+
+  // ============================================================
+  // Appearance Settings
+  // ============================================================
+
+  getRichToolDescriptions: () =>
+    apiGet<{ value: boolean }>('/settings/rich-tool-descriptions').then((r: any) => r.value),
+
+  setRichToolDescriptions: (enabled: boolean) =>
+    apiPost<void>('/settings/rich-tool-descriptions', { enabled }).then(() => undefined),
+
+  // ============================================================
+  // Badge/Dock (web: no-ops)
+  // ============================================================
+
+  updateBadgeCount: (_count: number) => Promise.resolve(),
+  clearBadgeCount: () => Promise.resolve(),
+  setDockIconWithBadge: (_dataUrl: string) => Promise.resolve(),
+  onBadgeDraw: (_callback: (data: { count: number; iconDataUrl: string }) => void): (() => void) => () => {},
+
+  // ============================================================
+  // Window Focus
+  // ============================================================
+
+  getWindowFocusState: async (): Promise<boolean> => !document.hidden,
+
+  onWindowFocusChange: (callback: (isFocused: boolean) => void): (() => void) => {
+    const handler = () => callback(!document.hidden)
+    document.addEventListener('visibilitychange', handler)
+    return () => document.removeEventListener('visibilitychange', handler)
+  },
+
+  onNotificationNavigate: (callback: (data: { workspaceId: string; sessionId: string }) => void): (() => void) => {
+    return wsClient.on(IPC.NOTIFICATION_NAVIGATE, (payload) => callback(payload as any))
+  },
+
+  // ============================================================
+  // Theme Preferences Sync
+  // ============================================================
+
+  broadcastThemePreferences: (preferences: { mode: string; colorTheme: string; font: string }) =>
+    apiPost<void>('/theme/broadcast-preferences', preferences).then(() => undefined),
+
+  onThemePreferencesChange: (callback: (preferences: { mode: string; colorTheme: string; font: string }) => void): (() => void) => {
+    return wsClient.on(IPC.THEME_PREFERENCES_CHANGED, (payload) => callback(payload as any))
+  },
+
+  broadcastWorkspaceThemeChange: (workspaceId: string, themeId: string | null) =>
+    apiPost<void>('/theme/broadcast-workspace', { workspaceId, themeId }).then(() => undefined),
+
+  onWorkspaceThemeChange: (callback: (data: { workspaceId: string; themeId: string | null }) => void): (() => void) => {
+    return wsClient.on(IPC.THEME_WORKSPACE_THEME_CHANGED, (payload) => callback(payload as any))
+  },
+
+  // ============================================================
+  // Git Operations
+  // ============================================================
+
+  getGitBranch: (dirPath: string) =>
+    apiGet<{ branch: string | null }>('/git/branch', { dirPath }).then((r: any) => r.branch),
+
+  // ============================================================
+  // Git Bash (Windows only - stubs for web)
+  // ============================================================
+
+  checkGitBash: async () => ({
+    found: false,
+    path: null,
+    platform: 'linux' as const,
+  }),
+
+  browseForGitBash: async () => null,
+  setGitBashPath: async (_path: string) => ({ success: false, error: 'Not applicable in web mode' }),
+
+  // ============================================================
+  // Menu Actions (web: keyboard shortcuts instead)
+  // ============================================================
+
+  menuQuit: () => Promise.resolve(),
+  menuNewWindow: () => Promise.resolve(),
+  menuMinimize: () => { window.blur() },
+  menuMaximize: () => Promise.resolve(),
+  menuZoomIn: () => Promise.resolve(),
+  menuZoomOut: () => Promise.resolve(),
+  menuZoomReset: () => Promise.resolve(),
+  menuToggleDevTools: () => Promise.resolve(),
+  menuUndo: () => { document.execCommand('undo') },
+  menuRedo: () => { document.execCommand('redo') },
+  menuCut: () => { document.execCommand('cut') },
+  menuCopy: () => { document.execCommand('copy') },
+  menuPaste: () => { document.execCommand('paste') },
+  menuSelectAll: () => { document.execCommand('selectAll') },
+
+  // ============================================================
+  // LLM Connections
+  // ============================================================
+
+  listLlmConnections: () =>
+    apiGet<any[]>('/llm-connections'),
+
+  listLlmConnectionsWithStatus: () =>
+    apiGet<any[]>('/llm-connections/with-status'),
+
+  getLlmConnection: (slug: string) =>
+    apiGet<any | null>(`/llm-connections/${slug}`),
+
+  saveLlmConnection: (connection: any) =>
+    apiPost<{ success: boolean; error?: string }>('/llm-connections', connection),
+
+  deleteLlmConnection: (slug: string) =>
+    apiDelete<{ success: boolean; error?: string }>(`/llm-connections/${slug}`),
+
+  testLlmConnection: (slug: string) =>
+    apiPost<{ success: boolean; error?: string }>(`/llm-connections/${slug}/test`),
+
+  setDefaultLlmConnection: (slug: string) =>
+    apiPost<{ success: boolean; error?: string }>('/llm-connections/default', { slug }),
+
+  setWorkspaceDefaultLlmConnection: (workspaceId: string, slug: string | null) =>
+    apiPost<{ success: boolean; error?: string }>('/llm-connections/workspace-default', { workspaceId, slug }),
+}
+
+// Make API available globally as window.electronAPI
+;(window as any).electronAPI = webElectronAPI

--- a/apps/web/src/client/index.html
+++ b/apps/web/src/client/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en" class="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Craft Agents</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400;14..32,500;14..32,600;14..32,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div id="root">
+    <style>
+      #_loader { display:flex; align-items:center; justify-content:center; height:100vh; opacity:0; animation:_fade 0.4s 0.3s forwards; }
+      #_loader svg { width:24px; height:24px; animation:_spin 1s linear infinite; }
+      @keyframes _fade { to { opacity:1 } }
+      @keyframes _spin { to { transform:rotate(360deg) } }
+      @media (prefers-color-scheme:dark) { #_loader svg { color:rgba(255,255,255,0.4) } }
+      @media (prefers-color-scheme:light) { #_loader svg { color:rgba(0,0,0,0.3) } }
+    </style>
+    <div id="_loader"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" stroke-linecap="round"/></svg></div>
+  </div>
+  <script type="module" src="./main.tsx"></script>
+</body>
+</html>

--- a/apps/web/src/client/main.tsx
+++ b/apps/web/src/client/main.tsx
@@ -1,0 +1,61 @@
+/**
+ * Web app entry point.
+ * Sets up the web API (window.electronAPI) via HTTP/WebSocket,
+ * then renders the same React app as the Electron renderer.
+ */
+
+// IMPORTANT: Import web API first to set up window.electronAPI before React renders
+import './api.js'
+
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import * as Sentry from '@sentry/react'
+import { Provider as JotaiProvider, useAtomValue } from 'jotai'
+// Import the original App and related files from the electron renderer via @ alias
+import App from '@/App'
+import { ThemeProvider } from '@/context/ThemeContext'
+import { windowWorkspaceIdAtom } from '@/atoms/sessions'
+import { Toaster } from '@/components/ui/sonner'
+import '@/index.css'
+
+/**
+ * Minimal fallback UI shown when the entire React tree crashes.
+ */
+function CrashFallback() {
+  return (
+    <div className="flex flex-col items-center justify-center h-screen font-sans text-foreground/50 gap-3">
+      <p className="text-base font-medium">Something went wrong</p>
+      <p className="text-[13px]">Please reload the page. The error has been reported.</p>
+      <button
+        onClick={() => window.location.reload()}
+        className="mt-2 px-4 py-1.5 rounded-md bg-background shadow-minimal text-[13px] text-foreground/70 cursor-pointer"
+      >
+        Reload
+      </button>
+    </div>
+  )
+}
+
+/**
+ * Root component - loads workspace ID for theme context and renders App
+ */
+function Root() {
+  const workspaceId = useAtomValue(windowWorkspaceIdAtom)
+
+  return (
+    <ThemeProvider activeWorkspaceId={workspaceId}>
+      <App />
+      <Toaster />
+    </ThemeProvider>
+  )
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Sentry.ErrorBoundary fallback={<CrashFallback />}>
+      <JotaiProvider>
+        <Root />
+      </JotaiProvider>
+    </Sentry.ErrorBoundary>
+  </React.StrictMode>
+)

--- a/apps/web/src/server/app.ts
+++ b/apps/web/src/server/app.ts
@@ -1,0 +1,1110 @@
+/**
+ * Express application setup for Craft Agents web server.
+ * Translates Electron IPC handlers into HTTP REST endpoints.
+ */
+import express, { type Request, type Response, type NextFunction } from 'express'
+import cors from 'cors'
+import { join, normalize, isAbsolute, sep, resolve, basename, dirname, relative } from 'path'
+import { homedir, tmpdir } from 'os'
+import { existsSync, readFileSync } from 'fs'
+import { readFile, readdir, stat, realpath, mkdir, writeFile, unlink, rm } from 'fs/promises'
+import { randomUUID } from 'crypto'
+import { ipcLog, serverLog, searchLog } from './logger.js'
+import { broadcastToAll } from './broadcaster.js'
+
+// Shared packages (no Electron dependency)
+import {
+  getWorkspaces,
+  getWorkspaceByNameOrId,
+  addWorkspace,
+  setActiveWorkspace,
+  loadStoredConfig,
+  saveConfig,
+  getLlmConnections,
+  getLlmConnection,
+  addLlmConnection,
+  updateLlmConnection,
+  deleteLlmConnection,
+  getDefaultLlmConnection,
+  setDefaultLlmConnection,
+  getSessionDraft,
+  setSessionDraft,
+  deleteSessionDraft,
+  getAllSessionDrafts,
+  getPreferencesPath,
+  type Workspace,
+  type LlmConnection,
+  isCompatProvider,
+  isAnthropicProvider,
+  isOpenAIProvider,
+  isCopilotProvider,
+  getDefaultModelsForConnection,
+  getDefaultModelForConnection,
+} from '@craft-agent/shared/config'
+import { getSessionAttachmentsPath, validateSessionId } from '@craft-agent/shared/sessions'
+import { loadWorkspaceSources, getSourcesBySlugs, type LoadedSource } from '@craft-agent/shared/sources'
+import { getCredentialManager } from '@craft-agent/shared/credentials'
+import { getAuthState, getSetupNeeds } from '@craft-agent/shared/auth'
+import { listLabels, createLabel, deleteLabel } from '@craft-agent/shared/labels/storage'
+import { listViews, saveViews } from '@craft-agent/shared/views/storage'
+import { loadAllSkills, loadSkillBySlug } from '../../packages/shared/src/skills/index.ts'
+import { loadWorkspaceConfig, saveWorkspaceConfig } from '@craft-agent/shared/workspaces'
+import { readFileAttachment, perf, validateImageForClaudeAPI, IMAGE_LIMITS } from '@craft-agent/shared/utils'
+import { safeJsonParse } from '@craft-agent/shared/utils/files'
+import type { FileAttachment } from '@craft-agent/shared/utils'
+import { IPC_CHANNELS } from '../../../electron/src/shared/types.ts'
+
+// Session manager - imports from electron app src (uses our electron mock)
+import { SessionManager } from '../../../electron/src/main/sessions.ts'
+import { WebWindowManager } from './web-window-manager.ts'
+
+// Initialize session manager and window manager
+const webWindowManager = new WebWindowManager()
+const sessionManager = new SessionManager()
+sessionManager.setWindowManager(webWindowManager as any)
+
+/**
+ * Sanitizes a filename to prevent path traversal and filesystem issues.
+ */
+function sanitizeFilename(name: string): string {
+  return name
+    .replace(/[/\\]/g, '_')
+    .replace(/[<>:"|?*]/g, '_')
+    .replace(/[\x00-\x1f]/g, '')
+    .replace(/\.{2,}/g, '.')
+    .replace(/^[.\s]+|[.\s]+$/g, '')
+    .slice(0, 200)
+    || 'unnamed'
+}
+
+/**
+ * Validates that a file path is within allowed directories (security check).
+ */
+async function validateFilePath(filePath: string): Promise<string> {
+  let normalizedPath = normalize(filePath)
+  if (normalizedPath.startsWith('~')) {
+    normalizedPath = normalizedPath.replace(/^~/, homedir())
+  }
+  if (!isAbsolute(normalizedPath)) {
+    throw new Error('Only absolute file paths are allowed')
+  }
+  let realPath: string
+  try {
+    realPath = await realpath(normalizedPath)
+  } catch {
+    realPath = normalizedPath
+  }
+  const allowedDirs = [homedir(), tmpdir()]
+  const isAllowed = allowedDirs.some(dir => {
+    const normalizedDir = normalize(dir)
+    const normalizedReal = normalize(realPath)
+    return normalizedReal.startsWith(normalizedDir + sep) || normalizedReal === normalizedDir
+  })
+  if (!isAllowed) {
+    throw new Error('Access denied: file path is outside allowed directories')
+  }
+  return realPath
+}
+
+export async function createApp() {
+  // Initialize session manager
+  await sessionManager.initialize()
+
+  // Set up initial workspace if needed
+  const workspaces = getWorkspaces()
+  if (workspaces.length > 0) {
+    const activeWs = workspaces[0]
+    webWindowManager.setWorkspaceId(activeWs.id)
+    sessionManager.setupConfigWatcher(activeWs.rootPath, activeWs.id)
+  }
+
+  const app = express()
+
+  // Middleware
+  app.use(cors({ origin: true, credentials: true }))
+  app.use(express.json({ limit: '50mb' }))
+  app.use(express.urlencoded({ extended: true, limit: '50mb' }))
+
+  // Serve built frontend in production
+  const clientDistPath = join(new URL('.', import.meta.url).pathname, '../../dist/client')
+  if (existsSync(clientDistPath)) {
+    app.use(express.static(clientDistPath))
+  }
+
+  // Error handler helper
+  function asyncHandler(fn: (req: Request, res: Response, next: NextFunction) => Promise<any>) {
+    return (req: Request, res: Response, next: NextFunction) => {
+      fn(req, res, next).catch(next)
+    }
+  }
+
+  // ============================================================
+  // Session Routes
+  // ============================================================
+
+  // GET /api/sessions - Get all sessions for workspace
+  app.get('/api/sessions', asyncHandler(async (req, res) => {
+    await sessionManager.waitForInit()
+    const workspaceId = req.query.workspaceId as string || webWindowManager.getWorkspaceId() || undefined
+    const sessions = sessionManager.getSessions(workspaceId)
+    res.json(sessions)
+  }))
+
+  // GET /api/sessions/:sessionId - Get session with messages
+  app.get('/api/sessions/:sessionId', asyncHandler(async (req, res) => {
+    const session = await sessionManager.getSession(req.params.sessionId)
+    if (!session) {
+      res.status(404).json({ error: 'Session not found' })
+      return
+    }
+    res.json(session)
+  }))
+
+  // POST /api/sessions - Create new session
+  app.post('/api/sessions', asyncHandler(async (req, res) => {
+    const { workspaceId, options } = req.body
+    const wsId = workspaceId || webWindowManager.getWorkspaceId()
+    if (!wsId) {
+      res.status(400).json({ error: 'workspaceId required' })
+      return
+    }
+    const session = sessionManager.createSession(wsId, options)
+    res.json(session)
+  }))
+
+  // POST /api/sessions/:parentSessionId/sub-sessions - Create sub-session
+  app.post('/api/sessions/:parentSessionId/sub-sessions', asyncHandler(async (req, res) => {
+    const { workspaceId, options } = req.body
+    const wsId = workspaceId || webWindowManager.getWorkspaceId()
+    if (!wsId) {
+      res.status(400).json({ error: 'workspaceId required' })
+      return
+    }
+    const session = await sessionManager.createSubSession(wsId, req.params.parentSessionId, options)
+    res.json(session)
+  }))
+
+  // DELETE /api/sessions/:sessionId - Delete session
+  app.delete('/api/sessions/:sessionId', asyncHandler(async (req, res) => {
+    await sessionManager.deleteSession(req.params.sessionId)
+    res.json({ success: true })
+  }))
+
+  // POST /api/sessions/:sessionId/messages - Send a message
+  app.post('/api/sessions/:sessionId/messages', asyncHandler(async (req, res) => {
+    const { sessionId } = req.params
+    const { message, attachments, storedAttachments, options } = req.body
+
+    // Start processing in background - results come via WebSocket
+    sessionManager.sendMessage(sessionId, message, attachments, storedAttachments, options).catch(err => {
+      ipcLog.error('Error in sendMessage:', err)
+      broadcastToAll(IPC_CHANNELS.SESSION_EVENT, {
+        type: 'error',
+        sessionId,
+        error: err instanceof Error ? err.message : 'Unknown error'
+      })
+      broadcastToAll(IPC_CHANNELS.SESSION_EVENT, {
+        type: 'complete',
+        sessionId
+      })
+    })
+
+    res.json({ started: true })
+  }))
+
+  // POST /api/sessions/:sessionId/cancel - Cancel processing
+  app.post('/api/sessions/:sessionId/cancel', asyncHandler(async (req, res) => {
+    const { silent } = req.body
+    await sessionManager.cancelProcessing(req.params.sessionId, silent)
+    res.json({ success: true })
+  }))
+
+  // POST /api/sessions/:sessionId/kill-shell - Kill shell
+  app.post('/api/sessions/:sessionId/kill-shell', asyncHandler(async (req, res) => {
+    const { shellId } = req.body
+    const result = await sessionManager.killShell(req.params.sessionId, shellId)
+    res.json(result)
+  }))
+
+  // POST /api/sessions/:sessionId/permission - Respond to permission
+  app.post('/api/sessions/:sessionId/permission', asyncHandler(async (req, res) => {
+    const { requestId, allowed, alwaysAllow } = req.body
+    const result = await sessionManager.respondToPermission(req.params.sessionId, requestId, allowed, alwaysAllow)
+    res.json({ success: result })
+  }))
+
+  // POST /api/sessions/:sessionId/credential - Respond to credential request
+  app.post('/api/sessions/:sessionId/credential', asyncHandler(async (req, res) => {
+    const { requestId, response } = req.body
+    const result = await sessionManager.respondToCredential(req.params.sessionId, requestId, response)
+    res.json({ success: result })
+  }))
+
+  // POST /api/sessions/:sessionId/command - Consolidated session command
+  app.post('/api/sessions/:sessionId/command', asyncHandler(async (req, res) => {
+    const { command } = req.body
+    const { sessionId } = req.params
+
+    let result: any
+    switch (command.type) {
+      case 'flag': result = sessionManager.flagSession(sessionId); break
+      case 'unflag': result = sessionManager.unflagSession(sessionId); break
+      case 'archive': result = sessionManager.archiveSession(sessionId); break
+      case 'unarchive': result = sessionManager.unarchiveSession(sessionId); break
+      case 'rename': result = sessionManager.renameSession(sessionId, command.name); break
+      case 'setSessionStatus': result = sessionManager.setSessionStatus(sessionId, command.state); break
+      case 'setActiveViewing':
+        sessionManager.setActiveViewingSession(command.workspaceId, sessionId)
+        result = undefined; break
+      case 'markRead': result = sessionManager.markSessionRead(sessionId); break
+      case 'markUnread': result = sessionManager.markSessionUnread(sessionId); break
+      case 'setPermissionMode': result = sessionManager.setSessionPermissionMode(sessionId, command.mode); break
+      case 'setThinkingLevel': result = sessionManager.setThinkingLevel(sessionId, command.level); break
+      case 'share': result = await sessionManager.shareSession(sessionId); break
+      case 'revokeShare': result = await sessionManager.revokeSessionShare(sessionId); break
+      case 'refreshTitle': result = await sessionManager.refreshSessionTitle(sessionId); break
+      case 'getFamily': result = await sessionManager.getSessionFamily(sessionId); break
+      case 'getChildSessions': result = await sessionManager.getChildSessions(sessionId); break
+      case 'clearMessages': result = await sessionManager.clearSessionMessages(sessionId); break
+      case 'compactMessages': result = await sessionManager.compactSessionMessages(sessionId); break
+      case 'addLabels': result = await sessionManager.addLabels(sessionId, command.labelIds); break
+      case 'removeLabels': result = await sessionManager.removeLabels(sessionId, command.labelIds); break
+      case 'reorderSiblings': result = await sessionManager.reorderSiblings(sessionId, command.orderedIds); break
+      default:
+        res.status(400).json({ error: `Unknown command type: ${command.type}` })
+        return
+    }
+
+    res.json(result ?? { success: true })
+  }))
+
+  // GET /api/sessions/:sessionId/pending-plan - Get pending plan execution
+  app.get('/api/sessions/:sessionId/pending-plan', asyncHandler(async (req, res) => {
+    const result = await sessionManager.getPendingPlanExecution(req.params.sessionId)
+    res.json(result)
+  }))
+
+  // GET /api/sessions/:sessionId/files - Get session files
+  app.get('/api/sessions/:sessionId/files', asyncHandler(async (req, res) => {
+    const files = await sessionManager.getSessionFiles(req.params.sessionId)
+    res.json(files)
+  }))
+
+  // GET /api/sessions/:sessionId/notes - Get session notes
+  app.get('/api/sessions/:sessionId/notes', asyncHandler(async (req, res) => {
+    const notes = await sessionManager.getSessionNotes(req.params.sessionId)
+    res.json({ content: notes })
+  }))
+
+  // PUT /api/sessions/:sessionId/notes - Set session notes
+  app.put('/api/sessions/:sessionId/notes', asyncHandler(async (req, res) => {
+    await sessionManager.setSessionNotes(req.params.sessionId, req.body.content)
+    res.json({ success: true })
+  }))
+
+  // GET /api/tasks/:taskId/output - Get background task output
+  app.get('/api/tasks/:taskId/output', asyncHandler(async (req, res) => {
+    const output = await sessionManager.getTaskOutput(req.params.taskId)
+    res.json({ output })
+  }))
+
+  // POST /api/sessions/search - Search session content
+  app.post('/api/sessions/search', asyncHandler(async (req, res) => {
+    const { workspaceId, query, searchId } = req.body
+    const results = await sessionManager.searchSessionContent(workspaceId, query, searchId)
+    res.json(results)
+  }))
+
+  // ============================================================
+  // Workspace Routes
+  // ============================================================
+
+  // GET /api/workspaces - Get all workspaces
+  app.get('/api/workspaces', asyncHandler(async (req, res) => {
+    const workspaces = sessionManager.getWorkspaces()
+    res.json(workspaces)
+  }))
+
+  // POST /api/workspaces - Create workspace
+  app.post('/api/workspaces', asyncHandler(async (req, res) => {
+    const { folderPath, name } = req.body
+    const workspace = addWorkspace({ name, rootPath: folderPath })
+    setActiveWorkspace(workspace.id)
+    res.json(workspace)
+  }))
+
+  // GET /api/workspaces/check-slug - Check if workspace slug exists
+  app.get('/api/workspaces/check-slug', asyncHandler(async (req, res) => {
+    const slug = req.query.slug as string
+    const defaultWorkspacesDir = join(homedir(), '.craft-agent', 'workspaces')
+    const workspacePath = join(defaultWorkspacesDir, slug)
+    const exists = existsSync(workspacePath)
+    res.json({ exists, path: workspacePath })
+  }))
+
+  // POST /api/workspaces/switch - Switch active workspace
+  app.post('/api/workspaces/switch', asyncHandler(async (req, res) => {
+    const { workspaceId } = req.body
+    webWindowManager.setWorkspaceId(workspaceId)
+    const workspace = getWorkspaceByNameOrId(workspaceId)
+    if (workspace) {
+      sessionManager.setupConfigWatcher(workspace.rootPath, workspaceId)
+    }
+    res.json({ success: true })
+  }))
+
+  // GET /api/workspaces/window - Get current window workspace
+  app.get('/api/workspaces/window', asyncHandler(async (req, res) => {
+    const workspaceId = webWindowManager.getWorkspaceId()
+    if (workspaceId) {
+      const workspace = getWorkspaceByNameOrId(workspaceId)
+      if (workspace) {
+        sessionManager.setupConfigWatcher(workspace.rootPath, workspaceId)
+      }
+    }
+    res.json({ workspaceId })
+  }))
+
+  // GET /api/workspaces/:workspaceId/settings - Get workspace settings
+  app.get('/api/workspaces/:workspaceId/settings', asyncHandler(async (req, res) => {
+    const ws = getWorkspaceByNameOrId(req.params.workspaceId)
+    if (!ws) { res.json(null); return }
+    const config = loadWorkspaceConfig(ws.rootPath)
+    res.json({
+      name: config?.name,
+      model: config?.defaults?.model,
+      permissionMode: config?.defaults?.permissionMode,
+      cyclablePermissionModes: config?.defaults?.cyclablePermissionModes,
+      thinkingLevel: config?.defaults?.thinkingLevel,
+      workingDirectory: config?.defaults?.workingDirectory,
+      localMcpEnabled: config?.localMcpServers?.enabled ?? true,
+      defaultLlmConnection: config?.defaults?.defaultLlmConnection,
+      enabledSourceSlugs: config?.defaults?.enabledSourceSlugs ?? [],
+    })
+  }))
+
+  // PATCH /api/workspaces/:workspaceId/settings - Update workspace setting
+  app.patch('/api/workspaces/:workspaceId/settings', asyncHandler(async (req, res) => {
+    const { key, value } = req.body
+    const ws = getWorkspaceByNameOrId(req.params.workspaceId)
+    if (!ws) { res.status(404).json({ error: 'Workspace not found' }); return }
+    const config = loadWorkspaceConfig(ws.rootPath)
+    if (!config) { res.status(404).json({ error: 'Workspace config not found' }); return }
+    if (key === 'name') {
+      config.name = String(value).trim()
+    } else {
+      if (!config.defaults) config.defaults = {}
+      ;(config.defaults as any)[key] = value
+    }
+    saveWorkspaceConfig(ws.rootPath, config)
+    res.json({ success: true })
+  }))
+
+  // GET /api/workspaces/:workspaceId/permissions - Get workspace permissions config
+  app.get('/api/workspaces/:workspaceId/permissions', asyncHandler(async (req, res) => {
+    const config = await sessionManager.getWorkspacePermissionsConfig(req.params.workspaceId)
+    res.json(config)
+  }))
+
+  // GET /api/workspaces/:workspaceId/image - Read workspace image
+  app.get('/api/workspaces/:workspaceId/image', asyncHandler(async (req, res) => {
+    const relativePath = req.query.path as string
+    const result = await sessionManager.readWorkspaceImage(req.params.workspaceId, relativePath)
+    res.json({ data: result })
+  }))
+
+  // POST /api/workspaces/:workspaceId/image - Write workspace image
+  app.post('/api/workspaces/:workspaceId/image', asyncHandler(async (req, res) => {
+    const { relativePath, base64, mimeType } = req.body
+    await sessionManager.writeWorkspaceImage(req.params.workspaceId, relativePath, base64, mimeType)
+    res.json({ success: true })
+  }))
+
+  // ============================================================
+  // Window Management (simplified for web)
+  // ============================================================
+
+  app.get('/api/window/mode', asyncHandler(async (req, res) => {
+    res.json({ mode: 'main' })
+  }))
+
+  app.post('/api/window/open-workspace', asyncHandler(async (req, res) => {
+    // In web: just switch the workspace (no multi-window support)
+    const { workspaceId } = req.body
+    webWindowManager.setWorkspaceId(workspaceId)
+    res.json({ success: true })
+  }))
+
+  app.post('/api/window/close', asyncHandler(async (req, res) => {
+    // In web: no-op (browser handles window close)
+    res.json({ success: true })
+  }))
+
+  app.post('/api/window/traffic-lights', asyncHandler(async (req, res) => {
+    // In web: no-op (macOS only feature)
+    res.json({ success: true })
+  }))
+
+  // ============================================================
+  // File Routes
+  // ============================================================
+
+  // GET /api/files/read?path=... - Read a file
+  app.get('/api/files/read', asyncHandler(async (req, res) => {
+    const filePath = req.query.path as string
+    const validated = await validateFilePath(filePath)
+    const content = await readFile(validated, 'utf-8')
+    res.json({ content })
+  }))
+
+  // GET /api/files/read-binary?path=... - Read file as base64
+  app.get('/api/files/read-binary', asyncHandler(async (req, res) => {
+    const filePath = req.query.path as string
+    const validated = await validateFilePath(filePath)
+    const content = await readFile(validated)
+    res.json({ base64: content.toString('base64') })
+  }))
+
+  // GET /api/files/read-data-url?path=... - Read file as data URL
+  app.get('/api/files/read-data-url', asyncHandler(async (req, res) => {
+    const filePath = req.query.path as string
+    const validated = await validateFilePath(filePath)
+    const content = await readFile(validated)
+    const ext = filePath.split('.').pop()?.toLowerCase() || ''
+    const mimeTypes: Record<string, string> = {
+      'png': 'image/png', 'jpg': 'image/jpeg', 'jpeg': 'image/jpeg',
+      'gif': 'image/gif', 'webp': 'image/webp', 'svg': 'image/svg+xml',
+      'pdf': 'application/pdf',
+    }
+    const mime = mimeTypes[ext] || 'application/octet-stream'
+    res.json({ dataUrl: `data:${mime};base64,${content.toString('base64')}` })
+  }))
+
+  // POST /api/files/attachment - Read file attachment
+  app.post('/api/files/attachment', asyncHandler(async (req, res) => {
+    const { path: filePath } = req.body
+    const validated = await validateFilePath(filePath)
+    const attachment = await readFileAttachment(validated)
+    res.json(attachment)
+  }))
+
+  // POST /api/files/store-attachment - Store a session attachment
+  app.post('/api/files/store-attachment', asyncHandler(async (req, res) => {
+    const { sessionId, attachment } = req.body
+    const result = await sessionManager.storeAttachment(sessionId, attachment)
+    res.json(result)
+  }))
+
+  // POST /api/files/thumbnail - Generate thumbnail
+  app.post('/api/files/thumbnail', asyncHandler(async (req, res) => {
+    // In web context, return null for thumbnails (not needed for web)
+    res.json({ thumbnail: null })
+  }))
+
+  // GET /api/files/search?basePath=...&query=... - Search files
+  app.get('/api/files/search', asyncHandler(async (req, res) => {
+    const { basePath, query } = req.query as { basePath: string; query: string }
+    const results = await sessionManager.searchFiles(basePath, query)
+    res.json(results)
+  }))
+
+  // ============================================================
+  // System Routes
+  // ============================================================
+
+  app.get('/api/system/home-dir', asyncHandler(async (req, res) => {
+    res.json({ homeDir: homedir() })
+  }))
+
+  app.get('/api/system/debug-mode', asyncHandler(async (req, res) => {
+    res.json({ isDebugMode: process.env.CRAFT_DEBUG === '1' })
+  }))
+
+  app.get('/api/system/versions', asyncHandler(async (req, res) => {
+    res.json({
+      node: process.version,
+      server: '1.0.0',
+      app: '0.4.8',
+    })
+  }))
+
+  // ============================================================
+  // Theme Routes
+  // ============================================================
+
+  app.get('/api/theme/system', asyncHandler(async (req, res) => {
+    // Web: check system theme via CSS media query (client-side)
+    res.json({ isDark: false })
+  }))
+
+  app.get('/api/theme/app', asyncHandler(async (req, res) => {
+    const theme = await sessionManager.getAppTheme()
+    res.json(theme)
+  }))
+
+  app.get('/api/theme/presets', asyncHandler(async (req, res) => {
+    const presets = await sessionManager.loadPresetThemes()
+    res.json(presets)
+  }))
+
+  app.get('/api/theme/presets/:themeId', asyncHandler(async (req, res) => {
+    const preset = await sessionManager.loadPresetTheme(req.params.themeId)
+    res.json(preset)
+  }))
+
+  app.get('/api/theme/color', asyncHandler(async (req, res) => {
+    const theme = await sessionManager.getColorTheme()
+    res.json({ theme })
+  }))
+
+  app.post('/api/theme/color', asyncHandler(async (req, res) => {
+    await sessionManager.setColorTheme(req.body.themeId)
+    res.json({ success: true })
+  }))
+
+  app.get('/api/theme/workspace/:workspaceId', asyncHandler(async (req, res) => {
+    const theme = await sessionManager.getWorkspaceColorTheme(req.params.workspaceId)
+    res.json({ theme })
+  }))
+
+  app.post('/api/theme/workspace/:workspaceId', asyncHandler(async (req, res) => {
+    await sessionManager.setWorkspaceColorTheme(req.params.workspaceId, req.body.themeId)
+    res.json({ success: true })
+  }))
+
+  app.get('/api/theme/all-workspace-themes', asyncHandler(async (req, res) => {
+    const themes = await sessionManager.getAllWorkspaceThemes()
+    res.json(themes)
+  }))
+
+  app.post('/api/theme/broadcast-preferences', asyncHandler(async (req, res) => {
+    broadcastToAll(IPC_CHANNELS.THEME_PREFERENCES_CHANGED, req.body)
+    res.json({ success: true })
+  }))
+
+  app.post('/api/theme/broadcast-workspace', asyncHandler(async (req, res) => {
+    broadcastToAll(IPC_CHANNELS.THEME_WORKSPACE_THEME_CHANGED, req.body)
+    res.json({ success: true })
+  }))
+
+  // ============================================================
+  // Auth / Onboarding Routes
+  // ============================================================
+
+  app.get('/api/auth/state', asyncHandler(async (req, res) => {
+    const authState = await getAuthState()
+    const setupNeeds = getSetupNeeds(authState)
+    res.json({ authState, setupNeeds })
+  }))
+
+  app.post('/api/auth/logout', asyncHandler(async (req, res) => {
+    const credManager = getCredentialManager()
+    await credManager.clearAll()
+    res.json({ success: true })
+  }))
+
+  app.get('/api/auth/credential-health', asyncHandler(async (req, res) => {
+    const health = await sessionManager.getCredentialHealth()
+    res.json(health)
+  }))
+
+  // Claude OAuth flow
+  app.post('/api/auth/claude/start', asyncHandler(async (req, res) => {
+    const { startClaudeOAuth } = await import('@craft-agent/shared/auth')
+    const authUrl = await startClaudeOAuth((status) => {
+      ipcLog.info('[OAuth] Claude OAuth status:', status)
+    })
+    res.json({ success: true, authUrl })
+  }))
+
+  app.post('/api/auth/claude/exchange', asyncHandler(async (req, res) => {
+    const { code, connectionSlug } = req.body
+    const { exchangeClaudeCode, hasValidOAuthState } = await import('@craft-agent/shared/auth')
+    if (!hasValidOAuthState()) {
+      res.json({ success: false, error: 'OAuth session expired. Please start again.' })
+      return
+    }
+    const result = await exchangeClaudeCode(code, connectionSlug, (status) => {
+      ipcLog.info('[OAuth] Exchange status:', status)
+    })
+    res.json(result)
+  }))
+
+  app.get('/api/auth/claude/has-state', asyncHandler(async (req, res) => {
+    const { hasValidOAuthState } = await import('@craft-agent/shared/auth')
+    res.json({ hasState: hasValidOAuthState() })
+  }))
+
+  app.post('/api/auth/claude/clear-state', asyncHandler(async (req, res) => {
+    const { clearOAuthState } = await import('@craft-agent/shared/auth')
+    clearOAuthState()
+    res.json({ success: true })
+  }))
+
+  // ============================================================
+  // LLM Connection Routes
+  // ============================================================
+
+  app.get('/api/llm-connections', asyncHandler(async (req, res) => {
+    const connections = getLlmConnections()
+    res.json(connections)
+  }))
+
+  app.get('/api/llm-connections/with-status', asyncHandler(async (req, res) => {
+    const connections = await sessionManager.listLlmConnectionsWithStatus()
+    res.json(connections)
+  }))
+
+  app.get('/api/llm-connections/:slug', asyncHandler(async (req, res) => {
+    const connection = getLlmConnection(req.params.slug)
+    res.json(connection)
+  }))
+
+  app.post('/api/llm-connections', asyncHandler(async (req, res) => {
+    const connection: LlmConnection = req.body
+    try {
+      addLlmConnection(connection)
+      res.json({ success: true })
+    } catch (err) {
+      res.json({ success: false, error: err instanceof Error ? err.message : 'Failed to save' })
+    }
+  }))
+
+  app.put('/api/llm-connections/:slug', asyncHandler(async (req, res) => {
+    const connection: LlmConnection = req.body
+    updateLlmConnection(req.params.slug, connection)
+    res.json({ success: true })
+  }))
+
+  app.delete('/api/llm-connections/:slug', asyncHandler(async (req, res) => {
+    deleteLlmConnection(req.params.slug)
+    res.json({ success: true })
+  }))
+
+  app.post('/api/llm-connections/:slug/test', asyncHandler(async (req, res) => {
+    const result = await sessionManager.testLlmConnection(req.params.slug)
+    res.json(result)
+  }))
+
+  app.post('/api/llm-connections/default', asyncHandler(async (req, res) => {
+    setDefaultLlmConnection(req.body.slug)
+    res.json({ success: true })
+  }))
+
+  app.post('/api/llm-connections/workspace-default', asyncHandler(async (req, res) => {
+    const { workspaceId, slug } = req.body
+    await sessionManager.setWorkspaceDefaultLlmConnection(workspaceId, slug)
+    res.json({ success: true })
+  }))
+
+  // Setup LLM connection (with credential)
+  app.post('/api/settings/setup-llm-connection', asyncHandler(async (req, res) => {
+    const result = await sessionManager.setupLlmConnection(req.body)
+    res.json(result)
+  }))
+
+  // Test API connection
+  app.post('/api/settings/test-api-connection', asyncHandler(async (req, res) => {
+    const { apiKey, baseUrl, models } = req.body
+    const result = await sessionManager.testApiConnection(apiKey, baseUrl, models)
+    res.json(result)
+  }))
+
+  app.post('/api/settings/test-openai-connection', asyncHandler(async (req, res) => {
+    const { apiKey, baseUrl, models } = req.body
+    const result = await sessionManager.testOpenAiConnection(apiKey, baseUrl, models)
+    res.json(result)
+  }))
+
+  // ============================================================
+  // Session Model Routes
+  // ============================================================
+
+  app.get('/api/sessions/:sessionId/model', asyncHandler(async (req, res) => {
+    const { workspaceId } = req.query as { workspaceId: string }
+    const model = await sessionManager.getSessionModel(req.params.sessionId, workspaceId)
+    res.json({ model })
+  }))
+
+  app.post('/api/sessions/:sessionId/model', asyncHandler(async (req, res) => {
+    const { workspaceId, model, connection } = req.body
+    await sessionManager.setSessionModel(req.params.sessionId, workspaceId, model, connection)
+    res.json({ success: true })
+  }))
+
+  // ============================================================
+  // Preferences Routes
+  // ============================================================
+
+  app.get('/api/preferences', asyncHandler(async (req, res) => {
+    const prefsPath = getPreferencesPath()
+    const exists = existsSync(prefsPath)
+    const content = exists ? readFileSync(prefsPath, 'utf-8') : ''
+    res.json({ content, exists, path: prefsPath })
+  }))
+
+  app.put('/api/preferences', asyncHandler(async (req, res) => {
+    const prefsPath = getPreferencesPath()
+    await mkdir(dirname(prefsPath), { recursive: true })
+    await writeFile(prefsPath, req.body.content, 'utf-8')
+    res.json({ success: true })
+  }))
+
+  // ============================================================
+  // Drafts Routes
+  // ============================================================
+
+  app.get('/api/drafts', asyncHandler(async (req, res) => {
+    const drafts = getAllSessionDrafts()
+    res.json(drafts)
+  }))
+
+  app.get('/api/drafts/:sessionId', asyncHandler(async (req, res) => {
+    const draft = getSessionDraft(req.params.sessionId)
+    res.json({ draft })
+  }))
+
+  app.put('/api/drafts/:sessionId', asyncHandler(async (req, res) => {
+    setSessionDraft(req.params.sessionId, req.body.text)
+    res.json({ success: true })
+  }))
+
+  app.delete('/api/drafts/:sessionId', asyncHandler(async (req, res) => {
+    deleteSessionDraft(req.params.sessionId)
+    res.json({ success: true })
+  }))
+
+  // ============================================================
+  // Sources Routes
+  // ============================================================
+
+  app.get('/api/workspaces/:workspaceId/sources', asyncHandler(async (req, res) => {
+    const sources = await sessionManager.getSources(req.params.workspaceId)
+    res.json(sources)
+  }))
+
+  app.post('/api/workspaces/:workspaceId/sources', asyncHandler(async (req, res) => {
+    const result = await sessionManager.createSource(req.params.workspaceId, req.body)
+    res.json(result)
+  }))
+
+  app.delete('/api/workspaces/:workspaceId/sources/:sourceSlug', asyncHandler(async (req, res) => {
+    await sessionManager.deleteSource(req.params.workspaceId, req.params.sourceSlug)
+    res.json({ success: true })
+  }))
+
+  app.post('/api/workspaces/:workspaceId/sources/:sourceSlug/save-credentials', asyncHandler(async (req, res) => {
+    await sessionManager.saveSourceCredentials(req.params.workspaceId, req.params.sourceSlug, req.body.credential)
+    res.json({ success: true })
+  }))
+
+  app.get('/api/workspaces/:workspaceId/sources/:sourceSlug/permissions', asyncHandler(async (req, res) => {
+    const config = await sessionManager.getSourcePermissionsConfig(req.params.workspaceId, req.params.sourceSlug)
+    res.json(config)
+  }))
+
+  app.get('/api/workspaces/:workspaceId/sources/:sourceSlug/mcp-tools', asyncHandler(async (req, res) => {
+    const result = await sessionManager.getMcpTools(req.params.workspaceId, req.params.sourceSlug)
+    res.json(result)
+  }))
+
+  // Default permissions
+  app.get('/api/permissions/defaults', asyncHandler(async (req, res) => {
+    const result = await sessionManager.getDefaultPermissionsConfig()
+    res.json(result)
+  }))
+
+  // ============================================================
+  // Skills Routes
+  // ============================================================
+
+  app.get('/api/workspaces/:workspaceId/skills', asyncHandler(async (req, res) => {
+    const { workingDirectory } = req.query as { workingDirectory?: string }
+    const skills = await sessionManager.getSkills(req.params.workspaceId, workingDirectory)
+    res.json(skills)
+  }))
+
+  app.get('/api/workspaces/:workspaceId/skills/:skillSlug/files', asyncHandler(async (req, res) => {
+    const files = await sessionManager.getSkillFiles(req.params.workspaceId, req.params.skillSlug)
+    res.json(files)
+  }))
+
+  app.delete('/api/workspaces/:workspaceId/skills/:skillSlug', asyncHandler(async (req, res) => {
+    await sessionManager.deleteSkill(req.params.workspaceId, req.params.skillSlug)
+    res.json({ success: true })
+  }))
+
+  // ============================================================
+  // Statuses Routes
+  // ============================================================
+
+  app.get('/api/workspaces/:workspaceId/statuses', asyncHandler(async (req, res) => {
+    const ws = getWorkspaceByNameOrId(req.params.workspaceId)
+    if (!ws) { res.status(404).json({ error: 'Workspace not found' }); return }
+    const { listStatuses } = await import('@craft-agent/shared/src/statuses/index.ts' as any)
+    const statuses = listStatuses(ws.rootPath)
+    res.json(statuses)
+  }))
+
+  app.post('/api/workspaces/:workspaceId/statuses/reorder', asyncHandler(async (req, res) => {
+    const ws = getWorkspaceByNameOrId(req.params.workspaceId)
+    if (!ws) { res.status(404).json({ error: 'Workspace not found' }); return }
+    const { reorderStatuses } = await import('@craft-agent/shared/src/statuses/crud.ts' as any)
+    reorderStatuses(ws.rootPath, req.body.orderedIds)
+    res.json({ success: true })
+  }))
+
+  // ============================================================
+  // Labels Routes
+  // ============================================================
+
+  app.get('/api/workspaces/:workspaceId/labels', asyncHandler(async (req, res) => {
+    const ws = getWorkspaceByNameOrId(req.params.workspaceId)
+    if (!ws) { res.status(404).json({ error: 'Workspace not found' }); return }
+    const labels = listLabels(ws.rootPath)
+    res.json(labels)
+  }))
+
+  app.post('/api/workspaces/:workspaceId/labels', asyncHandler(async (req, res) => {
+    const ws = getWorkspaceByNameOrId(req.params.workspaceId)
+    if (!ws) { res.status(404).json({ error: 'Workspace not found' }); return }
+    const label = createLabel(ws.rootPath, req.body)
+    res.json(label)
+  }))
+
+  app.delete('/api/workspaces/:workspaceId/labels/:labelId', asyncHandler(async (req, res) => {
+    const ws = getWorkspaceByNameOrId(req.params.workspaceId)
+    if (!ws) { res.status(404).json({ error: 'Workspace not found' }); return }
+    const result = deleteLabel(ws.rootPath, req.params.labelId)
+    res.json(result)
+  }))
+
+  // ============================================================
+  // Views Routes
+  // ============================================================
+
+  app.get('/api/workspaces/:workspaceId/views', asyncHandler(async (req, res) => {
+    const ws = getWorkspaceByNameOrId(req.params.workspaceId)
+    if (!ws) { res.status(404).json({ error: 'Workspace not found' }); return }
+    const views = listViews(ws.rootPath)
+    res.json(views)
+  }))
+
+  app.put('/api/workspaces/:workspaceId/views', asyncHandler(async (req, res) => {
+    const ws = getWorkspaceByNameOrId(req.params.workspaceId)
+    if (!ws) { res.status(404).json({ error: 'Workspace not found' }); return }
+    saveViews(ws.rootPath, req.body)
+    res.json({ success: true })
+  }))
+
+  // ============================================================
+  // Input Settings Routes
+  // ============================================================
+
+  app.get('/api/settings/auto-capitalisation', asyncHandler(async (req, res) => {
+    const value = await sessionManager.getAutoCapitalisation()
+    res.json({ value })
+  }))
+
+  app.post('/api/settings/auto-capitalisation', asyncHandler(async (req, res) => {
+    await sessionManager.setAutoCapitalisation(req.body.enabled)
+    res.json({ success: true })
+  }))
+
+  app.get('/api/settings/send-message-key', asyncHandler(async (req, res) => {
+    const value = await sessionManager.getSendMessageKey()
+    res.json({ value })
+  }))
+
+  app.post('/api/settings/send-message-key', asyncHandler(async (req, res) => {
+    await sessionManager.setSendMessageKey(req.body.key)
+    res.json({ success: true })
+  }))
+
+  app.get('/api/settings/spell-check', asyncHandler(async (req, res) => {
+    const value = await sessionManager.getSpellCheck()
+    res.json({ value })
+  }))
+
+  app.post('/api/settings/spell-check', asyncHandler(async (req, res) => {
+    await sessionManager.setSpellCheck(req.body.enabled)
+    res.json({ success: true })
+  }))
+
+  app.get('/api/settings/keep-awake', asyncHandler(async (req, res) => {
+    const value = await sessionManager.getKeepAwakeWhileRunning()
+    res.json({ value })
+  }))
+
+  app.post('/api/settings/keep-awake', asyncHandler(async (req, res) => {
+    await sessionManager.setKeepAwakeWhileRunning(req.body.enabled)
+    res.json({ success: true })
+  }))
+
+  app.get('/api/settings/rich-tool-descriptions', asyncHandler(async (req, res) => {
+    const value = await sessionManager.getRichToolDescriptions()
+    res.json({ value })
+  }))
+
+  app.post('/api/settings/rich-tool-descriptions', asyncHandler(async (req, res) => {
+    await sessionManager.setRichToolDescriptions(req.body.enabled)
+    res.json({ success: true })
+  }))
+
+  app.get('/api/settings/notifications-enabled', asyncHandler(async (req, res) => {
+    const value = await sessionManager.getNotificationsEnabled()
+    res.json({ value })
+  }))
+
+  app.post('/api/settings/notifications-enabled', asyncHandler(async (req, res) => {
+    await sessionManager.setNotificationsEnabled(req.body.enabled)
+    res.json({ success: true })
+  }))
+
+  // ============================================================
+  // Tool Icons Route
+  // ============================================================
+
+  app.get('/api/tool-icons', asyncHandler(async (req, res) => {
+    const icons = await sessionManager.getToolIconMappings()
+    res.json(icons)
+  }))
+
+  // ============================================================
+  // Shell / OS Routes (web-adapted)
+  // ============================================================
+
+  // In web, we return the URL for the client to navigate to
+  app.post('/api/shell/open-url', asyncHandler(async (req, res) => {
+    res.json({ url: req.body.url })
+  }))
+
+  app.post('/api/shell/open-file', asyncHandler(async (req, res) => {
+    // In web context, we can't open files natively
+    res.json({ success: false, error: 'Cannot open files in web mode' })
+  }))
+
+  app.post('/api/shell/show-in-folder', asyncHandler(async (req, res) => {
+    // In web context: return the folder path for client display
+    res.json({ success: false, error: 'Cannot show in folder in web mode' })
+  }))
+
+  // ============================================================
+  // Update Routes (stubs - not applicable for web)
+  // ============================================================
+
+  app.get('/api/update/info', asyncHandler(async (req, res) => {
+    res.json({ hasUpdate: false, version: null })
+  }))
+
+  app.post('/api/update/check', asyncHandler(async (req, res) => {
+    res.json({ hasUpdate: false })
+  }))
+
+  app.post('/api/update/install', asyncHandler(async (req, res) => {
+    res.json({ success: false, error: 'Auto-update not available in web mode' })
+  }))
+
+  app.get('/api/update/dismissed', asyncHandler(async (req, res) => {
+    res.json({ version: null })
+  }))
+
+  app.post('/api/update/dismiss', asyncHandler(async (req, res) => {
+    res.json({ success: true })
+  }))
+
+  app.get('/api/release-notes', asyncHandler(async (req, res) => {
+    res.json({ notes: '' })
+  }))
+
+  app.get('/api/release-notes/latest-version', asyncHandler(async (req, res) => {
+    res.json({ version: null })
+  }))
+
+  // ============================================================
+  // Logo URL (web-adapted)
+  // ============================================================
+
+  app.get('/api/logo-url', asyncHandler(async (req, res) => {
+    // Return null - in web we use favicon.ico or similar
+    res.json({ url: null })
+  }))
+
+  // ============================================================
+  // Git Operations
+  // ============================================================
+
+  app.get('/api/git/branch', asyncHandler(async (req, res) => {
+    const { dirPath } = req.query as { dirPath: string }
+    const branch = await sessionManager.getGitBranch(dirPath)
+    res.json({ branch })
+  }))
+
+  // ============================================================
+  // Notifications (web-adapted)
+  // ============================================================
+
+  app.post('/api/notifications/show', asyncHandler(async (req, res) => {
+    // In web: broadcast via WebSocket so client can show a browser notification
+    broadcastToAll('notification', {
+      title: req.body.title,
+      body: req.body.body,
+      workspaceId: req.body.workspaceId,
+      sessionId: req.body.sessionId,
+    })
+    res.json({ success: true })
+  }))
+
+  app.post('/api/notifications/update-badge', asyncHandler(async (req, res) => {
+    // No-op in web
+    res.json({ success: true })
+  }))
+
+  // ============================================================
+  // Debug logging
+  // ============================================================
+
+  app.post('/api/debug/log', asyncHandler(async (req, res) => {
+    const { args } = req.body
+    ipcLog.info('[renderer]', ...args)
+    res.json({ success: true })
+  }))
+
+  // ============================================================
+  // Confirmation dialogs (web-adapted)
+  // ============================================================
+
+  // In web, these are handled client-side - server just confirms
+  app.post('/api/dialog/confirm-logout', asyncHandler(async (req, res) => {
+    res.json({ confirmed: true })
+  }))
+
+  app.post('/api/dialog/confirm-delete-session', asyncHandler(async (req, res) => {
+    res.json({ confirmed: true })
+  }))
+
+  app.post('/api/dialog/open-folder', asyncHandler(async (req, res) => {
+    // In web: can't open folder dialog - return null
+    res.json({ folderPath: null })
+  }))
+
+  // ============================================================
+  // Catch-all for SPA routing
+  // ============================================================
+
+  if (existsSync(clientDistPath)) {
+    app.get('*', (req, res) => {
+      res.sendFile(join(clientDistPath, 'index.html'))
+    })
+  }
+
+  // Error handler
+  app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
+    serverLog.error('API error:', err.message)
+    res.status(500).json({
+      error: err.message || 'Internal server error'
+    })
+  })
+
+  return app
+}

--- a/apps/web/src/server/broadcaster.ts
+++ b/apps/web/src/server/broadcaster.ts
@@ -1,0 +1,54 @@
+/**
+ * WebSocket broadcaster - replaces Electron's WindowManager.broadcastToAll()
+ * Sends events to all connected web clients.
+ */
+import { WebSocketServer, WebSocket } from 'ws'
+import type { IncomingMessage } from 'http'
+import type { Server } from 'http'
+
+export interface WsMessage {
+  type: string
+  payload?: unknown
+}
+
+export class Broadcaster {
+  private wss: WebSocketServer
+  private clients = new Set<WebSocket>()
+
+  constructor(server: Server) {
+    this.wss = new WebSocketServer({ server, path: '/ws' })
+    this.wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
+      this.clients.add(ws)
+      ws.on('close', () => this.clients.delete(ws))
+      ws.on('error', () => this.clients.delete(ws))
+    })
+  }
+
+  broadcast(type: string, payload?: unknown): void {
+    const msg = JSON.stringify({ type, payload })
+    for (const client of this.clients) {
+      if (client.readyState === WebSocket.OPEN) {
+        client.send(msg)
+      }
+    }
+  }
+
+  get clientCount(): number {
+    return this.clients.size
+  }
+}
+
+let _broadcaster: Broadcaster | null = null
+
+export function setBroadcaster(b: Broadcaster): void {
+  _broadcaster = b
+}
+
+export function getBroadcaster(): Broadcaster {
+  if (!_broadcaster) throw new Error('Broadcaster not initialized')
+  return _broadcaster
+}
+
+export function broadcastToAll(channel: string, payload?: unknown): void {
+  _broadcaster?.broadcast(channel, payload)
+}

--- a/apps/web/src/server/index.ts
+++ b/apps/web/src/server/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Web server entry point for Craft Agents.
+ * Replaces Electron main process with an Express.js + WebSocket server.
+ *
+ * Run with: bun run src/server/index.ts
+ */
+import { createServer } from 'http'
+import { Broadcaster, setBroadcaster } from './broadcaster.js'
+import { serverLog, isDebugMode } from './logger.js'
+import { join } from 'path'
+import { homedir } from 'os'
+
+const PORT = parseInt(process.env.PORT || '3000', 10)
+const HOST = process.env.HOST || '0.0.0.0'
+
+// Set up broadcaster first so the electron mock can use it immediately
+const httpServer = createServer()
+const broadcaster = new Broadcaster(httpServer)
+setBroadcaster(broadcaster)
+// Register broadcaster with the electron shim via globalThis
+;(globalThis as any).__craftWebBroadcaster = broadcaster
+
+// Now import the Express app (this triggers electron-dependent module loading)
+const { createApp } = await import('./app.js')
+const app = await createApp()
+httpServer.on('request', app)
+
+httpServer.listen(PORT, HOST, () => {
+  serverLog.info(`Craft Agents web server running at http://${HOST}:${PORT}`)
+  serverLog.info(`Config dir: ${process.env.CRAFT_CONFIG_DIR || join(homedir(), '.craft-agent')}`)
+  serverLog.info(`Debug mode: ${isDebugMode}`)
+  if (isDebugMode) {
+    serverLog.info('Dev mode: Vite frontend at http://localhost:5174')
+  }
+})
+
+process.on('SIGTERM', () => {
+  serverLog.info('Received SIGTERM, shutting down gracefully...')
+  httpServer.close(() => process.exit(0))
+})
+
+process.on('SIGINT', () => {
+  serverLog.info('Received SIGINT, shutting down gracefully...')
+  httpServer.close(() => process.exit(0))
+})

--- a/apps/web/src/server/logger.ts
+++ b/apps/web/src/server/logger.ts
@@ -1,0 +1,29 @@
+/**
+ * Logger for web server - replaces the Electron electron-log based logger.
+ * Uses simple console output with structured prefixes.
+ */
+
+const isDebugMode = process.env.CRAFT_DEBUG === '1' || process.env.NODE_ENV !== 'production'
+
+function createLogger(prefix: string) {
+  return {
+    info: (...args: unknown[]) => console.info(`[${prefix}]`, ...args),
+    warn: (...args: unknown[]) => console.warn(`[${prefix}]`, ...args),
+    error: (...args: unknown[]) => console.error(`[${prefix}]`, ...args),
+    debug: (...args: unknown[]) => {
+      if (isDebugMode) console.debug(`[${prefix}]`, ...args)
+    },
+  }
+}
+
+export const serverLog = createLogger('server')
+export const sessionLog = createLogger('session')
+export const ipcLog = createLogger('api')
+export const windowLog = createLogger('window')
+export const searchLog = createLogger('search')
+
+export { isDebugMode }
+
+export function getLogFilePath(): string {
+  return '/dev/null'
+}

--- a/apps/web/src/server/web-window-manager.ts
+++ b/apps/web/src/server/web-window-manager.ts
@@ -1,0 +1,78 @@
+/**
+ * WebWindowManager - adapts the Electron WindowManager interface for web use.
+ * Uses WebSocket broadcasting instead of Electron IPC.
+ *
+ * This class implements a subset of WindowManager's interface that SessionManager uses,
+ * specifically the broadcastToAll() method.
+ */
+import { broadcastToAll } from './broadcaster.js'
+import { homedir } from 'os'
+import { join } from 'path'
+
+/**
+ * A minimal mock of BrowserWindow for the web context.
+ * Used for getAllWindowsForWorkspace return type compatibility.
+ */
+class WebBrowserWindow {
+  constructor(public readonly workspaceId: string) {}
+}
+
+export class WebWindowManager {
+  private activeWorkspaceId: string | null = null
+  private windowWorkspaceId: string | null = null
+  private windowMode: string = 'main'
+
+  setWorkspaceId(workspaceId: string): void {
+    this.activeWorkspaceId = workspaceId
+    this.windowWorkspaceId = workspaceId
+  }
+
+  getWorkspaceId(): string | null {
+    return this.windowWorkspaceId
+  }
+
+  getWindowMode(): string {
+    return this.windowMode
+  }
+
+  /**
+   * Replace Electron's WindowManager.broadcastToAll().
+   * Broadcasts a message to all connected WebSocket clients.
+   */
+  broadcastToAll(channel: string, ...args: unknown[]): void {
+    // For consistency with Electron's multi-arg IPC, we send first arg as payload
+    const payload = args.length === 0 ? undefined : args.length === 1 ? args[0] : args
+    broadcastToAll(channel, payload)
+  }
+
+  /**
+   * Get all "windows" for a workspace.
+   * In web context, we return a mock window representing the web client.
+   */
+  getAllWindowsForWorkspace(workspaceId: string): WebBrowserWindow[] {
+    // In web context, we always have at most one "window"
+    if (this.activeWorkspaceId === workspaceId) {
+      return [new WebBrowserWindow(workspaceId)]
+    }
+    return []
+  }
+
+  /**
+   * Send a message to a specific workspace's windows.
+   * In web context, this broadcasts to all clients (no per-window targeting).
+   */
+  sendToWorkspace(workspaceId: string, channel: string, payload?: unknown): void {
+    broadcastToAll(channel, payload)
+  }
+
+  /**
+   * No-op methods for window management features not applicable in web context
+   */
+  setTrafficLightsVisible(_webContentsId: number, _visible: boolean): void {
+    // No-op for web
+  }
+
+  createWindow(_options: { workspaceId: string }): WebBrowserWindow {
+    return new WebBrowserWindow(_options.workspaceId)
+  }
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,57 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+import { resolve } from 'path'
+
+export default defineConfig({
+  plugins: [
+    react({
+      babel: {
+        plugins: [
+          'jotai/babel/plugin-debug-label',
+          ['jotai/babel/plugin-react-refresh', { customAtomNames: ['atomFamily'] }],
+        ],
+      },
+    }),
+    tailwindcss(),
+  ],
+  root: resolve(__dirname, 'src/client'),
+  base: './',
+  build: {
+    outDir: resolve(__dirname, 'dist/client'),
+    emptyDirBeforeWrite: true,
+    sourcemap: true,
+  },
+  resolve: {
+    alias: {
+      // Point @ to the electron renderer so we can reuse all components without copying
+      '@': resolve(__dirname, '../electron/src/renderer'),
+      '@config': resolve(__dirname, '../../packages/shared/src/config'),
+      'react': resolve(__dirname, '../../node_modules/react'),
+      'react-dom': resolve(__dirname, '../../node_modules/react-dom'),
+    },
+    dedupe: ['react', 'react-dom']
+  },
+  optimizeDeps: {
+    include: ['react', 'react-dom', 'jotai', 'pdfjs-dist'],
+    exclude: ['@craft-agent/ui'],
+    esbuildOptions: {
+      supported: { 'top-level-await': true },
+      target: 'esnext'
+    }
+  },
+  server: {
+    port: 5174,
+    open: false,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+      '/ws': {
+        target: 'ws://localhost:3000',
+        ws: true,
+      },
+    }
+  }
+})

--- a/bun.lock
+++ b/bun.lock
@@ -82,7 +82,7 @@
     },
     "apps/electron": {
       "name": "@craft-agent/electron",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/shared": "workspace:*",
@@ -118,32 +118,9 @@
         "vaul": "^1.1.2",
       },
     },
-    "apps/marketing": {
-      "name": "@craft-agent/marketing",
-      "version": "0.4.3",
-      "dependencies": {
-        "@craft-agent/ui": "workspace:*",
-        "@paper-design/shaders-react": "^0.0.70",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-router-dom": "^7.13.0",
-        "shiki": "^3.21.0",
-        "three": "^0.170.0",
-      },
-      "devDependencies": {
-        "@tailwindcss/vite": "^4.1.18",
-        "@types/react": "^18.3.0",
-        "@types/react-dom": "^18.3.0",
-        "@types/three": "^0.170.0",
-        "@vitejs/plugin-react": "^5.1.2",
-        "tailwindcss": "^4.1.18",
-        "typescript": "^5.0.0",
-        "vite": "^6.2.4",
-      },
-    },
     "apps/viewer": {
       "name": "@craft-agent/viewer",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/ui": "workspace:*",
@@ -168,9 +145,56 @@
         "vite": "^6.2.5",
       },
     },
+    "apps/web": {
+      "name": "@craft-agent/web",
+      "version": "0.4.8",
+      "dependencies": {
+        "@craft-agent/core": "workspace:*",
+        "@craft-agent/shared": "workspace:*",
+        "@craft-agent/ui": "workspace:*",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "@paper-design/shaders-react": "^0.0.69",
+        "@pierre/diffs": "^1.0.4",
+        "@radix-ui/react-context-menu": "^2.2.16",
+        "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-switch": "^1.2.6",
+        "@sentry/react": "^10.36.0",
+        "@tanstack/react-table": "^8.21.3",
+        "chrono-node": "^2.9.0",
+        "cmdk": "^1.1.1",
+        "cors": "^2.8.5",
+        "express": "^4.19.2",
+        "jotai-family": "^1.0.1",
+        "motion": "^12.23.26",
+        "multer": "^1.4.5-lts.1",
+        "next-themes": "^0.4.6",
+        "react": "^18.3.1",
+        "react-day-picker": "^9.13.0",
+        "react-dom": "^18.3.1",
+        "react-pdf": "^10.3.0",
+        "react-simple-code-editor": "^0.14.1",
+        "remark": "^15.0.1",
+        "sonner": "^2.0.7",
+        "strip-markdown": "^6.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vaul": "^1.1.2",
+        "ws": "^8.18.0",
+      },
+      "devDependencies": {
+        "@types/cors": "^2.8.17",
+        "@types/express": "^4.17.21",
+        "@types/multer": "^1.4.11",
+        "@types/ws": "^8.5.13",
+      },
+    },
     "packages/bridge-mcp-server": {
       "name": "@craft-agent/bridge-mcp-server",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "bin": {
         "bridge-mcp-server": "./dist/index.js",
       },
@@ -183,11 +207,11 @@
     },
     "packages/codex-types": {
       "name": "@craft-agent/codex-types",
-      "version": "0.4.3",
+      "version": "0.4.8",
     },
     "packages/core": {
       "name": "@craft-agent/core",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "devDependencies": {
         "@types/uuid": "^11.0.0",
       },
@@ -199,7 +223,7 @@
     },
     "packages/mermaid": {
       "name": "@craft-agent/mermaid",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "dependencies": {
         "elkjs": "^0.11.0",
       },
@@ -209,7 +233,7 @@
     },
     "packages/session-mcp-server": {
       "name": "@craft-agent/session-mcp-server",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "bin": {
         "session-mcp-server": "./dist/index.js",
       },
@@ -224,7 +248,7 @@
     },
     "packages/session-tools-core": {
       "name": "@craft-agent/session-tools-core",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "dependencies": {
         "@craft-agent/mermaid": "workspace:*",
         "gray-matter": "^4.0.3",
@@ -236,7 +260,7 @@
     },
     "packages/shared": {
       "name": "@craft-agent/shared",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "dependencies": {
         "@craft-agent/codex-types": "workspace:*",
         "@craft-agent/core": "workspace:*",
@@ -262,7 +286,7 @@
     },
     "packages/ui": {
       "name": "@craft-agent/ui",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/mermaid": "workspace:*",
@@ -472,8 +496,6 @@
 
     "@craft-agent/electron": ["@craft-agent/electron@workspace:apps/electron"],
 
-    "@craft-agent/marketing": ["@craft-agent/marketing@workspace:apps/marketing"],
-
     "@craft-agent/mermaid": ["@craft-agent/mermaid@workspace:packages/mermaid"],
 
     "@craft-agent/session-mcp-server": ["@craft-agent/session-mcp-server@workspace:packages/session-mcp-server"],
@@ -485,6 +507,8 @@
     "@craft-agent/ui": ["@craft-agent/ui@workspace:packages/ui"],
 
     "@craft-agent/viewer": ["@craft-agent/viewer@workspace:apps/viewer"],
+
+    "@craft-agent/web": ["@craft-agent/web@workspace:apps/web"],
 
     "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
 
@@ -1138,8 +1162,6 @@
 
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
-    "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
-
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -1148,11 +1170,15 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
     "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
 
     "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
+    "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
@@ -1160,11 +1186,17 @@
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
 
+    "@types/express": ["@types/express@4.17.25", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^4.17.33", "@types/qs": "*", "@types/serve-static": "^1" } }, "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@4.19.8", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA=="],
+
     "@types/fs-extra": ["@types/fs-extra@9.0.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
     "@types/http-cache-semantics": ["@types/http-cache-semantics@4.0.4", "", {}, "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
 
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
@@ -1178,7 +1210,11 @@
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
+    "@types/mime": ["@types/mime@1.3.5", "", {}, "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="],
+
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
+    "@types/multer": ["@types/multer@1.4.13", "", { "dependencies": { "@types/express": "*" } }, "sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw=="],
 
     "@types/mysql": ["@types/mysql@2.15.27", "", { "dependencies": { "@types/node": "*" } }, "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA=="],
 
@@ -1192,6 +1228,10 @@
 
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
 
+    "@types/qs": ["@types/qs@6.14.0", "", {}, "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
     "@types/react": ["@types/react@18.3.27", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w=="],
 
     "@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
@@ -1200,13 +1240,13 @@
 
     "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
+    "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
+
+    "@types/serve-static": ["@types/serve-static@1.15.10", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "<1" } }, "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw=="],
+
     "@types/shell-quote": ["@types/shell-quote@1.7.5", "", {}, "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw=="],
 
-    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
-
     "@types/tedious": ["@types/tedious@4.0.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
-
-    "@types/three": ["@types/three@0.170.0", "", { "dependencies": { "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": "*", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~0.18.1" } }, "sha512-CUm2uckq+zkCY7ZbFpviRttY+6f9fvwm6YqSqPfA5K22s9w7R4VnA3rzJse8kHVvuzLcTx+CjNCs2NYe0QFAyg=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -1214,7 +1254,7 @@
 
     "@types/verror": ["@types/verror@1.10.11", "", {}, "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg=="],
 
-    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
@@ -1246,13 +1286,11 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.1.2", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.53", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ=="],
 
-    "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
-
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
 
     "abbrev": ["abbrev@3.0.1", "", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
 
-    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+    "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
@@ -1284,6 +1322,8 @@
 
     "app-builder-lib": ["app-builder-lib@26.4.0", "", { "dependencies": { "@develar/schema-utils": "~2.6.5", "@electron/asar": "3.4.1", "@electron/fuses": "^1.8.0", "@electron/notarize": "2.5.0", "@electron/osx-sign": "1.3.3", "@electron/rebuild": "4.0.1", "@electron/universal": "2.0.3", "@malept/flatpak-bundler": "^0.4.0", "@types/fs-extra": "9.0.13", "async-exit-hook": "^2.0.1", "builder-util": "26.3.4", "builder-util-runtime": "9.5.1", "chromium-pickle-js": "^0.2.0", "ci-info": "4.3.1", "debug": "^4.3.4", "dotenv": "^16.4.5", "dotenv-expand": "^11.0.6", "ejs": "^3.1.8", "electron-publish": "26.3.4", "fs-extra": "^10.1.0", "hosted-git-info": "^4.1.0", "isbinaryfile": "^5.0.0", "jiti": "^2.4.2", "js-yaml": "^4.1.0", "json5": "^2.2.3", "lazy-val": "^1.0.5", "minimatch": "^10.0.3", "plist": "3.1.0", "resedit": "^1.7.0", "semver": "~7.7.3", "tar": "^6.1.12", "temp-file": "^3.4.0", "tiny-async-pool": "1.3.0", "which": "^5.0.0" }, "peerDependencies": { "dmg-builder": "26.4.0", "electron-builder-squirrel-windows": "26.4.0" } }, "sha512-Uas6hNe99KzP3xPWxh5LGlH8kWIVjZixzmMJHNB9+6hPyDpjc7NQMkVgi16rQDdpCFy22ZU5sp8ow7tvjeMgYQ=="],
 
+    "append-field": ["append-field@1.0.0", "", {}, "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="],
+
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
@@ -1291,6 +1331,8 @@
     "arity-n": ["arity-n@1.0.4", "", {}, "sha512-fExL2kFDC1Q2DUOx3whE/9KoN66IzkY4b4zUHUBFM1ojEYjZZYDcUW3bek/ufGionX9giIKDC5redH2IlGqcQQ=="],
 
     "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
+
+    "array-flatten": ["array-flatten@1.1.1", "", {}, "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="],
 
     "array-includes": ["array-includes@3.1.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.0", "es-object-atoms": "^1.1.1", "get-intrinsic": "^1.3.0", "is-string": "^1.1.1", "math-intrinsics": "^1.1.0" } }, "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ=="],
 
@@ -1348,7 +1390,7 @@
 
     "bluebird": ["bluebird@3.7.2", "", {}, "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="],
 
-    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+    "body-parser": ["body-parser@1.20.4", "", { "dependencies": { "bytes": "~3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "~1.2.0", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "on-finished": "~2.4.1", "qs": "~6.14.0", "raw-body": "~2.5.3", "type-is": "~1.6.18", "unpipe": "~1.0.0" } }, "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
@@ -1377,6 +1419,8 @@
     "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
+    "busboy": ["busboy@1.6.0", "", { "dependencies": { "streamsearch": "^1.1.0" } }, "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA=="],
 
     "byte-counter": ["byte-counter@0.1.0", "", {}, "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ=="],
 
@@ -1462,9 +1506,11 @@
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
+    "concat-stream": ["concat-stream@1.6.2", "", { "dependencies": { "buffer-from": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^2.2.2", "typedarray": "^0.0.6" } }, "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw=="],
+
     "concurrently": ["concurrently@9.2.1", "", { "dependencies": { "chalk": "4.1.2", "rxjs": "7.8.2", "shell-quote": "1.8.3", "supports-color": "8.1.1", "tree-kill": "1.2.2", "yargs": "17.7.2" }, "bin": { "conc": "dist/bin/concurrently.js", "concurrently": "dist/bin/concurrently.js" } }, "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng=="],
 
-    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+    "content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
@@ -1472,7 +1518,7 @@
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
-    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+    "cookie-signature": ["cookie-signature@1.0.7", "", {}, "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="],
 
     "core-util-is": ["core-util-is@1.0.2", "", {}, "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="],
 
@@ -1539,6 +1585,8 @@
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
@@ -1694,7 +1742,7 @@
 
     "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
 
-    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+    "express": ["express@4.22.1", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.3", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.14.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g=="],
 
     "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
 
@@ -1738,7 +1786,7 @@
 
     "filtrex": ["filtrex@3.1.0", "", {}, "sha512-mHzZ2wUISETF1OaEcNRiGz1ljuIV8c/C9td9qyAZ+wTwigkAk5RO9YrCxQKk5H9v7joDRFIBik9U5RTK9eXZ/A=="],
 
-    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+    "finalhandler": ["finalhandler@1.3.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "statuses": "~2.0.2", "unpipe": "~1.0.0" } }, "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -1770,7 +1818,7 @@
 
     "framer-motion": ["framer-motion@12.26.2", "", { "dependencies": { "motion-dom": "^12.26.2", "motion-utils": "^12.24.10", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-lflOQEdjquUi9sCg5Y1LrsZDlsjrHw7m0T9Yedvnk7Bnhqfkc89/Uha10J3CFhkL+TCZVCRw9eUGyM/lyYhXQA=="],
 
-    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+    "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
 
     "fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
@@ -2198,13 +2246,13 @@
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
-    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+    "media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
 
-    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+    "merge-descriptors": ["merge-descriptors@1.0.3", "", {}, "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="],
 
     "merge-refs": ["merge-refs@2.0.0", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg=="],
 
-    "meshoptimizer": ["meshoptimizer@0.18.1", "", {}, "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw=="],
+    "methods": ["methods@1.1.2", "", {}, "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
@@ -2262,7 +2310,7 @@
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
-    "mime": ["mime@2.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="],
+    "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
 
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
@@ -2290,7 +2338,7 @@
 
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
-    "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
+    "mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
 
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
@@ -2302,13 +2350,15 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "multer": ["multer@1.4.5-lts.2", "", { "dependencies": { "append-field": "^1.0.0", "busboy": "^1.0.0", "concat-stream": "^1.5.2", "mkdirp": "^0.5.4", "object-assign": "^4.1.1", "type-is": "^1.6.4", "xtend": "^4.0.0" } }, "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A=="],
+
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "nanolru": ["nanolru@1.0.0", "", {}, "sha512-GyQkE8M32pULhQk7Sko5raoIbPalAk90ICG+An4fq6fCsFHsP6fB2K46WGXVdoJpy4SGMnZ/EKbo123fZJomWg=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+    "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
@@ -2422,7 +2472,7 @@
 
     "path-scurry": ["path-scurry@2.0.1", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA=="],
 
-    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+    "path-to-regexp": ["path-to-regexp@0.1.12", "", {}, "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="],
 
     "path-type": ["path-type@2.0.0", "", { "dependencies": { "pify": "^2.0.0" } }, "sha512-dUnb5dXUf+kzhC/W/F4e5/SkluXIFf5VUHolW1Eg1irn1hGWjPGdsRcvYJ1nD6lhk8Ir7VM0bHJKsYTx8Jx9OQ=="],
 
@@ -2522,10 +2572,6 @@
 
     "react-resizable-panels": ["react-resizable-panels@3.0.6", "", { "peerDependencies": { "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew=="],
 
-    "react-router": ["react-router@7.13.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw=="],
-
-    "react-router-dom": ["react-router-dom@7.13.0", "", { "dependencies": { "react-router": "7.13.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g=="],
-
     "react-simple-code-editor": ["react-simple-code-editor@0.14.1", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-BR5DtNRy+AswWJECyA17qhUDvrrCZ6zXOCfkQY5zSmb96BVUbpVAv03WpcjcwtCwiLbIANx3gebHOcXYn1EHow=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
@@ -2620,13 +2666,11 @@
 
     "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
 
-    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+    "send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
 
     "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
-    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
+    "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -2700,6 +2744,8 @@
 
     "stoppable": ["stoppable@1.1.0", "", {}, "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="],
 
+    "streamsearch": ["streamsearch@1.1.0", "", {}, "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="],
+
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -2760,8 +2806,6 @@
 
     "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
 
-    "three": ["three@0.170.0", "", {}, "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ=="],
-
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
@@ -2808,7 +2852,7 @@
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
-    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+    "type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
@@ -2817,6 +2861,8 @@
     "typed-array-byte-offset": ["typed-array-byte-offset@1.0.4", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "for-each": "^0.3.3", "gopd": "^1.2.0", "has-proto": "^1.2.0", "is-typed-array": "^1.1.15", "reflect.getprototypeof": "^1.0.9" } }, "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ=="],
 
     "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
+
+    "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -2867,6 +2913,8 @@
     "utf8-byte-length": ["utf8-byte-length@1.0.5", "", {}, "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
 
     "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
 
@@ -2928,7 +2976,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
@@ -2994,8 +3042,6 @@
 
     "@craft-agent/bridge-mcp-server/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
 
-    "@craft-agent/marketing/@paper-design/shaders-react": ["@paper-design/shaders-react@0.0.70", "", { "dependencies": { "@paper-design/shaders": "0.0.70" }, "peerDependencies": { "@types/react": "^18 || ^19", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-9DkZXcyehorsZzyWnYV3OOO1i7rF7a5CkasjKJ1h1tLlY3JJLUEX9W+gZz7JgWHyvCimUu0OSq1sbHTb2OntRw=="],
-
     "@craft-agent/session-mcp-server/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
 
     "@craft-agent/session-mcp-server/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -3035,6 +3081,8 @@
     "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "@modelcontextprotocol/sdk/express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -3146,9 +3194,9 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+    "@types/serve-static/@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
 
-    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "ajv-formats/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
@@ -3172,7 +3220,11 @@
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+    "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "body-parser/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
+
+    "body-parser/raw-body": ["raw-body@2.5.3", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "unpipe": "~1.0.0" } }, "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA=="],
 
     "cacache/fs-minipass": ["fs-minipass@3.0.3", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw=="],
 
@@ -3200,6 +3252,8 @@
 
     "electron/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
 
+    "electron-publish/mime": ["mime@2.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="],
+
     "electron-winstaller/@electron/asar": ["@electron/asar@3.4.1", "", { "dependencies": { "commander": "^5.0.0", "glob": "^7.1.6", "minimatch": "^3.0.4" }, "bin": { "asar": "bin/asar.js" } }, "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA=="],
 
     "electron-winstaller/@electron/windows-sign": ["@electron/windows-sign@1.2.2", "", { "dependencies": { "cross-dirname": "^0.1.0", "debug": "^4.3.4", "fs-extra": "^11.1.1", "minimist": "^1.2.8", "postject": "^1.0.0-alpha.6" }, "bin": { "electron-windows-sign": "bin/electron-windows-sign.js" } }, "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ=="],
@@ -3218,9 +3272,11 @@
 
     "eslint_d/eslint": ["eslint@7.32.0", "", { "dependencies": { "@babel/code-frame": "7.12.11", "@eslint/eslintrc": "^0.4.3", "@humanwhocodes/config-array": "^0.5.0", "ajv": "^6.10.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.2", "debug": "^4.0.1", "doctrine": "^3.0.0", "enquirer": "^2.3.5", "escape-string-regexp": "^4.0.0", "eslint-scope": "^5.1.1", "eslint-utils": "^2.1.0", "eslint-visitor-keys": "^2.0.0", "espree": "^7.3.1", "esquery": "^1.4.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^6.0.1", "functional-red-black-tree": "^1.0.1", "glob-parent": "^5.1.2", "globals": "^13.6.0", "ignore": "^4.0.6", "import-fresh": "^3.0.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "js-yaml": "^3.13.1", "json-stable-stringify-without-jsonify": "^1.0.1", "levn": "^0.4.1", "lodash.merge": "^4.6.2", "minimatch": "^3.0.4", "natural-compare": "^1.4.0", "optionator": "^0.9.1", "progress": "^2.0.0", "regexpp": "^3.1.0", "semver": "^7.2.1", "strip-ansi": "^6.0.0", "strip-json-comments": "^3.1.0", "table": "^6.0.9", "text-table": "^0.2.0", "v8-compile-cache": "^2.0.3" }, "bin": { "eslint": "bin/eslint.js" } }, "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA=="],
 
-    "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+    "express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "filelist/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
+
+    "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "flat-cache/keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
@@ -3239,6 +3295,8 @@
     "jake/async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
     "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "make-fetch-happen/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "mammoth/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
@@ -3270,7 +3328,7 @@
 
     "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
-    "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+    "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "read-pkg-up/find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "^2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
 
@@ -3286,7 +3344,9 @@
 
     "roarr/sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
-    "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+    "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+
+    "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
@@ -3294,13 +3354,9 @@
 
     "table/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
-    "temp/mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
-
     "tiny-async-pool/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
     "to-regex-range/is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
-
-    "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "unzipper/fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
 
@@ -3327,8 +3383,6 @@
     "@babel/highlight/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
 
     "@craft-agent/bridge-mcp-server/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
-
-    "@craft-agent/marketing/@paper-design/shaders-react/@paper-design/shaders": ["@paper-design/shaders@0.0.70", "", {}, "sha512-d9LQcmPoEm3+Y6Vuz7cvsnSelfTM5QD63yQ3ddLM7QGYfoSjbQiU38kzjA4O3oCQ6zv23o/IGvGA8k9S/L+kZw=="],
 
     "@craft-agent/session-mcp-server/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -3358,6 +3412,8 @@
 
     "@electron/rebuild/tar/minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
 
+    "@electron/rebuild/tar/mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
+
     "@electron/rebuild/tar/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "@electron/universal/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
@@ -3369,6 +3425,28 @@
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "@modelcontextprotocol/sdk/express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "@modelcontextprotocol/sdk/express/body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "@modelcontextprotocol/sdk/express/content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "@modelcontextprotocol/sdk/express/cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "@modelcontextprotocol/sdk/express/finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "@modelcontextprotocol/sdk/express/fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "@modelcontextprotocol/sdk/express/merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "@modelcontextprotocol/sdk/express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "@modelcontextprotocol/sdk/express/send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "@modelcontextprotocol/sdk/express/serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "@modelcontextprotocol/sdk/express/type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "@prisma/instrumentation/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
 
@@ -3412,8 +3490,6 @@
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
-    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "app-builder-lib/@electron/asar/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
@@ -3438,7 +3514,11 @@
 
     "app-builder-lib/tar/minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
 
+    "app-builder-lib/tar/mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
+
     "app-builder-lib/tar/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "body-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "cacache/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
@@ -3492,9 +3572,11 @@
 
     "eslint_d/eslint/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
-    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+    "express/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "fluent-ffmpeg/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -3514,11 +3596,9 @@
 
     "read-pkg-up/find-up/locate-path": ["locate-path@2.0.0", "", { "dependencies": { "p-locate": "^2.0.0", "path-exists": "^3.0.0" } }, "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA=="],
 
-    "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+    "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "table/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
@@ -3537,6 +3617,14 @@
     "@electron/rebuild/got/decompress-response/mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
     "@electron/rebuild/tar/minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "@modelcontextprotocol/sdk/express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "@modelcontextprotocol/sdk/express/body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "@modelcontextprotocol/sdk/express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "@modelcontextprotocol/sdk/express/type-is/media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
     "@sentry/bundler-plugin-core/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 


### PR DESCRIPTION
## Summary
This PR adds a complete web server implementation for Craft Agents, enabling remote access to the application via HTTP and WebSocket. The web server translates Electron IPC handlers into REST API endpoints and uses WebSocket for real-time event broadcasting, allowing the same React frontend to run in a browser instead of Electron.

## Key Changes

### Server Implementation (`apps/web/src/server/`)
- **app.ts**: Express.js application with 1100+ lines implementing REST API endpoints for:
  - Session management (create, delete, send messages, cancel processing)
  - Workspace management (create, switch, configure settings)
  - File operations (read, write, search with path validation)
  - LLM connections and authentication
  - Labels, views, and workspace configuration
  - System information and debug endpoints
  
- **broadcaster.ts**: WebSocket server that replaces Electron's `WindowManager.broadcastToAll()`, broadcasting events to all connected clients

- **web-window-manager.ts**: Adapter class implementing the `WindowManager` interface for web context, routing broadcasts through WebSocket instead of Electron IPC

- **logger.ts**: Simple console-based logger replacing Electron's electron-log

- **index.ts**: Server entry point that sets up HTTP server, WebSocket broadcaster, and Express app

### Client Implementation (`apps/web/src/client/`)
- **api.ts**: Complete implementation of `ElectronAPI` interface using HTTP fetch and WebSocket:
  - HTTP helper functions (GET, POST, PUT, DELETE, PATCH)
  - WebSocket client with automatic reconnection and exponential backoff
  - All session, workspace, file, auth, and settings operations mapped to REST endpoints
  - Event listeners using WebSocket instead of Electron IPC channels

- **main.tsx**: Web app entry point that sets up the web API before rendering the React app

- **index.html**: HTML template for the web app

### Configuration
- **vite.config.ts**: Vite configuration for building the web client, with path aliases pointing to the Electron renderer components for code reuse

- **package.json**: Web app package with dev/build scripts and dependencies

## Notable Implementation Details

- **Code Reuse**: The web app reuses 100% of the React components from the Electron renderer by aliasing `@` to the electron renderer directory
- **Security**: File path operations include validation to prevent path traversal attacks, restricting access to home and temp directories
- **Session Manager Integration**: Reuses the existing `SessionManager` from the Electron app with a web-compatible window manager adapter
- **Real-time Events**: WebSocket broadcasts replace Electron IPC for session events, theme changes, and other real-time updates
- **Graceful Degradation**: Web-specific features (like file dialogs, native file operations) are stubbed or adapted for browser constraints

https://claude.ai/code/session_01CApDgQqk4k1vKq7iGkjFWb