### PR TITLE
feat(input): add ArrowUp/ArrowDown input history navigation

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/ChatDisplay.tsx
+++ b/apps/electron/src/renderer/components/app-shell/ChatDisplay.tsx
@@ -1216,6 +1216,14 @@ export const ChatDisplay = React.forwardRef<ChatDisplayHandle, ChatDisplayProps>
     return groupMessagesByTurn(session.messages)
   }, [session?.messages])
 
+  // Memoized array of user messages 
+  const userHistory = React.useMemo(() => {
+    return session?.messages
+      .filter(m => m.role === 'user' && m.content?.trim())
+      .map(m => m.content.trim())
+      .reverse()
+  }, [session?.messages])
+
   // Keep ref in sync for scroll handler
   totalTurnCountRef.current = allTurns.length
 
@@ -1603,6 +1611,7 @@ export const ChatDisplay = React.forwardRef<ChatDisplayHandle, ChatDisplayProps>
               disableSend={disableSend || connectionUnavailable}
               connectionUnavailable={connectionUnavailable}
               isEmptySession={session.messages.length === 0}
+              inputHistory={userHistory}
               currentConnection={session.llmConnection}
               onConnectionChange={onConnectionChange}
               contextStatus={{

--- a/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
+++ b/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
@@ -174,6 +174,8 @@ export interface FreeFormInputProps {
   sessionFolderPath?: string
   /** Session ID for scoping events like approve-plan */
   sessionId?: string
+  /** Input history for ArrowUp/ArrowDown navigation (derived from session messages, per-session) */
+  inputHistory?: string[]
   /** Current session status of the session (for # menu state selection) */
   currentSessionStatus?: string
   /** Disable send action (for tutorial guidance) */
@@ -243,6 +245,7 @@ export function FreeFormInput({
   onWorkingDirectoryChange,
   sessionFolderPath,
   sessionId,
+  inputHistory = [],
   currentSessionStatus,
   disableSend = false,
   isEmptySession = false,
@@ -401,14 +404,35 @@ export function FreeFormInput({
     }
   }, [enabledSourceSlugs])
 
-  // Sync from parent when inputValue changes externally (e.g., switching sessions)
+  // Sync from parent when inputValue changes externally (e.g., draft restored after async load)
+  // Session switches are handled separately below to also reset history navigation state.
+  // historyDraftRef: saves the in-progress draft when the user starts navigating history
+  const historyDraftRef = React.useRef('')
   const prevInputValueRef = React.useRef(inputValue)
+  const prevSessionIdRef = React.useRef(sessionId)
   React.useEffect(() => {
-    if (inputValue !== undefined && inputValue !== prevInputValueRef.current) {
+    const isSessionSwitch = sessionId !== prevSessionIdRef.current
+    const inputChanged = inputValue !== prevInputValueRef.current
+    if (isSessionSwitch ) {
+      // On session switch: restore draft if present, otherwise clear the input field.
+      // Always reset history navigation so the new session starts from index -1.
+      const draft = inputValue ?? ''
+      setInput(draft)
+      prevInputValueRef.current = inputValue
+      prevSessionIdRef.current = sessionId
+      historyDraftRef.current = ''
+      setTimeout(() => {
+        richInputRef.current?.setSelectionRange(draft.length, draft.length)
+      }, 0)
+    } else if (inputChanged && inputValue !== undefined) {
+      // Same session, external update (e.g., async draft load) — just sync the value.
       setInput(inputValue)
       prevInputValueRef.current = inputValue
+      setTimeout(() => {
+        richInputRef.current?.setSelectionRange(inputValue.length, inputValue.length)
+      }, 0)
     }
-  }, [inputValue])
+  }, [sessionId, inputValue])
 
   // Debounced sync to parent (saves draft without blocking typing)
   const syncTimeoutRef = React.useRef<NodeJS.Timeout | null>(null)
@@ -1076,8 +1100,12 @@ export function FreeFormInput({
       }
     }
 
+    // Reset history draft on submit
+    const trimmedInput = input.trim()
+    historyDraftRef.current = ''
+
     onSubmit(
-      input.trim(),
+      trimmedInput,
       attachments.length > 0 ? attachments : undefined,
       mentions.skills.length > 0 ? mentions.skills : undefined
     )
@@ -1106,6 +1134,62 @@ export function FreeFormInput({
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    // ArrowUp/ArrowDown: navigate input history when cursor is on the first/last line
+    if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+      // Only intercept when no overlays (mention/slash/label menus) are open
+      if (!inlineMention.isOpen && !inlineSlash.isOpen && !inlineLabel.isOpen) {
+        const cursorPos = input.length === 0 ? 0 : (richInputRef.current?.selectionStart ?? 0)
+        const currentValue = input
+        const currentIndex = inputHistory.indexOf(currentValue)
+        if (e.key === 'ArrowUp') {
+          if (cursorPos !== 0) {
+            // Not at start yet — jump to very beginning first
+            e.preventDefault()
+            richInputRef.current?.setSelectionRange(0, 0)
+            return
+          }
+          // Already at start — trigger history navigation
+          if (inputHistory.length > 0) {
+            const nextIndex = currentIndex === -1 ? 0 : currentIndex + 1
+            if (nextIndex < inputHistory.length) {
+              e.preventDefault()
+              // Save draft when first entering history navigation
+              if (currentIndex === -1) {
+                historyDraftRef.current = currentValue
+              }
+              const historyValue = inputHistory[nextIndex]
+              setInput(historyValue)
+              syncToParent(historyValue)
+              // hack empty input, put cursor at start
+              if (currentValue === '') {
+                setTimeout(() => {
+                  richInputRef.current?.setSelectionRange(0, 0)
+                }, 0)
+              }
+              return
+            }
+          }
+        } else {
+          // ArrowDown
+          if (currentIndex >= 0) {
+            if (cursorPos !== currentValue.length) {
+              // Not at end yet — jump to very end first
+              e.preventDefault()
+              richInputRef.current?.setSelectionRange(currentValue.length, currentValue.length)
+              return
+            }
+            // Already at end — trigger history navigation
+            e.preventDefault()
+            const nextIndex = currentIndex - 1
+            const targetValue = nextIndex < 0 ? historyDraftRef.current : inputHistory[nextIndex]
+            setInput(targetValue)
+            syncToParent(targetValue)
+            return
+          }
+        }
+      }
+    }
+
     // Shift+Tab cycles through enabled permission modes
     if (e.key === 'Tab' && e.shiftKey) {
       e.preventDefault()

--- a/apps/electron/src/renderer/components/ui/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ui/rich-text-input.tsx
@@ -563,6 +563,19 @@ export const RichTextInput = React.forwardRef<RichTextInputHandle, RichTextInput
       get element() { return divRef.current },
     }), [])
 
+    // Keep cursorPositionRef up-to-date on every selection change (cursor movement via arrow
+    // keys doesn't trigger handleInput, so the ref would otherwise be stale).
+    React.useEffect(() => {
+      const handleSelectionChange = () => {
+        if (!divRef.current) return
+        // Only update when our contenteditable is the active/focused element
+        if (document.activeElement !== divRef.current) return
+        cursorPositionRef.current = getCursorPosition(divRef.current, cursorPositionRef.current)
+      }
+      document.addEventListener('selectionchange', handleSelectionChange)
+      return () => document.removeEventListener('selectionchange', handleSelectionChange)
+    }, [])
+
     // Handle input events
     const handleInput = React.useCallback(() => {
       if (isComposing.current) return


### PR DESCRIPTION
This pull request adds per-session input history navigation to the chat input component, enabling users to recall previous messages with ArrowUp/ArrowDown keys. It also improves cursor position tracking for the rich text input. The most important changes are grouped below.

**Input History Navigation Enhancements:**

* Added a memoized `userHistory` array in `ChatDisplay.tsx` to collect trimmed user messages in reverse order for input history navigation.
* Passed `userHistory` as the `inputHistory` prop to `FreeFormInput`, and updated the `FreeFormInputProps` interface to support this feature. [[1]](diffhunk://#diff-3154e2bd1db99ff094a184866d009778426ee4dd7896d9719bd0233a17b855d0R1614) [[2]](diffhunk://#diff-8f45fdb3e5ebbc0360a53553f9b16be05400782b73a4596dd93949d08fdf1deeR177-R178)
* Implemented ArrowUp/ArrowDown key handling in `FreeFormInput.tsx` to navigate through input history when the cursor is at the start/end of the input, including draft preservation and restoration logic.
* Improved session switching logic in `FreeFormInput.tsx` to reset input history navigation and restore drafts appropriately.
* Reset history draft on input submission to avoid stale drafts.

**Rich Text Input Improvements:**

* Added a `selectionchange` event listener in `rich-text-input.tsx` to keep the cursor position reference up-to-date, ensuring correct cursor tracking during navigation and editing.