### PR TITLE
fix: prevent duplicate Opus 4.6 entry in model selector

### DIFF
--- a/packages/shared/src/config/storage.ts
+++ b/packages/shared/src/config/storage.ts
@@ -1371,19 +1371,43 @@ function migrateOpus45ToOpus46(config: StoredConfig): boolean {
 
     // Migrate models array
     if (connection.models && Array.isArray(connection.models)) {
-      for (let i = 0; i < connection.models.length; i++) {
-        const model = connection.models[i];
-        if (typeof model === 'string' && model === OPUS_45_ID) {
-          connection.models[i] = OPUS_46_ID;
-          changed = true;
-        } else if (typeof model === 'object' && model.id === OPUS_45_ID) {
-          model.id = OPUS_46_ID;
-          if (model.name?.includes('4.5')) {
-            model.name = model.name.replace('4.5', '4.6');
+      const getId = (m: string | { id: string }): string => typeof m === 'string' ? m : m.id;
+      const modelIds = connection.models.map(getId);
+      const hasOpus45 = modelIds.includes(OPUS_45_ID);
+      const opus46Count = modelIds.filter(id => id === OPUS_46_ID).length;
+
+      if (hasOpus45 && opus46Count > 0) {
+        // Both exist (backfill populated both) — remove the old 4.5 entry
+        connection.models = connection.models.filter(m => getId(m) !== OPUS_45_ID);
+        changed = true;
+      } else if (hasOpus45) {
+        // Only 4.5 exists — convert to 4.6 in place
+        for (let i = 0; i < connection.models.length; i++) {
+          const model = connection.models[i];
+          if (typeof model === 'string' && model === OPUS_45_ID) {
+            connection.models[i] = OPUS_46_ID;
+            changed = true;
+          } else if (typeof model === 'object' && model.id === OPUS_45_ID) {
+            model.id = OPUS_46_ID;
+            if (model.name?.includes('4.5')) {
+              model.name = model.name.replace('4.5', '4.6');
+            }
+            changed = true;
           }
-          changed = true;
         }
+      } else if (opus46Count > 1) {
+        // Already-affected user: duplicate 4.6 entries from previous migration bug.
+        // Keep only the first occurrence.
+        let kept = false;
+        connection.models = connection.models.filter(m => {
+          if (getId(m) !== OPUS_46_ID) return true;
+          if (kept) return false;
+          kept = true;
+          return true;
+        });
+        changed = true;
       }
+      // else: single 4.6, no 4.5 — nothing to do (natural no-op)
     }
   }
 


### PR DESCRIPTION
The migrateOpus45ToOpus46() migration converts claude-opus-4-5 to claude-opus-4-6 in the models array. However, backfillAllConnectionModels() (which runs earlier in the startup sequence) already populates the array from MODEL_REGISTRY, which includes both Opus 4.5 and Opus 4.6.

This means the models array already contains claude-opus-4-6 when the migration runs, and converting the 4.5 entry creates a second 4.6 entry, causing users to see duplicate "Opus 4.6" choices in the model picker.

Fix: rewrite the models migration to handle all possible states:
- Both 4.5 and 4.6 present → remove 4.5
- Only 4.5 → convert to 4.6 (original behavior)
- Duplicate 4.6 entries → keep first (cleans up already-affected users)
- Single 4.6 → no-op

After one successful run all paths converge and the migration becomes a permanent no-op with no runtime cost.