### PR TITLE
fix: ignore Escape propagation during IME composition

### DIFF
--- a/apps/electron/src/renderer/components/ui/__tests__/rich-text-input.test.ts
+++ b/apps/electron/src/renderer/components/ui/__tests__/rich-text-input.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'bun:test'
+import { isEscapeDuringComposition } from '../rich-text-input'
+
+describe('isEscapeDuringComposition', () => {
+  it('returns true for Escape during IME composition', () => {
+    expect(isEscapeDuringComposition({ key: 'Escape', nativeEvent: { isComposing: true } })).toBe(true)
+  })
+
+  it('returns false when not composing', () => {
+    expect(isEscapeDuringComposition({ key: 'Escape', nativeEvent: { isComposing: false } })).toBe(false)
+  })
+
+  it('returns false for non-Escape keys', () => {
+    expect(isEscapeDuringComposition({ key: 'Enter', nativeEvent: { isComposing: true } })).toBe(false)
+  })
+
+  it('returns false when nativeEvent is missing', () => {
+    expect(isEscapeDuringComposition({ key: 'Escape' })).toBe(false)
+  })
+})
+

--- a/apps/electron/src/renderer/components/ui/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ui/rich-text-input.tsx
@@ -95,6 +95,10 @@ function isCodeFile(name: string): boolean {
   return ext ? CODE_EXTENSIONS.has(ext) : false
 }
 
+export function isEscapeDuringComposition(event: { key: string; nativeEvent?: { isComposing?: boolean } | null }): boolean {
+  return event.key === 'Escape' && !!event.nativeEvent?.isComposing
+}
+
 function renderBadgeHTML(
   type: MentionItemType,
   label: string,
@@ -645,6 +649,14 @@ export const RichTextInput = React.forwardRef<RichTextInputHandle, RichTextInput
       onBlur?.(e)
     }, [onBlur])
 
+    const handleKeyDownInternal = React.useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (isEscapeDuringComposition(e)) {
+        e.stopPropagation()
+        return
+      }
+      onKeyDown?.(e)
+    }, [onKeyDown])
+
     // Sync value from props (when parent updates value externally)
     React.useEffect(() => {
       if (!divRef.current) return
@@ -755,7 +767,7 @@ export const RichTextInput = React.forwardRef<RichTextInputHandle, RichTextInput
           // Use inline style for line-height to override text-sm's built-in line-height
           style={{ lineHeight: 1.25 }}
           onInput={handleInput}
-          onKeyDown={onKeyDown}
+          onKeyDown={handleKeyDownInternal}
           onFocus={handleFocus}
           onBlur={handleBlur}
           onPaste={handlePasteInternal}


### PR DESCRIPTION
fix https://github.com/lukilabs/craft-agents-oss/issues/318

**Summary**
- Prevents `Escape` events from propagating upward during IME composition to avoid accidentally triggering exit/close logic.
- Added corresponding unit test covering this scenario.

**Changes**
- Enhanced `rich-text-input` handling of IME composition state.
- Added test cases for `Escape` behavior during IME composition.

**Testing**
- `bun test`
- `bun run typecheck:all`