### PR TITLE
infra: add dev container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "Craft Agents",
+  "image": "oven/bun:latest",
+  "remoteUser": "root",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "mounts": [
+    "source=claude-config,target=/root/.claude,type=volume",
+    "source=claude-bin,target=/root/.local/bin,type=volume",
+    "source=gh-config,target=/root/.config/gh,type=volume"
+  ],
+  "remoteEnv": {
+    "PATH": "/root/.local/bin:${containerEnv:PATH}"
+  },
+  "postCreateCommand": "apt-get update && apt-get install -y jq ripgrep && curl -fsSL https://claude.ai/install.sh | bash && echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> /root/.bashrc && bun install"
+}


### PR DESCRIPTION
Universal IDE-agnostic dev container using oven/bun base image with git, GitHub CLI, Claude Code, jq, and ripgrep. Named volumes persist auth state across rebuilds.

I kept it basic on purpose so it would be less opinionated (except for the Claude installation) and works with broader IDE set

This container is for development only. The electron app testing still have to be done from a host with GUI support