### PR TITLE
feat: right-click working directory to open in IDE/Finder with configurable editor

### DIFF
--- a/apps/electron/resources/config-defaults.json
+++ b/apps/electron/resources/config-defaults.json
@@ -8,7 +8,8 @@
     "sendMessageKey": "enter",
     "spellCheck": false,
     "keepAwakeWhileRunning": false,
-    "richToolDescriptions": true
+    "richToolDescriptions": true,
+    "defaultEditor": "vscode"
   },
   "workspaceDefaults": {
     "thinkingLevel": "think",

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1434,6 +1434,54 @@ export function registerIpcHandlers(sessionManager: SessionManager, windowManage
     }
   })
 
+  // Shell operations - open directory in configured editor (VS Code, Cursor, etc.)
+  ipcMain.handle(IPC_CHANNELS.OPEN_IN_EDITOR, async (_event, path: string) => {
+    try {
+      const absolutePath = resolve(path)
+      const safePath = await validateFilePath(absolutePath)
+
+      const { getDefaultEditor } = await import('@craft-agent/shared/config/storage')
+      const editor = getDefaultEditor()
+
+      const editorCommands: Record<string, { cli: string; macApp: string }> = {
+        vscode: { cli: 'code', macApp: 'Visual Studio Code' },
+        cursor: { cli: 'cursor', macApp: 'Cursor' },
+        windsurf: { cli: 'windsurf', macApp: 'Windsurf' },
+      }
+
+      const editorConfig = editorCommands[editor]
+      if (!editorConfig) {
+        throw new Error(`Unsupported editor: ${editor}`)
+      }
+
+      // Try CLI first
+      try {
+        execSync(`${editorConfig.cli} "${safePath}"`, {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          timeout: 5000,
+        })
+        return
+      } catch {
+        // CLI not in PATH, try platform-specific fallback
+      }
+
+      // macOS fallback: use open -a
+      if (process.platform === 'darwin') {
+        execSync(`open -a "${editorConfig.macApp}" "${safePath}"`, {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          timeout: 5000,
+        })
+        return
+      }
+
+      throw new Error(`${editorConfig.cli} command not found. Install the "${editorConfig.cli}" CLI from your editor settings.`)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      ipcLog.error('openInEditor error:', message)
+      throw new Error(`Failed to open in editor: ${message}`)
+    }
+  })
+
   // Menu actions from renderer (for unified Craft menu)
   ipcMain.handle(IPC_CHANNELS.MENU_QUIT, () => {
     app.quit()
@@ -3768,6 +3816,18 @@ export function registerIpcHandlers(sessionManager: SessionManager, windowManage
   ipcMain.handle(IPC_CHANNELS.APPEARANCE_SET_RICH_TOOL_DESCRIPTIONS, async (_event, enabled: boolean) => {
     const { setRichToolDescriptions } = await import('@craft-agent/shared/config/storage')
     setRichToolDescriptions(enabled)
+  })
+
+  // Get default editor setting
+  ipcMain.handle(IPC_CHANNELS.EDITOR_GET_DEFAULT, async () => {
+    const { getDefaultEditor } = await import('@craft-agent/shared/config/storage')
+    return getDefaultEditor()
+  })
+
+  // Set default editor setting
+  ipcMain.handle(IPC_CHANNELS.EDITOR_SET_DEFAULT, async (_event, editor: string) => {
+    const { setDefaultEditor } = await import('@craft-agent/shared/config/storage')
+    setDefaultEditor(editor)
   })
 
   // Update app badge count

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -121,6 +121,7 @@ const api: ElectronAPI = {
   openUrl: (url: string) => ipcRenderer.invoke(IPC_CHANNELS.OPEN_URL, url),
   openFile: (path: string) => ipcRenderer.invoke(IPC_CHANNELS.OPEN_FILE, path),
   showInFolder: (path: string) => ipcRenderer.invoke(IPC_CHANNELS.SHOW_IN_FOLDER, path),
+  openInEditor: (path: string) => ipcRenderer.invoke(IPC_CHANNELS.OPEN_IN_EDITOR, path),
 
   // Menu event listeners
   onMenuNewChat: (callback: () => void) => {
@@ -460,6 +461,12 @@ const api: ElectronAPI = {
     ipcRenderer.invoke(IPC_CHANNELS.APPEARANCE_GET_RICH_TOOL_DESCRIPTIONS) as Promise<boolean>,
   setRichToolDescriptions: (enabled: boolean) =>
     ipcRenderer.invoke(IPC_CHANNELS.APPEARANCE_SET_RICH_TOOL_DESCRIPTIONS, enabled),
+
+  // Editor settings
+  getDefaultEditor: () =>
+    ipcRenderer.invoke(IPC_CHANNELS.EDITOR_GET_DEFAULT) as Promise<string>,
+  setDefaultEditor: (editor: string) =>
+    ipcRenderer.invoke(IPC_CHANNELS.EDITOR_SET_DEFAULT, editor),
 
   updateBadgeCount: (count: number) =>
     ipcRenderer.invoke(IPC_CHANNELS.BADGE_UPDATE, count),

--- a/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
+++ b/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
@@ -11,6 +11,8 @@ import {
   ChevronDown,
   Loader2,
   AlertCircle,
+  ExternalLink,
+  FolderOpen,
 } from 'lucide-react'
 import { Icon_Home, Icon_Folder } from '@craft-agent/ui'
 
@@ -51,6 +53,12 @@ import {
   StyledDropdownMenuSubContent,
 } from '@/components/ui/styled-dropdown'
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
+import {
+  ContextMenu,
+  ContextMenuTrigger,
+  StyledContextMenuContent,
+  StyledContextMenuItem,
+} from '@/components/ui/styled-context-menu'
 import { cn } from '@/lib/utils'
 import { isMac, PATH_SEP, getPathBasename } from '@/lib/platform'
 import { applySmartTypography } from '@/lib/smart-typography'
@@ -2032,6 +2040,26 @@ function WorkingDirectoryBadge({
     }
   }
 
+  const handleOpenInEditor = async () => {
+    if (!workingDirectory || !window.electronAPI) return
+    try {
+      await window.electronAPI.openInEditor(workingDirectory)
+    } catch (error) {
+      toast.error('Failed to open in editor', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      })
+    }
+  }
+
+  const handleShowInFinder = async () => {
+    if (!workingDirectory || !window.electronAPI) return
+    try {
+      await window.electronAPI.showInFolder(workingDirectory)
+    } catch (error) {
+      toast.error('Failed to show in Finder')
+    }
+  }
+
   // Filter out current directory from recent list and sort alphabetically by folder name
   const filteredRecent = recentDirs
     .filter(p => p !== workingDirectory)
@@ -2056,7 +2084,10 @@ function WorkingDirectoryBadge({
   const MENU_ITEM_STYLE = 'flex cursor-pointer select-none items-center gap-2 rounded-[6px] px-3 py-1.5 text-[13px] outline-none'
 
   return (
-    <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+    <ContextMenu>
+      <ContextMenuTrigger disabled={!workingDirectory} asChild>
+        <span className="shrink min-w-0 overflow-hidden" onContextMenu={(e) => { if (workingDirectory) e.nativeEvent.stopImmediatePropagation() }}>
+          <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
       <PopoverTrigger asChild>
         <span className="shrink min-w-0 overflow-hidden">
           <FreeFormInputContextBadge
@@ -2163,6 +2194,19 @@ function WorkingDirectoryBadge({
           </div>
         </CommandPrimitive>
       </PopoverContent>
-    </Popover>
+          </Popover>
+        </span>
+      </ContextMenuTrigger>
+      <StyledContextMenuContent>
+        <StyledContextMenuItem onSelect={handleOpenInEditor}>
+          <ExternalLink className="h-3.5 w-3.5" />
+          Open in Editor
+        </StyledContextMenuItem>
+        <StyledContextMenuItem onSelect={handleShowInFinder}>
+          <FolderOpen className="h-3.5 w-3.5" />
+          Show in Finder
+        </StyledContextMenuItem>
+      </StyledContextMenuContent>
+    </ContextMenu>
   )
 }

--- a/apps/electron/src/renderer/pages/settings/AppSettingsPage.tsx
+++ b/apps/electron/src/renderer/pages/settings/AppSettingsPage.tsx
@@ -25,6 +25,7 @@ import {
   SettingsCard,
   SettingsRow,
   SettingsToggle,
+  SettingsMenuSelectRow,
 } from '@/components/settings'
 import { useUpdateChecker } from '@/hooks/useUpdateChecker'
 
@@ -44,6 +45,9 @@ export default function AppSettingsPage() {
   // Power state
   const [keepAwakeEnabled, setKeepAwakeEnabled] = useState(false)
 
+  // Editor state
+  const [defaultEditor, setDefaultEditor] = useState('vscode')
+
   // Auto-update state
   const updateChecker = useUpdateChecker()
   const [isCheckingForUpdates, setIsCheckingForUpdates] = useState(false)
@@ -61,12 +65,14 @@ export default function AppSettingsPage() {
   const loadSettings = useCallback(async () => {
     if (!window.electronAPI) return
     try {
-      const [notificationsOn, keepAwakeOn] = await Promise.all([
+      const [notificationsOn, keepAwakeOn, editorValue] = await Promise.all([
         window.electronAPI.getNotificationsEnabled(),
         window.electronAPI.getKeepAwakeWhileRunning(),
+        window.electronAPI.getDefaultEditor(),
       ])
       setNotificationsEnabled(notificationsOn)
       setKeepAwakeEnabled(keepAwakeOn)
+      setDefaultEditor(editorValue)
     } catch (error) {
       console.error('Failed to load settings:', error)
     }
@@ -84,6 +90,11 @@ export default function AppSettingsPage() {
   const handleKeepAwakeEnabledChange = useCallback(async (enabled: boolean) => {
     setKeepAwakeEnabled(enabled)
     await window.electronAPI.setKeepAwakeWhileRunning(enabled)
+  }, [])
+
+  const handleDefaultEditorChange = useCallback((value: string) => {
+    setDefaultEditor(value)
+    window.electronAPI.setDefaultEditor(value)
   }, [])
 
   return (
@@ -113,6 +124,23 @@ export default function AppSettingsPage() {
                     description="Prevent the screen from turning off while sessions are running."
                     checked={keepAwakeEnabled}
                     onCheckedChange={handleKeepAwakeEnabledChange}
+                  />
+                </SettingsCard>
+              </SettingsSection>
+
+              {/* Editor */}
+              <SettingsSection title="Editor" description="Default editor for opening working directories.">
+                <SettingsCard>
+                  <SettingsMenuSelectRow
+                    label="Default editor"
+                    description="Editor used when opening directories from the working directory menu"
+                    value={defaultEditor}
+                    onValueChange={handleDefaultEditorChange}
+                    options={[
+                      { value: 'vscode', label: 'VS Code', description: 'Visual Studio Code' },
+                      { value: 'cursor', label: 'Cursor', description: 'Cursor AI Editor' },
+                      { value: 'windsurf', label: 'Windsurf', description: 'Windsurf Editor' },
+                    ]}
                   />
                 </SettingsCard>
               </SettingsSection>

--- a/apps/electron/src/shared/types.ts
+++ b/apps/electron/src/shared/types.ts
@@ -650,6 +650,7 @@ export const IPC_CHANNELS = {
   OPEN_URL: 'shell:openUrl',
   OPEN_FILE: 'shell:openFile',
   SHOW_IN_FOLDER: 'shell:showInFolder',
+  OPEN_IN_EDITOR: 'shell:openInEditor',
 
   // Menu actions (main → renderer)
   MENU_NEW_CHAT: 'menu:newChat',
@@ -826,6 +827,10 @@ export const IPC_CHANNELS = {
   APPEARANCE_GET_RICH_TOOL_DESCRIPTIONS: 'appearance:getRichToolDescriptions',
   APPEARANCE_SET_RICH_TOOL_DESCRIPTIONS: 'appearance:setRichToolDescriptions',
 
+  // Editor settings
+  EDITOR_GET_DEFAULT: 'editor:getDefault',
+  EDITOR_SET_DEFAULT: 'editor:setDefault',
+
   BADGE_UPDATE: 'badge:update',
   BADGE_CLEAR: 'badge:clear',
   BADGE_SET_ICON: 'badge:setIcon',
@@ -957,6 +962,7 @@ export interface ElectronAPI {
   openUrl(url: string): Promise<void>
   openFile(path: string): Promise<void>
   showInFolder(path: string): Promise<void>
+  openInEditor(path: string): Promise<void>
 
   // Menu event listeners
   onMenuNewChat(callback: () => void): () => void
@@ -1129,6 +1135,10 @@ export interface ElectronAPI {
   // Appearance settings
   getRichToolDescriptions(): Promise<boolean>
   setRichToolDescriptions(enabled: boolean): Promise<void>
+
+  // Editor settings
+  getDefaultEditor(): Promise<string>
+  setDefaultEditor(editor: string): Promise<void>
 
   updateBadgeCount(count: number): Promise<void>
   clearBadgeCount(): Promise<void>

--- a/docs/feats/20260223-open-directory-in-finder-and-ide.md
+++ b/docs/feats/20260223-open-directory-in-finder-and-ide.md
@@ -1,0 +1,47 @@
+# 工作目录右键菜单：在 Finder 中显示 & 在 IDE 中打开
+
+## 功能概述
+
+在输入框下方的工作目录徽章上，右键点击可弹出上下文菜单，支持：
+
+- **Open in Editor** — 使用用户配置的默认 IDE 打开当前工作目录
+- **Show in Finder** — 在系统文件管理器中显示当前工作目录
+
+仅在已设置工作目录时，右键菜单才会生效。
+
+## 默认 IDE 配置
+
+用户可在 **Settings → App → Editor** 中选择默认编辑器：
+
+
+| 编辑器      | 标识         | CLI 命令     | macOS 备选                       |
+| -------- | ---------- | ---------- | ------------------------------ |
+| VS Code  | `vscode`   | `code`     | `open -a "Visual Studio Code"` |
+| Cursor   | `cursor`   | `cursor`   | `open -a "Cursor"`             |
+| Windsurf | `windsurf` | `windsurf` | `open -a "Windsurf"`           |
+
+
+默认值为 VS Code。设置持久化在 `~/.craft-agent/config.json` 的 `defaultEditor` 字段中。
+
+## 涉及文件
+
+### 配置存储层
+
+- `packages/shared/src/config/config-defaults-schema.ts` — `ConfigDefaults.defaults` 新增 `defaultEditor: string`
+- `apps/electron/resources/config-defaults.json` — 默认值 `"defaultEditor": "vscode"`
+- `packages/shared/src/config/storage.ts` — `StoredConfig` 新增 `defaultEditor` 字段，新增 `getDefaultEditor()` / `setDefaultEditor()` 函数
+
+### IPC 通道
+
+- `apps/electron/src/shared/types.ts` — 新增 `OPEN_IN_EDITOR`、`EDITOR_GET_DEFAULT`、`EDITOR_SET_DEFAULT` 通道及 `ElectronAPI` 接口方法
+- `apps/electron/src/preload/index.ts` — 新增 `openInEditor`、`getDefaultEditor`、`setDefaultEditor` 桥接方法
+
+### 主进程
+
+- `apps/electron/src/main/ipc.ts` — 新增 `OPEN_IN_EDITOR` handler（先尝试 CLI，macOS fallback `open -a`，5 秒超时），新增 `EDITOR_GET_DEFAULT` / `EDITOR_SET_DEFAULT` handler
+
+### 渲染进程
+
+- `apps/electron/src/renderer/pages/settings/AppSettingsPage.tsx` — App 设置页新增 "Editor" section，使用 `SettingsMenuSelectRow` 下拉选择
+- `apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx` — `WorkingDirectoryBadge` 组件外层包裹 Radix `ContextMenu`，右键显示菜单；使用 `stopImmediatePropagation` 阻止 Electron 开发模式下的默认右键菜单
+

--- a/packages/shared/src/config/config-defaults-schema.ts
+++ b/packages/shared/src/config/config-defaults-schema.ts
@@ -19,6 +19,7 @@ export interface ConfigDefaults {
     spellCheck: boolean;
     keepAwakeWhileRunning: boolean;
     richToolDescriptions: boolean;
+    defaultEditor: string;
   };
   workspaceDefaults: {
     thinkingLevel: ThinkingLevel;

--- a/packages/shared/src/config/storage.ts
+++ b/packages/shared/src/config/storage.ts
@@ -70,6 +70,8 @@ export interface StoredConfig {
   keepAwakeWhileRunning?: boolean;  // Prevent screen sleep while sessions are running (default: false)
   // Tool metadata
   richToolDescriptions?: boolean;  // Add intent/action metadata to all tool calls (default: true)
+  // Default editor for "Open in Editor" actions (default: 'vscode')
+  defaultEditor?: string;
   // Windows: path to Git Bash (bash.exe) for the SDK subprocess
   gitBashPath?: string;
 }
@@ -341,6 +343,29 @@ export function setRichToolDescriptions(enabled: boolean): void {
   const config = loadStoredConfig();
   if (!config) return;
   config.richToolDescriptions = enabled;
+  saveConfig(config);
+}
+
+/**
+ * Get the default editor for "Open in Editor" actions.
+ * Defaults to 'vscode' if not set.
+ */
+export function getDefaultEditor(): string {
+  const config = loadStoredConfig();
+  if (config?.defaultEditor !== undefined) {
+    return config.defaultEditor;
+  }
+  const defaults = loadConfigDefaults();
+  return defaults.defaults.defaultEditor;
+}
+
+/**
+ * Set the default editor for "Open in Editor" actions.
+ */
+export function setDefaultEditor(editor: string): void {
+  const config = loadStoredConfig();
+  if (!config) return;
+  config.defaultEditor = editor;
   saveConfig(config);
 }
 


### PR DESCRIPTION
## Summary

- Right-click the working directory badge (below the input box) to show a context menu with **Open in Editor** and **Show in Finder** options
- Add a **Default Editor** setting in Settings → App → Editor, supporting VS Code (default), Cursor, and Windsurf
- The editor preference is persisted in `~/.craft-agent/config.json`

## Motivation

When working with a project directory, it's common to want to quickly open it in your preferred IDE or reveal it in Finder. Currently there's no way to do this directly from the working directory badge — users have to manually open their editor and navigate to the folder. This feature saves that friction.

## Changes

### Config storage layer
- `packages/shared/src/config/config-defaults-schema.ts` — add `defaultEditor: string` to defaults type
- `apps/electron/resources/config-defaults.json` — add `"defaultEditor": "vscode"` default
- `packages/shared/src/config/storage.ts` — add `defaultEditor` to `StoredConfig`, add `getDefaultEditor()` / `setDefaultEditor()`

### IPC channels
- `apps/electron/src/shared/types.ts` — add `OPEN_IN_EDITOR`, `EDITOR_GET_DEFAULT`, `EDITOR_SET_DEFAULT` channels and `ElectronAPI` methods
- `apps/electron/src/preload/index.ts` — add bridge methods

### Main process
- `apps/electron/src/main/ipc.ts` — add `OPEN_IN_EDITOR` handler (tries CLI first, macOS `open -a` fallback, 5s timeout), add editor settings handlers

### Renderer
- `apps/electron/src/renderer/pages/settings/AppSettingsPage.tsx` — add Editor section with `SettingsMenuSelectRow`
- `apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx` — wrap `WorkingDirectoryBadge` with Radix `ContextMenu`, add `stopImmediatePropagation` to prevent Electron dev menu override

## Test plan
- [ ] Set a working directory, right-click the badge → context menu appears with two options
- [ ] Click "Open in Editor" → opens directory in configured IDE
- [ ] Click "Show in Finder" → reveals directory in Finder
- [ ] No working directory set → right-click does nothing
- [ ] Settings → App → Editor → change editor, verify persistence after restart
- [ ] Editor not installed → toast error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)