### PR TITLE
fix: session list infinite scroll stops loading after first batch

### DIFF
--- a/apps/electron/src/renderer/hooks/useSessionSearch.ts
+++ b/apps/electron/src/renderer/hooks/useSessionSearch.ts
@@ -438,7 +438,7 @@ export function useSessionSearch({
 
     observer.observe(sentinelRef.current)
     return () => observer.disconnect()
-  }, [hasMore, loadMore])
+  }, [hasMore, loadMore, displayLimit])
 
   // --- Derived render data ---
 


### PR DESCRIPTION
## Summary

- Fixes the `IntersectionObserver` in `useSessionSearch` hook that stops firing after the first batch load, causing the "All Sessions" view to only display ~20-40 sessions instead of all available sessions.

## Root Cause

The `IntersectionObserver` only fires callbacks when the intersection state **crosses a threshold**. When the sentinel element stays continuously visible in the viewport after a batch of sessions loads (common on tall screens or when there are few sessions), the observer never re-fires because no threshold crossing occurs.

The `useEffect` dependency array was `[hasMore, loadMore]` — neither changes between batch loads (`hasMore` stays `true`, `loadMore` is referentially stable via `useCallback`), so the observer is never recreated.

## Fix

Add `displayLimit` to the `useEffect` dependency array. After each batch load, `displayLimit` changes (20 → 40 → 60...), causing the effect to re-run and recreate the observer. The new observer's initial observation detects if the sentinel is still visible and triggers the next batch, continuing until the sentinel scrolls out of view.

This is a one-line change in `apps/electron/src/renderer/hooks/useSessionSearch.ts`.

## Test plan

- [ ] Open "All Sessions" with 50+ sessions on a tall/portrait monitor — all sessions should progressively load
- [ ] Verify sessions load in batches of 20 as you scroll on shorter displays
- [ ] Confirm search mode pagination still works correctly
- [ ] Test with filter active (status/label) to ensure filtered pagination works

Fixes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)