### PR TITLE
docs: fix deep link action name new-chat → new-session

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ craftagents://allSessions                      # All sessions view
 craftagents://allSessions/session/session123   # Specific session
 craftagents://settings                         # Settings
 craftagents://sources/source/github            # Source info
-craftagents://action/new-chat                  # Create new session
+craftagents://action/new-session               # Create new session
 ```
 
 ## Tech Stack

--- a/apps/electron/README.md
+++ b/apps/electron/README.md
@@ -254,7 +254,7 @@ External apps can navigate using `craftagents://` URLs:
 craftagents://settings
 craftagents://allSessions/session/session123
 craftagents://sources/source/github
-craftagents://action/new-chat
+craftagents://action/new-session
 craftagents://workspace/{id}/allSessions/session/abc123
 ```
 

--- a/apps/electron/src/main/deep-link.ts
+++ b/apps/electron/src/main/deep-link.ts
@@ -17,7 +17,7 @@
  *   craftagents://workspace/{workspaceId}/action/{actionName}[?params]
  *
  * Actions:
- *   new-chat                  - Create new chat, optional ?input=text&name=name&send=true
+ *   new-session               - Create new session, optional ?input=text&name=name&send=true
  *                               If send=true is provided with input, immediately sends the message
  *   resume-sdk-session/{id}   - Resume Claude Code session by SDK session ID
  *   delete-session/{id}       - Delete session
@@ -29,7 +29,7 @@
  *   craftagents://allSessions/session/abc123                (specific session)
  *   craftagents://settings/shortcuts                     (shortcuts page)
  *   craftagents://sources/source/github                  (github source info)
- *   craftagents://action/new-chat                        (uses active window)
+ *   craftagents://action/new-session                     (uses active window)
  *   craftagents://action/resume-sdk-session/{sdkId}      (resume Claude Code session)
  *   craftagents://workspace/ws123/allSessions/session/abc123   (targets specific workspace)
  */
@@ -44,7 +44,7 @@ export interface DeepLinkTarget {
   workspaceId?: string
   /** Compound route format (e.g., 'allSessions/session/abc123', 'settings/shortcuts') */
   view?: string
-  /** Action route (e.g., 'new-chat', 'delete-session') */
+  /** Action route (e.g., 'new-session', 'delete-session') */
   action?: string
   actionParams?: Record<string, string>
   /** Window mode - if set, opens in a new window instead of navigating in existing */
@@ -65,7 +65,7 @@ export interface DeepLinkResult {
 export interface DeepLinkNavigation {
   /** Compound route format (e.g., 'allSessions/session/abc123', 'settings/shortcuts') */
   view?: string
-  /** Action route (e.g., 'new-chat', 'delete-session') */
+  /** Action route (e.g., 'new-session', 'delete-session') */
   action?: string
   actionParams?: Record<string, string>
 }


### PR DESCRIPTION
## Summary

Fixes #285

- Fix documented deep link action name `new-chat` to match the actual renderer handler `new-session`
- `craftagents://action/new-chat` silently fails because the renderer's action handler (`NavigationContext.tsx:261`) only recognizes `new-session`
- Updated 6 references across `deep-link.ts` (comments/JSDoc), `README.md`, and `apps/electron/README.md`

## Note

The Mintlify-hosted docs at [agents.craft.do/docs/go-further/deeplinks](https://agents.craft.do/docs/go-further/deeplinks) also reference `new-chat` and should be updated separately.