### PR TITLE
Add OpenAIAgent backend with native OpenAI API support

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -90,6 +90,11 @@ const BUILT_IN_CONNECTION_TEMPLATES: Record<string, {
     providerType: 'copilot',
     authType: 'oauth',
   },
+  'openai-direct': {
+    name: (h) => h ? 'OpenAI-Compatible (Custom Endpoint)' : 'OpenAI (API Key)',
+    providerType: 'openai_direct',
+    authType: (h) => h ? 'api_key_with_endpoint' : 'api_key',
+  },
 }
 
 /**

--- a/bun.lock
+++ b/bun.lock
@@ -82,7 +82,7 @@
     },
     "apps/electron": {
       "name": "@craft-agent/electron",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/shared": "workspace:*",
@@ -118,32 +118,9 @@
         "vaul": "^1.1.2",
       },
     },
-    "apps/marketing": {
-      "name": "@craft-agent/marketing",
-      "version": "0.4.3",
-      "dependencies": {
-        "@craft-agent/ui": "workspace:*",
-        "@paper-design/shaders-react": "^0.0.70",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-router-dom": "^7.13.0",
-        "shiki": "^3.21.0",
-        "three": "^0.170.0",
-      },
-      "devDependencies": {
-        "@tailwindcss/vite": "^4.1.18",
-        "@types/react": "^18.3.0",
-        "@types/react-dom": "^18.3.0",
-        "@types/three": "^0.170.0",
-        "@vitejs/plugin-react": "^5.1.2",
-        "tailwindcss": "^4.1.18",
-        "typescript": "^5.0.0",
-        "vite": "^6.2.4",
-      },
-    },
     "apps/viewer": {
       "name": "@craft-agent/viewer",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/ui": "workspace:*",
@@ -170,7 +147,7 @@
     },
     "packages/bridge-mcp-server": {
       "name": "@craft-agent/bridge-mcp-server",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "bin": {
         "bridge-mcp-server": "./dist/index.js",
       },
@@ -183,11 +160,11 @@
     },
     "packages/codex-types": {
       "name": "@craft-agent/codex-types",
-      "version": "0.4.3",
+      "version": "0.4.8",
     },
     "packages/core": {
       "name": "@craft-agent/core",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "devDependencies": {
         "@types/uuid": "^11.0.0",
       },
@@ -199,7 +176,7 @@
     },
     "packages/mermaid": {
       "name": "@craft-agent/mermaid",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "dependencies": {
         "elkjs": "^0.11.0",
       },
@@ -209,7 +186,7 @@
     },
     "packages/session-mcp-server": {
       "name": "@craft-agent/session-mcp-server",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "bin": {
         "session-mcp-server": "./dist/index.js",
       },
@@ -224,7 +201,7 @@
     },
     "packages/session-tools-core": {
       "name": "@craft-agent/session-tools-core",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "dependencies": {
         "@craft-agent/mermaid": "workspace:*",
         "gray-matter": "^4.0.3",
@@ -236,7 +213,7 @@
     },
     "packages/shared": {
       "name": "@craft-agent/shared",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "dependencies": {
         "@craft-agent/codex-types": "workspace:*",
         "@craft-agent/core": "workspace:*",
@@ -262,7 +239,7 @@
     },
     "packages/ui": {
       "name": "@craft-agent/ui",
-      "version": "0.4.3",
+      "version": "0.4.8",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/mermaid": "workspace:*",
@@ -471,8 +448,6 @@
     "@craft-agent/core": ["@craft-agent/core@workspace:packages/core"],
 
     "@craft-agent/electron": ["@craft-agent/electron@workspace:apps/electron"],
-
-    "@craft-agent/marketing": ["@craft-agent/marketing@workspace:apps/marketing"],
 
     "@craft-agent/mermaid": ["@craft-agent/mermaid@workspace:packages/mermaid"],
 
@@ -1138,8 +1113,6 @@
 
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
-    "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
-
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -1202,19 +1175,13 @@
 
     "@types/shell-quote": ["@types/shell-quote@1.7.5", "", {}, "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw=="],
 
-    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
-
     "@types/tedious": ["@types/tedious@4.0.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
-
-    "@types/three": ["@types/three@0.170.0", "", { "dependencies": { "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": "*", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~0.18.1" } }, "sha512-CUm2uckq+zkCY7ZbFpviRttY+6f9fvwm6YqSqPfA5K22s9w7R4VnA3rzJse8kHVvuzLcTx+CjNCs2NYe0QFAyg=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
     "@types/verror": ["@types/verror@1.10.11", "", {}, "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg=="],
-
-    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
@@ -1245,8 +1212,6 @@
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.1.2", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.53", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ=="],
-
-    "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
 
@@ -2204,8 +2169,6 @@
 
     "merge-refs": ["merge-refs@2.0.0", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg=="],
 
-    "meshoptimizer": ["meshoptimizer@0.18.1", "", {}, "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw=="],
-
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
@@ -2522,10 +2485,6 @@
 
     "react-resizable-panels": ["react-resizable-panels@3.0.6", "", { "peerDependencies": { "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew=="],
 
-    "react-router": ["react-router@7.13.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw=="],
-
-    "react-router-dom": ["react-router-dom@7.13.0", "", { "dependencies": { "react-router": "7.13.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g=="],
-
     "react-simple-code-editor": ["react-simple-code-editor@0.14.1", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-BR5DtNRy+AswWJECyA17qhUDvrrCZ6zXOCfkQY5zSmb96BVUbpVAv03WpcjcwtCwiLbIANx3gebHOcXYn1EHow=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
@@ -2625,8 +2584,6 @@
     "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -2759,8 +2716,6 @@
     "temp-file": ["temp-file@3.4.0", "", { "dependencies": { "async-exit-hook": "^2.0.1", "fs-extra": "^10.0.0" } }, "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg=="],
 
     "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
-
-    "three": ["three@0.170.0", "", {}, "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ=="],
 
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
 
@@ -2993,8 +2948,6 @@
     "@babel/highlight/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "@craft-agent/bridge-mcp-server/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
-
-    "@craft-agent/marketing/@paper-design/shaders-react": ["@paper-design/shaders-react@0.0.70", "", { "dependencies": { "@paper-design/shaders": "0.0.70" }, "peerDependencies": { "@types/react": "^18 || ^19", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-9DkZXcyehorsZzyWnYV3OOO1i7rF7a5CkasjKJ1h1tLlY3JJLUEX9W+gZz7JgWHyvCimUu0OSq1sbHTb2OntRw=="],
 
     "@craft-agent/session-mcp-server/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
 
@@ -3270,8 +3223,6 @@
 
     "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
-    "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
-
     "read-pkg-up/find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "^2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
 
     "readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
@@ -3327,8 +3278,6 @@
     "@babel/highlight/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
 
     "@craft-agent/bridge-mcp-server/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
-
-    "@craft-agent/marketing/@paper-design/shaders-react/@paper-design/shaders": ["@paper-design/shaders@0.0.70", "", {}, "sha512-d9LQcmPoEm3+Y6Vuz7cvsnSelfTM5QD63yQ3ddLM7QGYfoSjbQiU38kzjA4O3oCQ6zv23o/IGvGA8k9S/L+kZw=="],
 
     "@craft-agent/session-mcp-server/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/packages/shared/src/agent/backend/factory.ts
+++ b/packages/shared/src/agent/backend/factory.ts
@@ -18,6 +18,7 @@ import type { AgentBackend, BackendConfig, AgentProvider, LlmProviderType, LlmAu
 import { ClaudeAgent } from '../claude-agent.ts';
 import { CodexAgent } from '../codex-agent.ts';
 import { CopilotAgent } from '../copilot-agent.ts';
+import { OpenAIAgent } from '../openai-agent.ts';
 import {
   getLlmConnection,
   getDefaultLlmConnection,
@@ -86,6 +87,10 @@ export function createBackend(config: BackendConfig): AgentBackend {
       // Auth is handled via ChatGPT Plus OAuth (native flow)
       return new CodexAgent(config);
 
+    case 'openai_direct':
+      // OpenAIAgent: native OpenAI API via openai npm package, no Codex binary required
+      return new OpenAIAgent(config);
+
     case 'copilot':
       // CopilotAgent implements AgentBackend directly
       // Auth is handled via GitHub OAuth
@@ -108,7 +113,7 @@ export const createAgent = createBackend;
  * @returns Array of provider identifiers that have working implementations
  */
 export function getAvailableProviders(): AgentProvider[] {
-  return ['anthropic', 'openai', 'copilot'];
+  return ['anthropic', 'openai', 'openai_direct', 'copilot'];
 }
 
 /**
@@ -144,10 +149,14 @@ export function providerTypeToAgentProvider(providerType: LlmProviderType): Agen
     case 'vertex':     // Vertex uses Anthropic SDK with different auth
       return 'anthropic';
 
-    // OpenAI/Codex backends
+    // OpenAI/Codex backends (require Codex binary)
     case 'openai':
     case 'openai_compat':
       return 'openai';
+
+    // Native OpenAI API backend (no Codex binary required)
+    case 'openai_direct':
+      return 'openai_direct';
 
     // GitHub Copilot backend
     case 'copilot':

--- a/packages/shared/src/agent/core/mcp-client-manager.ts
+++ b/packages/shared/src/agent/core/mcp-client-manager.ts
@@ -1,0 +1,262 @@
+/**
+ * MCP Client Manager
+ *
+ * Manages connections to MCP (Model Context Protocol) servers and bridges their
+ * tools into OpenAI function-calling format. Used by OpenAIAgent (and any future
+ * non-Anthropic backends) to integrate sources and session tools.
+ *
+ * Responsibilities:
+ * - Connect/disconnect MCP clients for each configured server
+ * - Discover and cache the tools available from each server
+ * - Convert MCP tool schemas to OpenAI ChatCompletionTool format
+ * - Route tool-call requests to the correct MCP server and return results
+ *
+ * Each MCP server is identified by a slug (its key in the mcpServers map).
+ * Tool names are prefixed with the server slug to avoid collisions:
+ *   "github__search_repositories" → calls the "search_repositories" tool on
+ *   the "github" MCP server.
+ *
+ * The double-underscore separator (`__`) was chosen because it is unlikely to
+ * appear in real tool names while remaining readable.
+ */
+
+import { CraftMcpClient } from '../../mcp/client.ts';
+import type { SdkMcpServerConfig } from '../backend/types.ts';
+import { createLogger } from '../../utils/debug.ts';
+
+const log = createLogger('mcp-client-manager');
+
+// ============================================================
+// Types
+// ============================================================
+
+/** OpenAI function parameter schema (JSON Schema subset) */
+interface JsonSchema {
+  type?: string;
+  description?: string;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  items?: JsonSchema;
+  enum?: unknown[];
+  [key: string]: unknown;
+}
+
+/** OpenAI ChatCompletionTool format */
+export interface OpenAITool {
+  type: 'function';
+  function: {
+    name: string;
+    description?: string;
+    parameters: JsonSchema;
+  };
+}
+
+/** Internal record of a tool and which server handles it */
+interface RegisteredTool {
+  serverSlug: string;
+  originalName: string;
+  schema: OpenAITool;
+}
+
+// ============================================================
+// McpClientManager
+// ============================================================
+
+export class McpClientManager {
+  /** Active MCP clients keyed by server slug */
+  private clients: Map<string, CraftMcpClient> = new Map();
+
+  /** Tools discovered from all servers, keyed by prefixed tool name */
+  private tools: Map<string, RegisteredTool> = new Map();
+
+  /** Whether tools have been loaded from all current servers */
+  private toolsLoaded = false;
+
+  /**
+   * Connect to the given set of MCP servers.
+   * Disconnects any servers no longer in the map, connects new ones.
+   * Call this whenever the source servers change (setSourceServers).
+   */
+  async update(mcpServers: Record<string, SdkMcpServerConfig>): Promise<void> {
+    const incoming = new Set(Object.keys(mcpServers));
+    const existing = new Set(this.clients.keys());
+
+    // Disconnect removed servers
+    for (const slug of existing) {
+      if (!incoming.has(slug)) {
+        await this.disconnectServer(slug);
+      }
+    }
+
+    // Connect new servers
+    for (const [slug, config] of Object.entries(mcpServers)) {
+      if (!existing.has(slug)) {
+        await this.connectServer(slug, config);
+      }
+    }
+
+    // Invalidate tool cache so next listTools() re-fetches
+    this.toolsLoaded = false;
+    this.tools.clear();
+  }
+
+  /**
+   * Get all available tools in OpenAI function-calling format.
+   * Fetches from all connected MCP servers on first call (then cached until update()).
+   */
+  async listTools(): Promise<OpenAITool[]> {
+    if (this.toolsLoaded) {
+      return Array.from(this.tools.values()).map(t => t.schema);
+    }
+
+    this.tools.clear();
+    for (const [slug, client] of this.clients) {
+      try {
+        const mcpTools = await client.listTools();
+        for (const mcpTool of mcpTools) {
+          const prefixedName = `${slug}__${mcpTool.name}`;
+          const schema: OpenAITool = {
+            type: 'function',
+            function: {
+              name: prefixedName,
+              description: mcpTool.description,
+              parameters: (mcpTool.inputSchema as JsonSchema) ?? { type: 'object', properties: {} },
+            },
+          };
+          this.tools.set(prefixedName, {
+            serverSlug: slug,
+            originalName: mcpTool.name,
+            schema,
+          });
+        }
+        log.debug(`Loaded ${mcpTools.length} tools from MCP server: ${slug}`);
+      } catch (err) {
+        log.warn(`Failed to list tools from MCP server "${slug}": ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    this.toolsLoaded = true;
+    return Array.from(this.tools.values()).map(t => t.schema);
+  }
+
+  /**
+   * Call a tool by its prefixed name (e.g. "github__search_repositories").
+   * Returns the tool result as a string.
+   */
+  async callTool(prefixedName: string, args: Record<string, unknown>): Promise<string> {
+    const registered = this.tools.get(prefixedName);
+    if (!registered) {
+      throw new Error(`Unknown MCP tool: ${prefixedName}`);
+    }
+    const client = this.clients.get(registered.serverSlug);
+    if (!client) {
+      throw new Error(`MCP server "${registered.serverSlug}" is not connected`);
+    }
+    try {
+      const result = await client.callTool(registered.originalName, args);
+      return formatMcpResult(result);
+    } catch (err) {
+      throw new Error(
+        `MCP tool call failed (${prefixedName}): ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  /**
+   * Check if a given tool name (prefixed) is handled by this MCP manager.
+   * Use this before calling callTool() to distinguish MCP vs built-in tools.
+   */
+  isMcpTool(toolName: string): boolean {
+    return this.tools.has(toolName);
+  }
+
+  /**
+   * Disconnect all MCP servers and clean up resources.
+   */
+  async destroy(): Promise<void> {
+    for (const slug of [...this.clients.keys()]) {
+      await this.disconnectServer(slug);
+    }
+    this.tools.clear();
+    this.toolsLoaded = false;
+  }
+
+  // ============================================================
+  // Private helpers
+  // ============================================================
+
+  private async connectServer(slug: string, config: SdkMcpServerConfig): Promise<void> {
+    try {
+      const client = createClientFromConfig(config);
+      await client.connect();
+      this.clients.set(slug, client);
+      log.debug(`Connected to MCP server: ${slug}`);
+    } catch (err) {
+      log.warn(`Failed to connect to MCP server "${slug}": ${err instanceof Error ? err.message : String(err)}`);
+      // Non-fatal: agent can still function without this server's tools
+    }
+  }
+
+  private async disconnectServer(slug: string): Promise<void> {
+    const client = this.clients.get(slug);
+    if (!client) return;
+    try {
+      await client.close();
+    } catch {
+      // Ignore close errors
+    }
+    this.clients.delete(slug);
+    // Remove tools from this server
+    for (const [prefixedName, info] of this.tools) {
+      if (info.serverSlug === slug) {
+        this.tools.delete(prefixedName);
+      }
+    }
+    log.debug(`Disconnected from MCP server: ${slug}`);
+  }
+}
+
+// ============================================================
+// Utilities
+// ============================================================
+
+/**
+ * Map a SdkMcpServerConfig to a CraftMcpClient.
+ */
+function createClientFromConfig(config: SdkMcpServerConfig): CraftMcpClient {
+  if (config.type === 'stdio') {
+    return new CraftMcpClient({
+      transport: 'stdio',
+      command: config.command,
+      args: config.args,
+      env: config.env,
+    });
+  }
+  // http or sse
+  return new CraftMcpClient({
+    transport: 'http',
+    url: config.url,
+    headers: config.headers,
+  });
+}
+
+/**
+ * Convert an MCP tool call result to a string.
+ * MCP results are arrays of content blocks (text, image, etc.).
+ */
+function formatMcpResult(result: unknown): string {
+  if (typeof result === 'string') return result;
+  if (!result || typeof result !== 'object') return String(result);
+
+  // MCP CallToolResult shape: { content: Array<{ type, text?, ... }>, isError?: boolean }
+  const r = result as { content?: unknown[]; isError?: boolean };
+  if (Array.isArray(r.content)) {
+    const texts = r.content
+      .filter((block): block is { type: string; text: string } =>
+        typeof block === 'object' && block !== null && 'text' in block
+      )
+      .map(block => block.text);
+    return texts.join('\n') || JSON.stringify(result);
+  }
+  return JSON.stringify(result);
+}

--- a/packages/shared/src/agent/core/tool-executor.ts
+++ b/packages/shared/src/agent/core/tool-executor.ts
@@ -1,0 +1,564 @@
+/**
+ * Tool Executor
+ *
+ * In-process implementations of the standard development tools used by AI agents.
+ * These tools mirror the tools provided by @anthropic-ai/claude-agent-sdk but are
+ * implemented independently so that non-Anthropic backends (e.g. OpenAIAgent) can
+ * use them without the Claude SDK dependency.
+ *
+ * Tools implemented:
+ * - Read       — read a file (with optional line range)
+ * - Write      — write/create a file
+ * - Edit       — string-replace edit of a file
+ * - Bash       — execute a shell command (with PermissionManager check)
+ * - Glob       — find files by glob pattern
+ * - Grep       — search file contents
+ *
+ * Each tool exposes:
+ *  - execute(args, context) → Promise<string>   (result text or error text)
+ *  - schema: OpenAI.Chat.ChatCompletionTool     (for sending to the LLM)
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { PermissionManager } from './permission-manager.ts';
+
+const execFileAsync = promisify(execFile);
+
+// ============================================================
+// Context passed to each tool execute() call
+// ============================================================
+
+export interface ToolExecutionContext {
+  /** Working directory for the session */
+  workingDirectory: string;
+  /** Permission manager for Bash checks */
+  permissionManager: PermissionManager;
+  /**
+   * Called when Bash requires interactive user approval.
+   * Returns true if the user granted permission, false to deny.
+   */
+  requestPermission: (requestId: string, command: string, description: string) => Promise<boolean>;
+}
+
+// ============================================================
+// Tool result type
+// ============================================================
+
+export interface ToolExecutionResult {
+  /** Result text to send back to the LLM */
+  text: string;
+  /** Whether the execution produced an error (tool still returns, just flagged) */
+  isError: boolean;
+}
+
+// ============================================================
+// Read Tool
+// ============================================================
+
+export interface ReadArgs {
+  file_path: string;
+  offset?: number;
+  limit?: number;
+}
+
+export async function executeRead(
+  args: ReadArgs,
+  context: ToolExecutionContext
+): Promise<ToolExecutionResult> {
+  const filePath = resolveFilePath(args.file_path, context.workingDirectory);
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const lines = content.split('\n');
+    const offset = args.offset ?? 0;
+    const limit = args.limit ?? lines.length;
+    const slice = lines.slice(offset, offset + limit);
+    // Format with line numbers (1-indexed)
+    const numbered = slice
+      .map((line, i) => `${String(offset + i + 1).padStart(6)} ${line}`)
+      .join('\n');
+    return { text: numbered, isError: false };
+  } catch (err) {
+    return { text: `Error reading file: ${errorMessage(err)}`, isError: true };
+  }
+}
+
+export const READ_SCHEMA = {
+  type: 'function' as const,
+  function: {
+    name: 'Read',
+    description: 'Read a file from the local filesystem. Returns the file contents with line numbers.',
+    parameters: {
+      type: 'object',
+      properties: {
+        file_path: {
+          type: 'string',
+          description: 'Absolute path to the file to read.',
+        },
+        offset: {
+          type: 'number',
+          description: 'Line number to start reading from (0-indexed). Defaults to 0.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum number of lines to read.',
+        },
+      },
+      required: ['file_path'],
+    },
+  },
+};
+
+// ============================================================
+// Write Tool
+// ============================================================
+
+export interface WriteArgs {
+  file_path: string;
+  content: string;
+}
+
+export async function executeWrite(
+  args: WriteArgs,
+  context: ToolExecutionContext
+): Promise<ToolExecutionResult> {
+  const filePath = resolveFilePath(args.file_path, context.workingDirectory);
+  const permResult = context.permissionManager.evaluateToolCall('Write', { file_path: args.file_path });
+  if (permResult.requiresPermission) {
+    const requestId = `write-${Date.now()}`;
+    const granted = await context.requestPermission(
+      requestId,
+      args.file_path,
+      permResult.description ?? `Write to file: ${args.file_path}`
+    );
+    if (!granted) {
+      return { text: `Permission denied: write not allowed in current mode`, isError: true };
+    }
+  } else if (!permResult.allowed) {
+    return { text: `Permission denied: ${permResult.reason ?? 'write not allowed'}`, isError: true };
+  }
+  try {
+    const dir = path.dirname(filePath);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(filePath, args.content, 'utf-8');
+    return { text: `File written successfully: ${args.file_path}`, isError: false };
+  } catch (err) {
+    return { text: `Error writing file: ${errorMessage(err)}`, isError: true };
+  }
+}
+
+export const WRITE_SCHEMA = {
+  type: 'function' as const,
+  function: {
+    name: 'Write',
+    description: 'Write content to a file on the local filesystem. Creates the file and any parent directories if they do not exist.',
+    parameters: {
+      type: 'object',
+      properties: {
+        file_path: {
+          type: 'string',
+          description: 'Absolute path to the file to write.',
+        },
+        content: {
+          type: 'string',
+          description: 'Content to write to the file.',
+        },
+      },
+      required: ['file_path', 'content'],
+    },
+  },
+};
+
+// ============================================================
+// Edit Tool
+// ============================================================
+
+export interface EditArgs {
+  file_path: string;
+  old_string: string;
+  new_string: string;
+  replace_all?: boolean;
+}
+
+export async function executeEdit(
+  args: EditArgs,
+  context: ToolExecutionContext
+): Promise<ToolExecutionResult> {
+  const filePath = resolveFilePath(args.file_path, context.workingDirectory);
+  const permResult = context.permissionManager.evaluateToolCall('Edit', { file_path: args.file_path });
+  if (permResult.requiresPermission) {
+    const requestId = `edit-${Date.now()}`;
+    const granted = await context.requestPermission(
+      requestId,
+      args.file_path,
+      permResult.description ?? `Edit file: ${args.file_path}`
+    );
+    if (!granted) {
+      return { text: `Permission denied: edit not allowed in current mode`, isError: true };
+    }
+  } else if (!permResult.allowed) {
+    return { text: `Permission denied: ${permResult.reason ?? 'edit not allowed'}`, isError: true };
+  }
+  try {
+    let content = fs.readFileSync(filePath, 'utf-8');
+    const occurrences = content.split(args.old_string).length - 1;
+    if (occurrences === 0) {
+      return { text: `Error: old_string not found in file: ${args.file_path}`, isError: true };
+    }
+    if (!args.replace_all && occurrences > 1) {
+      return {
+        text: `Error: old_string is not unique in file (${occurrences} occurrences). Use replace_all: true to replace all occurrences.`,
+        isError: true,
+      };
+    }
+    if (args.replace_all) {
+      content = content.split(args.old_string).join(args.new_string);
+    } else {
+      content = content.replace(args.old_string, args.new_string);
+    }
+    fs.writeFileSync(filePath, content, 'utf-8');
+    return { text: `File edited successfully: ${args.file_path}`, isError: false };
+  } catch (err) {
+    return { text: `Error editing file: ${errorMessage(err)}`, isError: true };
+  }
+}
+
+export const EDIT_SCHEMA = {
+  type: 'function' as const,
+  function: {
+    name: 'Edit',
+    description: 'Perform an exact string replacement in a file. The old_string must uniquely match in the file unless replace_all is true.',
+    parameters: {
+      type: 'object',
+      properties: {
+        file_path: {
+          type: 'string',
+          description: 'Absolute path to the file to edit.',
+        },
+        old_string: {
+          type: 'string',
+          description: 'The exact string to find and replace.',
+        },
+        new_string: {
+          type: 'string',
+          description: 'The replacement string.',
+        },
+        replace_all: {
+          type: 'boolean',
+          description: 'If true, replace all occurrences. Default is false (requires old_string to be unique).',
+        },
+      },
+      required: ['file_path', 'old_string', 'new_string'],
+    },
+  },
+};
+
+// ============================================================
+// Bash Tool
+// ============================================================
+
+export interface BashArgs {
+  command: string;
+  timeout?: number;
+}
+
+const DEFAULT_BASH_TIMEOUT_MS = 120_000; // 2 minutes
+
+export async function executeBash(
+  args: BashArgs,
+  context: ToolExecutionContext
+): Promise<ToolExecutionResult> {
+  const permResult = context.permissionManager.evaluateToolCall('Bash', { command: args.command });
+  if (permResult.requiresPermission) {
+    const requestId = `bash-${Date.now()}`;
+    const granted = await context.requestPermission(
+      requestId,
+      args.command,
+      permResult.description ?? `Run command: ${args.command}`
+    );
+    if (!granted) {
+      return { text: `Permission denied: command not allowed in current mode`, isError: true };
+    }
+  } else if (!permResult.allowed) {
+    return { text: `Permission denied: ${permResult.reason ?? 'command blocked by permission mode'}`, isError: true };
+  }
+
+  const timeout = args.timeout ?? DEFAULT_BASH_TIMEOUT_MS;
+
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      'bash',
+      ['-c', args.command],
+      {
+        cwd: context.workingDirectory,
+        timeout,
+        maxBuffer: 10 * 1024 * 1024, // 10 MB
+        env: { ...process.env },
+      }
+    );
+    const output = [stdout, stderr].filter(Boolean).join('\n');
+    return { text: output || '(no output)', isError: false };
+  } catch (err: unknown) {
+    const execErr = err as { stdout?: string; stderr?: string; message?: string };
+    const output = [execErr.stdout, execErr.stderr, execErr.message].filter(Boolean).join('\n');
+    return { text: output || `Command failed: ${errorMessage(err)}`, isError: true };
+  }
+}
+
+export const BASH_SCHEMA = {
+  type: 'function' as const,
+  function: {
+    name: 'Bash',
+    description: 'Execute a bash command in the current working directory. Use for running tests, build commands, git operations, and other shell tasks.',
+    parameters: {
+      type: 'object',
+      properties: {
+        command: {
+          type: 'string',
+          description: 'The bash command to execute.',
+        },
+        timeout: {
+          type: 'number',
+          description: 'Timeout in milliseconds (max 600000). Defaults to 120000.',
+        },
+      },
+      required: ['command'],
+    },
+  },
+};
+
+// ============================================================
+// Glob Tool
+// ============================================================
+
+export interface GlobArgs {
+  pattern: string;
+  path?: string;
+}
+
+export async function executeGlob(
+  args: GlobArgs,
+  context: ToolExecutionContext
+): Promise<ToolExecutionResult> {
+  const searchDir = args.path
+    ? resolveFilePath(args.path, context.workingDirectory)
+    : context.workingDirectory;
+  try {
+    // Use Bun's native Glob if available, otherwise fall back to rg --files
+    if (typeof Bun !== 'undefined' && Bun.Glob) {
+      const glob = new Bun.Glob(args.pattern);
+      const matches: string[] = [];
+      for await (const file of glob.scan({ cwd: searchDir, absolute: true, followSymlinks: false })) {
+        if (!file.includes('/node_modules/') && !file.includes('/.git/')) {
+          matches.push(file);
+        }
+      }
+      if (matches.length === 0) {
+        return { text: 'No files matched the pattern.', isError: false };
+      }
+      return { text: matches.join('\n'), isError: false };
+    }
+    // Fallback: use rg --files with glob filter
+    const rgArgs = ['--files', '--glob', args.pattern, '--', searchDir];
+    const { stdout } = await execFileAsync('rg', rgArgs, {
+      cwd: context.workingDirectory,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    const result = stdout.trim();
+    return { text: result || 'No files matched the pattern.', isError: false };
+  } catch (err: unknown) {
+    const execErr = err as { code?: number };
+    if (execErr.code === 1) {
+      return { text: 'No files matched the pattern.', isError: false };
+    }
+    return { text: `Error running glob: ${errorMessage(err)}`, isError: true };
+  }
+}
+
+export const GLOB_SCHEMA = {
+  type: 'function' as const,
+  function: {
+    name: 'Glob',
+    description: 'Find files matching a glob pattern. Returns a list of matching absolute file paths.',
+    parameters: {
+      type: 'object',
+      properties: {
+        pattern: {
+          type: 'string',
+          description: 'Glob pattern to match files against (e.g. "**/*.ts", "src/**/*.tsx").',
+        },
+        path: {
+          type: 'string',
+          description: 'Directory to search in. Defaults to the current working directory.',
+        },
+      },
+      required: ['pattern'],
+    },
+  },
+};
+
+// ============================================================
+// Grep Tool
+// ============================================================
+
+export interface GrepArgs {
+  pattern: string;
+  path?: string;
+  glob?: string;
+  output_mode?: 'content' | 'files_with_matches' | 'count';
+  context?: number;
+  head_limit?: number;
+  case_insensitive?: boolean;
+}
+
+export async function executeGrep(
+  args: GrepArgs,
+  context: ToolExecutionContext
+): Promise<ToolExecutionResult> {
+  const searchDir = args.path
+    ? resolveFilePath(args.path, context.workingDirectory)
+    : context.workingDirectory;
+
+  // Build ripgrep / grep command
+  const rgArgs: string[] = ['--no-heading'];
+  if (args.case_insensitive) rgArgs.push('-i');
+  const outputMode = args.output_mode ?? 'files_with_matches';
+  if (outputMode === 'files_with_matches') {
+    rgArgs.push('-l');
+  } else if (outputMode === 'count') {
+    rgArgs.push('-c');
+  } else {
+    // content mode: show line numbers
+    rgArgs.push('-n');
+    if (args.context && args.context > 0) {
+      rgArgs.push('-C', String(args.context));
+    }
+  }
+  if (args.glob) {
+    rgArgs.push('--glob', args.glob);
+  }
+  rgArgs.push('--', args.pattern, searchDir);
+
+  try {
+    const { stdout } = await execFileAsync('rg', rgArgs, {
+      cwd: context.workingDirectory,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    let result = stdout.trim();
+    if (args.head_limit && args.head_limit > 0) {
+      const lines = result.split('\n');
+      result = lines.slice(0, args.head_limit).join('\n');
+    }
+    return { text: result || 'No matches found.', isError: false };
+  } catch (err: unknown) {
+    // rg exits with code 1 when no matches (not a real error)
+    const execErr = err as { code?: number; stdout?: string };
+    if (execErr.code === 1) {
+      return { text: 'No matches found.', isError: false };
+    }
+    return { text: `Error running grep: ${errorMessage(err)}`, isError: true };
+  }
+}
+
+export const GREP_SCHEMA = {
+  type: 'function' as const,
+  function: {
+    name: 'Grep',
+    description: 'Search file contents using regex patterns. By default returns a list of files with matches.',
+    parameters: {
+      type: 'object',
+      properties: {
+        pattern: {
+          type: 'string',
+          description: 'Regular expression pattern to search for.',
+        },
+        path: {
+          type: 'string',
+          description: 'File or directory to search in. Defaults to the current working directory.',
+        },
+        glob: {
+          type: 'string',
+          description: 'Glob pattern to filter which files are searched (e.g. "*.ts", "**/*.tsx").',
+        },
+        output_mode: {
+          type: 'string',
+          enum: ['content', 'files_with_matches', 'count'],
+          description: 'Output format. "files_with_matches" returns file paths (default), "content" returns matching lines, "count" returns match counts.',
+        },
+        context: {
+          type: 'number',
+          description: 'Number of context lines to show before and after each match (only for content mode).',
+        },
+        head_limit: {
+          type: 'number',
+          description: 'Limit output to first N lines.',
+        },
+        case_insensitive: {
+          type: 'boolean',
+          description: 'Perform case-insensitive search.',
+        },
+      },
+      required: ['pattern'],
+    },
+  },
+};
+
+// ============================================================
+// Tool registry
+// ============================================================
+
+export type ToolName = 'Read' | 'Write' | 'Edit' | 'Bash' | 'Glob' | 'Grep';
+
+/** All tool schemas — pass directly to OpenAI as the `tools` parameter */
+export const ALL_TOOL_SCHEMAS = [
+  READ_SCHEMA,
+  WRITE_SCHEMA,
+  EDIT_SCHEMA,
+  BASH_SCHEMA,
+  GLOB_SCHEMA,
+  GREP_SCHEMA,
+] as const;
+
+/**
+ * Execute a tool by name with the given arguments.
+ * Returns a ToolExecutionResult regardless of success/failure
+ * so the caller can always send a tool result message back to the LLM.
+ */
+export async function executeTool(
+  toolName: string,
+  args: Record<string, unknown>,
+  context: ToolExecutionContext
+): Promise<ToolExecutionResult> {
+  switch (toolName) {
+    case 'Read':
+      return executeRead(args as unknown as ReadArgs, context);
+    case 'Write':
+      return executeWrite(args as unknown as WriteArgs, context);
+    case 'Edit':
+      return executeEdit(args as unknown as EditArgs, context);
+    case 'Bash':
+      return executeBash(args as unknown as BashArgs, context);
+    case 'Glob':
+      return executeGlob(args as unknown as GlobArgs, context);
+    case 'Grep':
+      return executeGrep(args as unknown as GrepArgs, context);
+    default:
+      return { text: `Unknown tool: ${toolName}`, isError: true };
+  }
+}
+
+// ============================================================
+// Utilities
+// ============================================================
+
+function resolveFilePath(filePath: string, workingDirectory: string): string {
+  if (path.isAbsolute(filePath)) return filePath;
+  return path.resolve(workingDirectory, filePath);
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/packages/shared/src/agent/openai-agent.ts
+++ b/packages/shared/src/agent/openai-agent.ts
@@ -1,0 +1,579 @@
+/**
+ * OpenAI Agent Backend
+ *
+ * Native OpenAI API backend using the openai npm package.
+ * Unlike CodexAgent, this does NOT require the external Codex app-server binary.
+ * Users authenticate with a standard OpenAI API key.
+ *
+ * Supported provider types:
+ *   - 'openai_direct' → api.openai.com with API key
+ *   - (future) also handles 'openai_direct' with custom base URLs for compatible APIs
+ *
+ * Architecture:
+ * - Extends BaseAgent for common state, permissions, sources, prompt building
+ * - Implements the agentic loop in-process: call API → parse tool calls → execute → loop
+ * - Uses ToolExecutor for core dev tools (Read, Write, Edit, Bash, Glob, Grep)
+ * - Uses McpClientManager for MCP source integrations
+ * - Permission requests are surfaced via 'permission_request' AgentEvents and resolved
+ *   through respondToPermission() / a promise-based wait mechanism
+ */
+
+import OpenAI from 'openai';
+import type { AgentEvent } from '@craft-agent/core/types';
+import { BaseAgent } from './base-agent.ts';
+import type { BackendConfig, ChatOptions, SdkMcpServerConfig } from './backend/types.ts';
+import { AbortReason } from './backend/types.ts';
+import type { FileAttachment } from '../utils/files.ts';
+import type { LLMQueryRequest, LLMQueryResult } from './llm-tool.ts';
+import { getCredentialManager } from '../credentials/index.ts';
+import { getLlmConnection } from '../config/storage.ts';
+import { getSystemPrompt } from '../prompts/system.ts';
+import { OPENAI_DIRECT_MODELS } from '../config/models.ts';
+import { McpClientManager } from './core/mcp-client-manager.ts';
+import { executeTool, ALL_TOOL_SCHEMAS } from './core/tool-executor.ts';
+import type { ToolExecutionContext } from './core/tool-executor.ts';
+import { debug } from '../utils/debug.ts';
+import { readFileSync } from 'node:fs';
+
+// ============================================================
+// Constants
+// ============================================================
+
+const DEFAULT_MODEL = OPENAI_DIRECT_MODELS[0]?.id ?? 'gpt-4o';
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const MAX_TOOL_ITERATIONS = 50; // safety limit for tool call loops
+
+// ============================================================
+// OpenAI message types (chat completions)
+// ============================================================
+
+type OpenAIMessage =
+  | OpenAI.Chat.ChatCompletionSystemMessageParam
+  | OpenAI.Chat.ChatCompletionUserMessageParam
+  | OpenAI.Chat.ChatCompletionAssistantMessageParam
+  | OpenAI.Chat.ChatCompletionToolMessageParam;
+
+// ============================================================
+// OpenAIAgent
+// ============================================================
+
+export class OpenAIAgent extends BaseAgent {
+  // OpenAI client (lazily initialized once API key is known)
+  private openaiClient: OpenAI | null = null;
+
+  // Persistent conversation history for this session
+  private messages: OpenAIMessage[] = [];
+
+  // AbortController for the current streaming API call
+  private currentAbortController: AbortController | null = null;
+
+  // AbortReason for forceAbort (non-user-facing)
+  private forceAbortReason: AbortReason | null = null;
+
+  // Whether a chat() call is currently active
+  private _isProcessing = false;
+
+  // MCP manager for source integrations
+  private mcpManager: McpClientManager = new McpClientManager();
+
+  // Pending permission approvals: requestId → { resolve }
+  private pendingPermissions: Map<string, { resolve: (granted: boolean) => void }> = new Map();
+
+  // ============================================================
+  // Constructor
+  // ============================================================
+
+  constructor(config: BackendConfig) {
+    super(config, DEFAULT_MODEL, DEFAULT_CONTEXT_WINDOW);
+    if (!config.isHeadless) {
+      this.startConfigWatcher();
+    }
+  }
+
+  // ============================================================
+  // AgentBackend implementation
+  // ============================================================
+
+  async *chat(
+    message: string,
+    attachments?: FileAttachment[],
+    options?: ChatOptions
+  ): AsyncGenerator<AgentEvent> {
+    if (this._isProcessing) {
+      yield { type: 'error', message: 'Agent is already processing a request' };
+      return;
+    }
+    this._isProcessing = true;
+    this.forceAbortReason = null;
+
+    try {
+      const client = await this.getOrCreateClient();
+
+      // Extract skill mentions from the message (like CodexAgent / CopilotAgent)
+      const { skillContents, cleanMessage } = this.extractSkillContent(message);
+
+      // Build context parts (date/time, permission mode, source state, workspace info)
+      const activeSlugs = this.getActiveSourceSlugs();
+      const contextParts = this.promptBuilder.buildContextParts({
+        permissionMode: this.permissionManager.getPermissionMode(),
+        activeSources: activeSlugs,
+        inactiveSources: this.getAllSources().filter(
+          s => !activeSlugs.includes(s.config.slug)
+        ),
+      });
+
+      // Compose user message text: skills + context + message
+      const userContentParts: string[] = [
+        ...skillContents,
+        ...contextParts,
+        ...(cleanMessage ? [cleanMessage] : []),
+      ];
+
+      // Handle file attachments
+      const userContent = await buildUserContent(
+        userContentParts.join('\n\n'),
+        attachments ?? []
+      );
+
+      // Add user message to history
+      this.messages.push({ role: 'user', content: userContent });
+
+      // Collect all tools: core dev tools + MCP tools
+      const mcpTools = await this.mcpManager.listTools();
+      const allTools: OpenAI.Chat.ChatCompletionTool[] = [
+        ...(ALL_TOOL_SCHEMAS as unknown as OpenAI.Chat.ChatCompletionTool[]),
+        ...mcpTools,
+      ];
+
+      // Build execution context for tool runner
+      const toolContext: ToolExecutionContext = {
+        workingDirectory: this.workingDirectory,
+        permissionManager: this.permissionManager,
+        requestPermission: async (requestId, command, description) => {
+          // Surface permission_request event then wait for respondToPermission()
+          return new Promise<boolean>((resolve) => {
+            this.pendingPermissions.set(requestId, { resolve });
+            // Note: we can't yield here because we're in a callback, not the generator.
+            // The caller (the agentic loop) must observe the permission event via
+            // the onPermissionRequest callback and emit it as an AgentEvent externally.
+            this.onPermissionRequest?.({
+              requestId,
+              toolName: 'Bash',
+              command,
+              description,
+              type: 'bash',
+            });
+          });
+        },
+      };
+
+      // Agentic loop
+      let iterations = 0;
+      while (iterations < MAX_TOOL_ITERATIONS) {
+        iterations++;
+
+        // Check for force abort
+        if (this.forceAbortReason !== null) {
+          this.debug(`[OpenAIAgent] Force aborted: ${this.forceAbortReason}`);
+          return;
+        }
+
+        // Build system prompt on first message only (for caching efficiency)
+        const systemPrompt = getSystemPrompt(
+          undefined,
+          this.config.debugMode,
+          this.config.workspace.rootPath,
+          this.workingDirectory,
+          this.config.systemPromptPreset ?? 'default',
+          'OpenAI'
+        );
+
+        this.currentAbortController = new AbortController();
+        const stream = await client.chat.completions.create(
+          {
+            model: this._model,
+            messages: [
+              { role: 'system', content: systemPrompt },
+              ...this.messages,
+            ],
+            tools: allTools.length > 0 ? allTools : undefined,
+            tool_choice: allTools.length > 0 ? 'auto' : undefined,
+            stream: true,
+          },
+          { signal: this.currentAbortController.signal }
+        );
+
+        // Collect streamed response
+        let assistantText = '';
+        const toolCallsAccumulator: Map<number, {
+          id: string;
+          name: string;
+          argsJson: string;
+        }> = new Map();
+        let finishReason: string | null = null;
+        let turnId: string | undefined;
+
+        try {
+          for await (const chunk of stream) {
+            // Check for force abort mid-stream
+            if (this.forceAbortReason !== null) {
+              this.currentAbortController.abort();
+              return;
+            }
+
+            const choice = chunk.choices[0];
+            if (!choice) continue;
+
+            // Capture turn ID from first chunk
+            if (!turnId && chunk.id) {
+              turnId = chunk.id;
+            }
+
+            const delta = choice.delta;
+
+            // Stream text content
+            if (delta.content) {
+              assistantText += delta.content;
+              yield { type: 'text_delta', text: delta.content, turnId };
+            }
+
+            // Accumulate tool calls (streamed in pieces)
+            if (delta.tool_calls) {
+              for (const tc of delta.tool_calls) {
+                const existing = toolCallsAccumulator.get(tc.index);
+                if (existing) {
+                  existing.argsJson += tc.function?.arguments ?? '';
+                } else {
+                  toolCallsAccumulator.set(tc.index, {
+                    id: tc.id ?? `call_${tc.index}`,
+                    name: tc.function?.name ?? '',
+                    argsJson: tc.function?.arguments ?? '',
+                  });
+                }
+              }
+            }
+
+            finishReason = choice.finish_reason ?? finishReason;
+          }
+        } catch (err: unknown) {
+          if ((err as { name?: string }).name === 'AbortError') {
+            return; // Stream was aborted (user stop or force abort)
+          }
+          yield { type: 'error', message: `Stream error: ${errorMessage(err)}` };
+          return;
+        } finally {
+          this.currentAbortController = null;
+        }
+
+        // Emit complete text
+        if (assistantText) {
+          yield { type: 'text_complete', text: assistantText, turnId };
+        }
+
+        const toolCalls = [...toolCallsAccumulator.values()];
+
+        // Append assistant message to history
+        this.messages.push({
+          role: 'assistant',
+          content: assistantText || null,
+          tool_calls: toolCalls.length > 0
+            ? toolCalls.map(tc => ({
+                id: tc.id,
+                type: 'function' as const,
+                function: { name: tc.name, arguments: tc.argsJson },
+              }))
+            : undefined,
+        });
+
+        // If no tool calls, the turn is complete
+        if (toolCalls.length === 0 || finishReason === 'stop') {
+          break;
+        }
+
+        // Execute tool calls
+        for (const tc of toolCalls) {
+          // Check for force abort before each tool
+          if (this.forceAbortReason !== null) return;
+
+          let toolArgs: Record<string, unknown>;
+          try {
+            toolArgs = JSON.parse(tc.argsJson || '{}');
+          } catch {
+            toolArgs = {};
+          }
+
+          // Emit tool_start
+          yield {
+            type: 'tool_start',
+            toolName: tc.name,
+            toolUseId: tc.id,
+            input: toolArgs,
+            turnId,
+          };
+
+          let resultText: string;
+          let isError = false;
+
+          try {
+            if (this.mcpManager.isMcpTool(tc.name)) {
+              // Route to MCP server
+              resultText = await this.mcpManager.callTool(tc.name, toolArgs);
+            } else {
+              // Execute core tool in-process
+              const result = await executeTool(tc.name, toolArgs, toolContext);
+              resultText = result.text;
+              isError = result.isError;
+
+              // Handle session MCP tool completions (SubmitPlan, auth triggers)
+              if (!isError) {
+                this.handleSessionMcpToolCompletion(tc.name, toolArgs);
+              }
+            }
+          } catch (err) {
+            resultText = `Tool execution error: ${errorMessage(err)}`;
+            isError = true;
+          }
+
+          // Emit tool_result
+          yield {
+            type: 'tool_result',
+            toolUseId: tc.id,
+            toolName: tc.name,
+            result: resultText,
+            isError,
+            input: toolArgs,
+            turnId,
+          };
+
+          // Add tool result to history
+          this.messages.push({
+            role: 'tool',
+            tool_call_id: tc.id,
+            content: resultText,
+          });
+
+          // Check if force abort was triggered by a tool (e.g., SubmitPlan)
+          if (this.forceAbortReason !== null) return;
+        }
+      }
+
+      if (iterations >= MAX_TOOL_ITERATIONS) {
+        yield { type: 'error', message: `Exceeded maximum tool iteration limit (${MAX_TOOL_ITERATIONS})` };
+      }
+
+      yield { type: 'complete' };
+    } catch (err: unknown) {
+      if ((err as { name?: string }).name === 'AbortError') {
+        return;
+      }
+      yield { type: 'error', message: `Agent error: ${errorMessage(err)}` };
+    } finally {
+      this._isProcessing = false;
+      this.currentAbortController = null;
+    }
+  }
+
+  async abort(reason?: string): Promise<void> {
+    this.debug(`[OpenAIAgent] abort() called: ${reason ?? '(no reason)'}`);
+    this.currentAbortController?.abort();
+    this._isProcessing = false;
+    // Reject all pending permissions
+    for (const [, pending] of this.pendingPermissions) {
+      pending.resolve(false);
+    }
+    this.pendingPermissions.clear();
+  }
+
+  forceAbort(reason: AbortReason): void {
+    this.debug(`[OpenAIAgent] forceAbort(${reason})`);
+    this.forceAbortReason = reason;
+    this.currentAbortController?.abort();
+    // Reject all pending permissions
+    for (const [, pending] of this.pendingPermissions) {
+      pending.resolve(false);
+    }
+    this.pendingPermissions.clear();
+  }
+
+  isProcessing(): boolean {
+    return this._isProcessing;
+  }
+
+  respondToPermission(requestId: string, allowed: boolean, _alwaysAllow?: boolean): void {
+    const pending = this.pendingPermissions.get(requestId);
+    if (!pending) {
+      this.debug(`[OpenAIAgent] respondToPermission: unknown requestId ${requestId}`);
+      return;
+    }
+    this.pendingPermissions.delete(requestId);
+    pending.resolve(allowed);
+  }
+
+  // ============================================================
+  // Source (MCP) Management
+  // ============================================================
+
+  override setSourceServers(
+    mcpServers: Record<string, SdkMcpServerConfig>,
+    _apiServers: Record<string, unknown>,
+    intendedSlugs?: string[]
+  ): void {
+    super.setSourceServers(mcpServers, _apiServers, intendedSlugs);
+    // Update MCP manager asynchronously; errors are non-fatal
+    this.mcpManager.update(mcpServers).catch(err => {
+      this.debug(`[OpenAIAgent] MCP update error: ${errorMessage(err)}`);
+    });
+  }
+
+  // ============================================================
+  // Simple completions (title generation, summarization, call_llm)
+  // ============================================================
+
+  async runMiniCompletion(prompt: string): Promise<string | null> {
+    try {
+      const result = await this.queryLlm({ prompt });
+      return result.text || null;
+    } catch (err) {
+      this.debug(`[OpenAIAgent] runMiniCompletion failed: ${errorMessage(err)}`);
+      return null;
+    }
+  }
+
+  async queryLlm(request: LLMQueryRequest): Promise<LLMQueryResult> {
+    const client = await this.getOrCreateClient();
+    const model = request.model ?? this.config.miniModel ?? this._model;
+
+    const response = await client.chat.completions.create({
+      model,
+      messages: [
+        ...(request.systemPrompt ? [{ role: 'system' as const, content: request.systemPrompt }] : []),
+        { role: 'user', content: request.prompt },
+      ],
+      max_tokens: request.maxTokens,
+      temperature: request.temperature,
+      stream: false,
+    });
+
+    const text = response.choices[0]?.message.content ?? '';
+    return {
+      text,
+      model: response.model,
+      inputTokens: response.usage?.prompt_tokens,
+      outputTokens: response.usage?.completion_tokens,
+    };
+  }
+
+  // ============================================================
+  // Lifecycle
+  // ============================================================
+
+  override destroy(): void {
+    super.destroy();
+    this.currentAbortController?.abort();
+    this.mcpManager.destroy().catch(() => {});
+    this.pendingPermissions.clear();
+  }
+
+  // ============================================================
+  // Private helpers
+  // ============================================================
+
+  private async getOrCreateClient(): Promise<OpenAI> {
+    if (this.openaiClient) return this.openaiClient;
+
+    const { apiKey, baseURL } = await this.resolveCredentials();
+
+    this.openaiClient = new OpenAI({
+      apiKey,
+      baseURL: baseURL ?? undefined,
+    });
+
+    return this.openaiClient;
+  }
+
+  /**
+   * Resolve API key and optional base URL from:
+   * 1. Environment variables (OPENAI_API_KEY / OPENAI_BASE_URL)
+   * 2. Credential manager (stored by onboarding flow under connectionSlug)
+   * 3. Connection config baseUrl field
+   */
+  private async resolveCredentials(): Promise<{ apiKey: string; baseURL: string | null }> {
+    // Check env var first (useful for headless / CI use)
+    const envKey = process.env.OPENAI_API_KEY;
+    if (envKey) {
+      return {
+        apiKey: envKey,
+        baseURL: process.env.OPENAI_BASE_URL ?? null,
+      };
+    }
+
+    // Look up from credential manager using the connection slug
+    const slug = this.config.connectionSlug;
+    if (!slug) {
+      throw new Error('[OpenAIAgent] No connectionSlug set and OPENAI_API_KEY env var is not present');
+    }
+
+    const credManager = getCredentialManager();
+    const apiKey = await credManager.getLlmApiKey(slug);
+    if (!apiKey) {
+      throw new Error(`[OpenAIAgent] No API key found for connection "${slug}". Please re-authenticate in Settings.`);
+    }
+
+    // Get baseURL from connection config (for openai_direct with custom endpoint)
+    const connection = getLlmConnection(slug);
+    const baseURL = connection?.baseUrl ?? null;
+
+    return { apiKey, baseURL };
+  }
+}
+
+// ============================================================
+// Utilities
+// ============================================================
+
+/**
+ * Build the user message content array for the OpenAI API.
+ * Supports text and image attachments.
+ */
+async function buildUserContent(
+  text: string,
+  attachments: FileAttachment[]
+): Promise<string | OpenAI.Chat.ChatCompletionContentPart[]> {
+  if (attachments.length === 0) {
+    return text;
+  }
+
+  const parts: OpenAI.Chat.ChatCompletionContentPart[] = [];
+
+  if (text) {
+    parts.push({ type: 'text', text });
+  }
+
+  for (const attachment of attachments) {
+    if (attachment.type === 'image' && attachment.path) {
+      try {
+        const data = readFileSync(attachment.path);
+        const base64 = data.toString('base64');
+        const mimeType = (attachment.mimeType || 'image/png') as
+          | 'image/jpeg'
+          | 'image/png'
+          | 'image/gif'
+          | 'image/webp';
+        parts.push({
+          type: 'image_url',
+          image_url: { url: `data:${mimeType};base64,${base64}` },
+        });
+      } catch {
+        // Skip unreadable attachments
+        debug(`[OpenAIAgent] Could not read attachment: ${attachment.path}`);
+      }
+    }
+  }
+
+  return parts.length > 0 ? parts : text;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/packages/shared/src/config/llm-connections.ts
+++ b/packages/shared/src/config/llm-connections.ts
@@ -11,6 +11,7 @@ import {
   type ModelDefinition,
   ANTHROPIC_MODELS,
   OPENAI_MODELS,
+  OPENAI_DIRECT_MODELS,
 } from './models';
 
 // ============================================================
@@ -25,6 +26,7 @@ import {
  * - 'anthropic_compat': Anthropic-format compatible endpoints (OpenRouter, etc.)
  * - 'openai': Direct OpenAI API (Codex via app-server)
  * - 'openai_compat': OpenAI-format compatible endpoints (Ollama, OpenRouter, etc.)
+ * - 'openai_direct': Native OpenAI API via openai npm package (no Codex binary required)
  * - 'bedrock': AWS Bedrock (Claude models via AWS)
  * - 'vertex': Google Vertex AI (Claude models via GCP)
  * - 'copilot': GitHub Copilot (via @github/copilot-sdk)
@@ -34,6 +36,7 @@ export type LlmProviderType =
   | 'anthropic_compat'
   | 'openai'
   | 'openai_compat'
+  | 'openai_direct'
   | 'bedrock'
   | 'vertex'
   | 'copilot';
@@ -329,12 +332,12 @@ export function isAnthropicProvider(providerType: LlmProviderType): boolean {
 }
 
 /**
- * Check if a provider type uses OpenAI models (Codex).
+ * Check if a provider type uses OpenAI models (Codex or direct).
  * @param providerType - Provider type to check
  * @returns true if this provider uses OpenAI/Codex models
  */
 export function isOpenAIProvider(providerType: LlmProviderType): boolean {
-  return providerType === 'openai' || providerType === 'openai_compat';
+  return providerType === 'openai' || providerType === 'openai_compat' || providerType === 'openai_direct';
 }
 
 /**
@@ -364,6 +367,11 @@ export function getModelsForProviderType(providerType: LlmProviderType): ModelDe
     return OPENAI_MODELS;
   }
 
+  // OpenAI Direct: standard GPT models via openai npm package
+  if (providerType === 'openai_direct') {
+    return OPENAI_DIRECT_MODELS;
+  }
+
   if (providerType === 'copilot') {
     return []; // Copilot models are dynamic — fetched via listModels(), no hardcoded fallbacks
   }
@@ -388,6 +396,7 @@ export function getDefaultModelsForConnection(providerType: LlmProviderType): Ar
     'openai/gpt-5.1-codex-mini',
   ];
   if (providerType === 'openai') return OPENAI_MODELS;
+  if (providerType === 'openai_direct') return OPENAI_DIRECT_MODELS;
   if (providerType === 'copilot') return []; // Dynamic — fetched via listModels()
   if (providerType === 'anthropic_compat') return [
     'anthropic/claude-opus-4.6',
@@ -481,6 +490,7 @@ export function isValidProviderAuthCombination(
     anthropic_compat: ['api_key_with_endpoint'],
     openai: ['api_key', 'oauth'],
     openai_compat: ['api_key_with_endpoint', 'none'],
+    openai_direct: ['api_key', 'api_key_with_endpoint'],
     bedrock: ['bearer_token', 'iam_credentials', 'environment'],
     vertex: ['oauth', 'service_account_file', 'environment'],
     copilot: ['oauth'],

--- a/packages/shared/src/config/models.ts
+++ b/packages/shared/src/config/models.ts
@@ -17,7 +17,7 @@
 /**
  * Provider identifier for AI backends.
  */
-export type ModelProvider = 'anthropic' | 'openai' | 'copilot';
+export type ModelProvider = 'anthropic' | 'openai' | 'openai_direct' | 'copilot';
 
 /**
  * Full model definition with capabilities and costs.
@@ -111,6 +111,45 @@ export const MODEL_REGISTRY: ModelDefinition[] = [
   },
 
   // ----------------------------------------
+  // OpenAI Direct Models (via openai npm package, no Codex binary needed)
+  // Used when provider type is 'openai_direct'.
+  // ----------------------------------------
+  {
+    id: 'gpt-4o',
+    name: 'GPT-4o',
+    shortName: 'GPT-4o',
+    description: 'Flagship multimodal model for complex tasks',
+    provider: 'openai_direct',
+    contextWindow: 128_000,
+  },
+  {
+    id: 'gpt-4o-mini',
+    name: 'GPT-4o Mini',
+    shortName: 'GPT-4o Mini',
+    description: 'Fast and affordable for focused tasks',
+    provider: 'openai_direct',
+    contextWindow: 128_000,
+  },
+  {
+    id: 'o3',
+    name: 'o3',
+    shortName: 'o3',
+    description: 'Advanced reasoning for hard problems',
+    provider: 'openai_direct',
+    contextWindow: 200_000,
+    supportsThinking: true,
+  },
+  {
+    id: 'o4-mini',
+    name: 'o4-mini',
+    shortName: 'o4-mini',
+    description: 'Fast reasoning at lower cost',
+    provider: 'openai_direct',
+    contextWindow: 200_000,
+    supportsThinking: true,
+  },
+
+  // ----------------------------------------
   // GitHub Copilot Models (via Copilot SDK)
   // No hardcoded entries — models are discovered at runtime via client.listModels()
   // and stored on the connection. See fetchAndStoreCopilotModels() in ipc.ts.
@@ -133,6 +172,9 @@ export const ANTHROPIC_MODELS = getModelsByProvider('anthropic');
 
 /** All OpenAI/Codex models */
 export const OPENAI_MODELS = getModelsByProvider('openai');
+
+/** All direct OpenAI API models (gpt-4o, o3, etc.) */
+export const OPENAI_DIRECT_MODELS = getModelsByProvider('openai_direct');
 
 /** All GitHub Copilot models */
 export const COPILOT_MODELS = getModelsByProvider('copilot');
@@ -267,6 +309,15 @@ export function isClaudeModel(modelId: string): boolean {
 export function isCodexModel(modelId: string): boolean {
   const lower = modelId.toLowerCase();
   return lower.includes('codex');
+}
+
+/**
+ * Check if a model ID refers to a native OpenAI API model (gpt-4o, o3, etc.).
+ * These are direct OpenAI API models, distinct from Codex app-server models.
+ */
+export function isOpenAIDirectModel(modelId: string): boolean {
+  const model = getModelById(modelId);
+  return model?.provider === 'openai_direct';
 }
 
 /**


### PR DESCRIPTION
## Summary
Introduces a new `OpenAIAgent` backend that provides native OpenAI API integration without requiring the external Codex app-server binary. Users can now authenticate directly with an OpenAI API key and use OpenAI models (GPT-4o, o3, etc.) through the standard `openai` npm package.

## Key Changes

### New Agent Backend
- **OpenAIAgent** (`packages/shared/src/agent/openai-agent.ts`): Full implementation of the agentic loop using OpenAI's chat completions API with streaming support
  - Extends `BaseAgent` for common state, permissions, and prompt building
  - Implements in-process tool execution loop: API call → parse tool calls → execute → repeat
  - Supports permission requests via `permission_request` events with promise-based resolution
  - Handles both core dev tools and MCP (Model Context Protocol) integrations
  - Manages conversation history and streaming responses with abort support

### Tool Execution Framework
- **ToolExecutor** (`packages/shared/src/agent/core/tool-executor.ts`): In-process implementations of standard dev tools
  - Implements: Read, Write, Edit, Bash, Glob, Grep
  - Each tool includes OpenAI-compatible JSON schema definitions
  - Integrates with `PermissionManager` for Bash command approval
  - Supports file operations with line-number formatting and glob/regex searching

### MCP Integration
- **McpClientManager** (`packages/shared/src/agent/core/mcp-client-manager.ts`): Bridges MCP servers to OpenAI function-calling format
  - Manages connections to multiple MCP servers
  - Converts MCP tool schemas to OpenAI `ChatCompletionTool` format
  - Routes tool calls to appropriate MCP servers with slug-prefixed tool names
  - Handles tool discovery caching and server lifecycle

### Configuration & Models
- Added `openai_direct` provider type to `ModelProvider` enum
- Registered OpenAI Direct models in `MODEL_REGISTRY`:
  - GPT-4o, GPT-4o Mini (standard models)
  - o3, o4-mini (reasoning models with thinking support)
- Updated LLM connections configuration to support `openai_direct` provider
- Added factory support to instantiate `OpenAIAgent` for `openai_direct` connections
- Added built-in connection template for OpenAI Direct in Electron IPC

## Notable Implementation Details
- **Credential Resolution**: Supports API key from environment variables (`OPENAI_API_KEY`), credential manager, or connection config
- **Custom Endpoints**: Allows custom base URLs for OpenAI-compatible APIs via `baseUrl` field
- **Streaming**: Full streaming support with text deltas and tool call accumulation
- **Safety Limits**: Enforces max 50 tool iterations to prevent infinite loops
- **Permission Handling**: Async permission requests with promise-based resolution for interactive approval
- **Error Handling**: Graceful degradation for MCP server failures; agent remains functional without unavailable sources

https://claude.ai/code/session_01WiAnRQvBsV13ZBYNmSUhGu