### PR TITLE
fix: resolve issues #298, #300, and #301

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
+++ b/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
@@ -442,6 +442,7 @@ export function FreeFormInput({
   const [isFocused, setIsFocused] = React.useState(false)
   const [inputMaxHeight, setInputMaxHeight] = React.useState(540)
   const [modelDropdownOpen, setModelDropdownOpen] = React.useState(false)
+  const [systemPromptAlwaysVisible, setSystemPromptAlwaysVisible] = React.useState(false)
 
   // Input settings (loaded from config)
   const [autoCapitalisation, setAutoCapitalisation] = React.useState(true)
@@ -466,6 +467,24 @@ export function FreeFormInput({
       }
     }
     loadInputSettings()
+  }, [])
+
+  // Load preferences on mount to honour systemPromptAlwaysVisible
+  React.useEffect(() => {
+    const loadPrefs = async () => {
+      if (!window.electronAPI) return
+      try {
+        const result = await window.electronAPI.readPreferences()
+        const prefs = JSON.parse(result.content)
+        if (prefs.systemPromptAlwaysVisible) {
+          setSystemPromptAlwaysVisible(true)
+          setModelDropdownOpen(true)
+        }
+      } catch {
+        // ignore — preferences are optional
+      }
+    }
+    loadPrefs()
   }, [])
 
   // Double-Esc interrupt: show warning overlay on first Esc, interrupt on second
@@ -1625,7 +1644,7 @@ export function FreeFormInput({
           <div className="flex items-center shrink-0">
           {/* 5. Model/Connection Selector - Hidden in compact mode (EditPopover embedding) */}
           {!compactMode && (
-          <DropdownMenu open={modelDropdownOpen} onOpenChange={setModelDropdownOpen}>
+          <DropdownMenu open={modelDropdownOpen} onOpenChange={(open) => { if (!open && systemPromptAlwaysVisible) return; setModelDropdownOpen(open) }}>
             <Tooltip>
               <TooltipTrigger asChild>
                 <DropdownMenuTrigger asChild>

--- a/apps/electron/src/renderer/components/ui/mention-menu.tsx
+++ b/apps/electron/src/renderer/components/ui/mention-menu.tsx
@@ -525,9 +525,9 @@ export function useInlineMention({
     currentInputRef.current = { value, cursorPosition }
 
     const textBeforeCursor = value.slice(0, cursorPosition)
-    // Match @ anywhere, followed by optional word chars, hyphens, slashes, and dots
-    // (dots needed for file extensions like @main.ts)
-    const atMatch = textBeforeCursor.match(/@([\w\-\/.]+)?$/)
+    // Match @ anywhere, followed by optional word chars, hyphens, slashes, dots, and spaces
+    // (dots needed for file extensions like @main.ts, spaces for filenames like @app availability.md)
+    const atMatch = textBeforeCursor.match(/@([\w\-\/. ]+)?$/)
 
     // Check if this is a valid @ mention trigger
     const matchStart = atMatch ? textBeforeCursor.lastIndexOf('@') : -1

--- a/apps/electron/src/renderer/pages/settings/PreferencesPage.tsx
+++ b/apps/electron/src/renderer/pages/settings/PreferencesPage.tsx
@@ -20,6 +20,7 @@ import {
   SettingsCard,
   SettingsInput,
   SettingsTextarea,
+  SettingsToggle,
 } from '@/components/settings'
 import { EditPopover, EditButton, getEditConfig } from '@/components/ui/EditPopover'
 import type { DetailsPageMeta } from '@/lib/navigation-registry'
@@ -36,6 +37,7 @@ interface PreferencesFormState {
   city: string
   country: string
   notes: string
+  systemPromptAlwaysVisible: boolean
 }
 
 const emptyFormState: PreferencesFormState = {
@@ -45,6 +47,7 @@ const emptyFormState: PreferencesFormState = {
   city: '',
   country: '',
   notes: '',
+  systemPromptAlwaysVisible: false,
 }
 
 // Parse JSON to form state
@@ -58,6 +61,7 @@ function parsePreferences(json: string): PreferencesFormState {
       city: prefs.location?.city || '',
       country: prefs.location?.country || '',
       notes: prefs.notes || '',
+      systemPromptAlwaysVisible: prefs.systemPromptAlwaysVisible ?? false,
     }
   } catch {
     return emptyFormState
@@ -80,6 +84,7 @@ function serializePreferences(state: PreferencesFormState): string {
   }
 
   if (state.notes) prefs.notes = state.notes
+  if (state.systemPromptAlwaysVisible) prefs.systemPromptAlwaysVisible = state.systemPromptAlwaysVisible
   prefs.updatedAt = Date.now()
 
   return JSON.stringify(prefs, null, 2)
@@ -247,6 +252,22 @@ export default function PreferencesPage() {
                 value={formState.country}
                 onChange={(v) => updateField('country', v)}
                 placeholder="e.g., USA"
+                inCard
+              />
+            </SettingsCard>
+          </SettingsSection>
+
+          {/* Interface */}
+          <SettingsSection
+            title="Interface"
+            description="Customise how Craft Agent's input panel behaves."
+          >
+            <SettingsCard divided>
+              <SettingsToggle
+                label="Always show model context panel"
+                description="Keep the model and context info panel visible in the input bar without clicking."
+                checked={formState.systemPromptAlwaysVisible}
+                onCheckedChange={(v) => updateField('systemPromptAlwaysVisible', v)}
                 inCard
               />
             </SettingsCard>

--- a/packages/shared/src/auth/google-oauth.ts
+++ b/packages/shared/src/auth/google-oauth.ts
@@ -337,10 +337,13 @@ export async function startGoogleOAuth(
 
     // Check for error
     if (callback.query.error) {
-      return {
-        success: false,
-        error: callback.query.error_description || callback.query.error,
-      };
+      const isAccessBlocked =
+        callback.query.error === 'access_denied' ||
+        String(callback.query.error_description ?? '').toLowerCase().includes('verif')
+      const error = isAccessBlocked
+        ? `Google has blocked this app (not yet verified).\n\nTo fix this, add your own Google OAuth credentials to the source config:\n  "googleOAuthClientId": "...",\n  "googleOAuthClientSecret": "..."\n\nSee: https://console.cloud.google.com/apis/credentials`
+        : callback.query.error_description || callback.query.error
+      return { success: false, error }
     }
 
     // Get authorization code

--- a/packages/shared/src/config/preferences.ts
+++ b/packages/shared/src/config/preferences.ts
@@ -30,6 +30,8 @@ export interface UserPreferences {
   notes?: string;
   // Diff viewer display preferences
   diffViewer?: DiffViewerPreferences;
+  // Always show the model/context panel in the input bar
+  systemPromptAlwaysVisible?: boolean;
   // When the preferences were last updated
   updatedAt?: number;
 }


### PR DESCRIPTION
#298 – @mention autocomplete now matches filenames with spaces by adding a space to the trigger regex character class in mention-menu.tsx.

#300 – Gmail OAuth 'Access Blocked' error now returns an actionable message telling users to supply their own Google OAuth credentials when Google rejects the app as unverified.

#301 – Adds a 'systemPromptAlwaysVisible' user preference that keeps the model/context dropdown pinned open in the input bar; exposed as a toggle in Settings → Preferences → Interface.