### PR TITLE
fix: navigate to correct session on notification click

### DIFF
--- a/apps/electron/src/main/notifications.ts
+++ b/apps/electron/src/main/notifications.ts
@@ -13,6 +13,11 @@ import { readFileSync } from 'fs'
 import { mainLog } from './logger'
 import type { WindowManager } from './window-manager'
 
+// Keep strong references to active notifications to prevent garbage collection.
+// Without this, Electron's Notification objects get GC'd after showNotification()
+// returns, which silently destroys the 'click' handler (electron/electron#16922).
+const activeNotifications = new Set<Notification>()
+
 let windowManager: WindowManager | null = null
 let baseIconPath: string | null = null
 let baseIconDataUrl: string | null = null
@@ -54,10 +59,18 @@ export function showNotification(
     icon: undefined,  // Will use app icon by default on macOS
   })
 
+  // Hold a strong reference to prevent GC before the user interacts
+  activeNotifications.add(notification)
+
+  const cleanup = () => { activeNotifications.delete(notification) }
+
   notification.on('click', () => {
     mainLog.info('Notification clicked:', { workspaceId, sessionId })
     handleNotificationClick(workspaceId, sessionId)
+    cleanup()
   })
+
+  notification.on('close', cleanup)
 
   notification.show()
   mainLog.info('Notification shown:', { title, sessionId })


### PR DESCRIPTION
## Problem
Clicking a notification focuses the app window but does **not** navigate to the session that triggered it.

**Root cause:** The `Notification` object is a local variable in `showNotification()`. After the function returns, V8 garbage collects it, silently destroying the `click` handler ([electron/electron#16922](https://github.com/electron/electron/issues/16922)). macOS still focuses the app (native OS behavior), but the navigation handler is gone.

## Before → After
| Step | Before | After |
|------|--------|-------|
| Notification appears | ✅ | ✅ |
| Click focuses app | ✅ | ✅ |
| Navigates to session | ❌ | ✅ |

## Fix
Hold strong references to active `Notification` objects in a module-level `Set` to prevent GC. Cleanup on both `click` and `close` events to prevent memory leaks.

## Test plan
- [x] Built and ran packaged app locally
- [x] Triggered notification, clicked it — navigates to correct session
- [x] Verified cleanup fires on dismiss (no memory leak)