### PR TITLE
feat: inline markdown annotations for plan review

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/ChatDisplay.tsx
+++ b/apps/electron/src/renderer/components/app-shell/ChatDisplay.tsx
@@ -995,6 +995,11 @@ export const ChatDisplay = React.forwardRef<ChatDisplayHandle, ChatDisplayProps>
     setOverlayState(null)
   }, [])
 
+  // Send structured comments as a message (used by plan annotation "Reply with Comments")
+  const handleSendToChat = useCallback((text: string) => {
+    onSendMessage(text)
+  }, [onSendMessage])
+
   // Extract overlay data for activity-based overlays
   // Uses the shared extractOverlayData parser from @craft-agent/ui
   const overlayData: OverlayData | null = useMemo(() => {
@@ -1417,6 +1422,7 @@ export const ChatDisplay = React.forwardRef<ChatDisplayHandle, ChatDisplayProps>
                         onOpenUrl={onOpenUrl}
                         isLastResponse={isLastResponse}
                         compactMode={compactMode}
+                        onSendToChat={handleSendToChat}
                         onAcceptPlan={() => {
                           window.dispatchEvent(new CustomEvent('craft:approve-plan', {
                             detail: { text: 'Plan approved, please execute.', sessionId: session?.id }
@@ -1690,6 +1696,7 @@ export const ChatDisplay = React.forwardRef<ChatDisplayHandle, ChatDisplayProps>
           onOpenFile={onOpenFile}
           error={overlayData.error}
           variant={isPlanFilePath(overlayData.filePath) ? 'plan' : 'response'}
+          onSendToChat={handleSendToChat}
         />
       )}
 

--- a/packages/ui/src/components/chat/TurnCard.tsx
+++ b/packages/ui/src/components/chat/TurnCard.tsx
@@ -32,6 +32,7 @@ import { TurnCardActionsMenu } from './TurnCardActionsMenu'
 import { computeLastChildSet, groupActivitiesByParent, isActivityGroup, formatDuration, formatTokens, deriveTurnPhase, shouldShowThinkingIndicator, type ActivityGroup, type AssistantTurn } from './turn-utils'
 import { DocumentFormattedMarkdownOverlay } from '../overlay'
 import { AcceptPlanDropdown } from './AcceptPlanDropdown'
+import { MarkdownAnnotationProvider, useMarkdownAnnotations, MarkdownAnnotationLayer, AnnotationPopover, AnnotationControls } from '../markdown-annotations'
 
 // ============================================================================
 // Utilities
@@ -261,6 +262,8 @@ export interface TurnCardProps {
   onAcceptPlan?: () => void
   /** Callback when user accepts the plan with compaction (compact conversation first, then execute) */
   onAcceptPlanWithCompact?: () => void
+  /** Callback to send structured comments text to the chat input (plan annotations) */
+  onSendToChat?: (text: string) => void
   /** Whether this is the last response in the session (shows Accept Plan button only for last response) */
   isLastResponse?: boolean
   /** Session folder path for stripping from file paths in tool display */
@@ -1306,9 +1309,58 @@ export interface ResponseCardProps {
   showAcceptPlan?: boolean
   /** Hide footer for compact embedding (EditPopover) */
   compactMode?: boolean
+  /** Callback to send structured comments text to the chat input */
+  onSendToChat?: (text: string) => void
+  /** Stable ID for plan annotation persistence */
+  planId?: string
 }
 
 const MAX_HEIGHT = 540
+
+/** Footer right section for plan cards — swaps Accept Plan for annotation controls when comments exist. */
+function AnnotationFooterRight({
+  onAccept,
+  onAcceptWithCompact,
+  isLastResponse,
+  onSendToChat,
+}: {
+  onAccept: () => void
+  onAcceptWithCompact: () => void
+  isLastResponse: boolean
+  onSendToChat?: (text: string) => void
+}) {
+  const { annotations, copyComments, getCommentsText, clearAll } = useMarkdownAnnotations()
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 transition-all duration-200",
+        isLastResponse
+          ? "opacity-100 translate-x-0"
+          : "opacity-0 translate-x-2 pointer-events-none"
+      )}
+    >
+      {annotations.length > 0 ? (
+        <AnnotationControls
+          count={annotations.length}
+          onCopy={copyComments}
+          onReply={onSendToChat ? () => { onSendToChat(getCommentsText()); clearAll() } : undefined}
+          onClear={clearAll}
+        />
+      ) : (
+        <>
+          <span className="text-xs text-muted-foreground">
+            Type your feedback in chat, leave comments inline or
+          </span>
+          <AcceptPlanDropdown
+            onAccept={onAccept}
+            onAcceptWithCompact={onAcceptWithCompact}
+          />
+        </>
+      )}
+    </div>
+  )
+}
 
 /**
  * ResponseCard - Unified card component for AI responses and plans
@@ -1339,6 +1391,8 @@ export function ResponseCard({
   isLastResponse = true,
   showAcceptPlan = true,
   compactMode = false,
+  onSendToChat,
+  planId,
 }: ResponseCardProps) {
   // Throttled content for display - updates every CONTENT_THROTTLE_MS during streaming
   const [displayedText, setDisplayedText] = useState(text)
@@ -1416,7 +1470,17 @@ export function ResponseCard({
   if (isCompleted || variant === 'plan') {
     const isPlan = variant === 'plan'
 
-    return (
+    const markdownContent = (
+      <Markdown
+        mode="minimal"
+        onUrlClick={onOpenUrl}
+        onFileClick={onOpenFile}
+      >
+        {text}
+      </Markdown>
+    )
+
+    const cardJsx = (
       <>
         <div className="bg-background shadow-minimal rounded-[8px] overflow-hidden relative group">
           {/* Fullscreen button - top right corner, visible on hover */}
@@ -1459,13 +1523,11 @@ export function ResponseCard({
               }),
             }}
           >
-            <Markdown
-              mode="minimal"
-              onUrlClick={onOpenUrl}
-              onFileClick={onOpenFile}
-            >
-              {text}
-            </Markdown>
+            {isPlan ? (
+              <MarkdownAnnotationLayer>{markdownContent}</MarkdownAnnotationLayer>
+            ) : (
+              markdownContent
+            )}
           </div>
 
           {/* Footer with actions - hidden in compact mode */}
@@ -1511,28 +1573,21 @@ export function ResponseCard({
                 )}
               </div>
 
-              {/* Right side - Accept Plan dropdown (only shown for plan variant when it's the last response) */}
+              {/* Right side - Accept Plan or Annotation Controls */}
               {isPlan && showAcceptPlan && onAccept && onAcceptWithCompact && (
-                <div
-                  className={cn(
-                    "flex items-center gap-3 transition-all duration-200",
-                    isLastResponse
-                      ? "opacity-100 translate-x-0"
-                      : "opacity-0 translate-x-2 pointer-events-none"
-                  )}
-                >
-                  <span className="text-xs text-muted-foreground">
-                    Type your feedback in chat or
-                  </span>
-                  <AcceptPlanDropdown
-                    onAccept={onAccept}
-                    onAcceptWithCompact={onAcceptWithCompact}
-                  />
-                </div>
+                <AnnotationFooterRight
+                  onAccept={onAccept}
+                  onAcceptWithCompact={onAcceptWithCompact}
+                  isLastResponse={isLastResponse}
+                  onSendToChat={onSendToChat}
+                />
               )}
             </div>
           )}
         </div>
+
+        {/* Annotation popover (portal) — only for plans */}
+        {isPlan && <AnnotationPopover />}
 
         {/* Fullscreen overlay for reading response/plan */}
         <DocumentFormattedMarkdownOverlay
@@ -1542,9 +1597,15 @@ export function ResponseCard({
           variant={isPlan ? 'plan' : undefined}
           onOpenUrl={onOpenUrl}
           onOpenFile={onOpenFile}
+          onSendToChat={onSendToChat}
         />
       </>
     )
+
+    // Plans are wrapped in MarkdownAnnotationProvider — planId enables persistence across unmounts
+    return isPlan ? (
+      <MarkdownAnnotationProvider planId={planId}>{cardJsx}</MarkdownAnnotationProvider>
+    ) : cardJsx
   }
 
   // Streaming response - show throttled content with spinner
@@ -1699,6 +1760,7 @@ export const TurnCard = React.memo(function TurnCard({
   renderActionsMenu,
   onAcceptPlan,
   onAcceptPlanWithCompact,
+  onSendToChat,
   isLastResponse,
   sessionFolderPath,
   displayMode = 'detailed',
@@ -2050,8 +2112,10 @@ export const TurnCard = React.memo(function TurnCard({
             onOpenUrl={onOpenUrl}
             onPopOut={onPopOut ? () => onPopOut(planActivity.content || '') : undefined}
             variant="plan"
+            planId={planActivity.id}
             onAccept={onAcceptPlan}
             onAcceptWithCompact={onAcceptPlanWithCompact}
+            onSendToChat={onSendToChat}
             isLastResponse={isLastResponse && index === planActivities.length - 1}
             compactMode={compactMode}
           />
@@ -2079,6 +2143,7 @@ export const TurnCard = React.memo(function TurnCard({
                 variant={response.isPlan ? 'plan' : 'response'}
                 onAccept={onAcceptPlan}
                 onAcceptWithCompact={onAcceptPlanWithCompact}
+                onSendToChat={onSendToChat}
                 isLastResponse={isLastResponse}
                 compactMode={compactMode}
               />
@@ -2099,6 +2164,7 @@ export const TurnCard = React.memo(function TurnCard({
             variant={response.isPlan ? 'plan' : 'response'}
             onAccept={onAcceptPlan}
             onAcceptWithCompact={onAcceptPlanWithCompact}
+            onSendToChat={onSendToChat}
             isLastResponse={isLastResponse}
             compactMode={compactMode}
           />

--- a/packages/ui/src/components/markdown-annotations/AnnotationControls.tsx
+++ b/packages/ui/src/components/markdown-annotations/AnnotationControls.tsx
@@ -1,0 +1,124 @@
+/**
+ * AnnotationControls — Shared action buttons for plan annotations.
+ *
+ * Layout: [N comments] |        spacer        Clear [Reply with Comments | Copy]
+ * The reply/copy split button matches AcceptPlanDropdown styling (accent instead of success).
+ * Used by both the inline card footer and the fullscreen island.
+ */
+
+import { Check, Copy, MessageSquare, Trash2 } from 'lucide-react';
+import React, { useCallback, useState } from 'react';
+import { cn } from '../../lib/utils';
+
+interface AnnotationControlsProps {
+  count: number;
+  onCopy: () => Promise<void>;
+  onReply?: () => void;
+  onClear: () => void;
+  /** Called after reply — used to close fullscreen overlay */
+  onDone?: () => void;
+}
+
+export function AnnotationControls({
+  count,
+  onCopy,
+  onReply,
+  onClear,
+  onDone,
+}: AnnotationControlsProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    await onCopy();
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [onCopy]);
+
+  const handleReply = useCallback(() => {
+    onReply?.();
+    onDone?.();
+  }, [onReply, onDone]);
+
+  const handleClear = useCallback(() => {
+    if (count > 3) {
+      if (!window.confirm(`Remove all ${count} comments?`)) return;
+    }
+    onClear();
+  }, [count, onClear]);
+
+  return (
+    <div className="flex items-center gap-3.5 min-h-[28px]">
+      <span className="text-xs text-muted-foreground tabular-nums">
+        {count} {count === 1 ? 'comment' : 'comments'}
+      </span>
+
+      <div className="w-px h-3.5 bg-border" />
+
+      <div className="flex items-center gap-3">
+        <button
+          onClick={handleClear}
+          className={cn(
+            'text-xs transition-colors select-none flex items-center gap-1.5',
+            'text-muted-foreground hover:text-destructive',
+            'focus:outline-none focus-visible:underline',
+          )}
+        >
+          <Trash2 className="h-3 w-3" />
+          Clear comments
+        </button>
+
+        <div
+          className="inline-flex items-center shadow-tinted rounded-[6px]"
+          style={
+            { '--shadow-color': 'var(--accent-rgb)' } as React.CSSProperties
+          }
+        >
+          {/* Primary action: Reply */}
+          {onReply && (
+            <button
+              type="button"
+              onClick={handleReply}
+              className={cn(
+                'h-[28px] px-2.5 text-xs font-medium flex items-center gap-1.5 transition-all',
+                'bg-accent/5 text-accent hover:bg-accent/10',
+                'rounded-l-[6px]',
+              )}
+            >
+              <MessageSquare className="h-3.5 w-3.5" />
+              <span>Reply with Comments</span>
+            </button>
+          )}
+
+          {/* Divider between split halves */}
+          {onReply && (
+            <div
+              className="w-px self-stretch"
+              style={{
+                backgroundColor: `rgba(var(--accent-rgb), calc(var(--shadow-border-opacity) * 1.5))`,
+              }}
+            />
+          )}
+
+          {/* Secondary action: Copy */}
+          <button
+            type="button"
+            onClick={handleCopy}
+            className={cn(
+              'h-[28px] px-2.5 text-xs font-medium flex items-center transition-all',
+              'bg-accent/5 hover:bg-accent/10',
+              onReply ? 'rounded-r-[6px]' : 'rounded-[6px]',
+              'text-accent',
+            )}
+            title={copied ? 'Copied!' : 'Copy comments'}
+          >
+            {copied ? (
+              <Check className="h-3.5 w-3.5" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/markdown-annotations/AnnotationIsland.tsx
+++ b/packages/ui/src/components/markdown-annotations/AnnotationIsland.tsx
@@ -1,0 +1,56 @@
+/**
+ * AnnotationIsland — Floating bar at the bottom of fullscreen plan overlay.
+ *
+ * Only renders when there are annotations. Animated enter/exit with
+ * blur + fade + y-translate. Contains AnnotationControls with copy/reply/clear actions.
+ */
+
+import { motion, AnimatePresence } from 'motion/react';
+import { useCallback } from 'react';
+import { cn } from '../../lib/utils';
+import { AnnotationControls } from './AnnotationControls';
+import { useMarkdownAnnotations } from './MarkdownAnnotationContext';
+
+interface AnnotationIslandProps {
+  onSendToChat?: (text: string) => void;
+  /** Called after reply — used to close fullscreen overlay */
+  onDone?: () => void;
+}
+
+export function AnnotationIsland({
+  onSendToChat,
+  onDone,
+}: AnnotationIslandProps) {
+  const { annotations, copyComments, getCommentsText, clearAll } =
+    useMarkdownAnnotations();
+
+  const handleReply = useCallback(() => {
+    onSendToChat?.(getCommentsText());
+    clearAll();
+  }, [onSendToChat, getCommentsText, clearAll]);
+
+  return (
+    <AnimatePresence>
+      {annotations.length > 0 && (
+        <motion.div
+          initial={{ opacity: 0, y: 8, filter: 'blur(3px)' }}
+          animate={{ opacity: 1, y: 0, filter: 'blur(0px)', transition: { duration: 0.18, ease: 'easeOut' } }}
+          exit={{ opacity: 0, y: 8, filter: 'blur(3px)', transition: { duration: 0.15, ease: 'easeIn' } }}
+          className={cn(
+            'fixed bottom-6 left-1/2 -translate-x-1/2 z-[360]',
+            'pl-5 pr-2.5 py-2.5 text-[14px]',
+            'bg-background/95 backdrop-blur-sm shadow-strong rounded-[12px] border border-border/50',
+          )}
+        >
+          <AnnotationControls
+            count={annotations.length}
+            onCopy={copyComments}
+            onReply={onSendToChat ? handleReply : undefined}
+            onClear={clearAll}
+            onDone={onDone}
+          />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/ui/src/components/markdown-annotations/AnnotationPopover.tsx
+++ b/packages/ui/src/components/markdown-annotations/AnnotationPopover.tsx
@@ -1,0 +1,263 @@
+/**
+ * AnnotationPopover — Floating comment input for adding or editing annotations.
+ *
+ * Two modes:
+ * 1. New annotation: shown when pendingSelection is set (user selected text)
+ * 2. Edit annotation: shown when editingAnnotation is set (clicked marker/text)
+ *
+ * Portals to the nearest Radix Dialog (fullscreen) or document.body (inline).
+ *
+ * The outer `AnnotationPopover` gates visibility; the inner
+ * `AnnotationPopoverInner` mounts fresh each time (keyed by annotation id)
+ * so `useState` initializes with the correct value — no sync effect needed.
+ */
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import * as ReactDOM from 'react-dom'
+import { motion } from 'motion/react'
+import { Trash2 } from 'lucide-react'
+import { useMarkdownAnnotations } from './MarkdownAnnotationContext'
+import { cn } from '../../lib/utils'
+
+const POPOVER_GAP = 8
+const POPOVER_WIDTH = 320
+
+function getPortalTarget(contentEl: HTMLElement | null): HTMLElement {
+  if (!contentEl) return document.body
+  const dialog = contentEl.closest('[role="dialog"]')
+  return (dialog as HTMLElement) || document.body
+}
+
+export function AnnotationPopover() {
+  const { pendingSelection, editingAnnotation } = useMarkdownAnnotations()
+
+  const isEditing = !!editingAnnotation
+  const isCreating = !!pendingSelection && !editingAnnotation
+  const isOpen = isCreating || isEditing
+
+  if (!isOpen) return null
+
+  // Key forces a fresh mount when switching annotations or between create/edit,
+  // so useState initializes with the correct comment value on first render.
+  return <AnnotationPopoverInner key={editingAnnotation?.id ?? 'new'} />
+}
+
+function AnnotationPopoverInner() {
+  const {
+    pendingSelection,
+    editingAnnotation,
+    annotations,
+    setPendingSelection,
+    setEditingAnnotation,
+    addAnnotation,
+    updateAnnotation,
+    removeAnnotation,
+    contentRef,
+  } = useMarkdownAnnotations()
+
+  const isEditing = !!editingAnnotation
+  const isCreating = !!pendingSelection && !editingAnnotation
+
+  // Find the annotation being edited
+  const editedAnnotation = isEditing
+    ? annotations.find(a => a.id === editingAnnotation.id)
+    : null
+
+  // Lazy initializer: correct value on first render, no sync effect needed.
+  const [comment, setComment] = useState(() =>
+    isEditing && editedAnnotation ? editedAnnotation.comment : ''
+  )
+
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+  const commentRef = useRef(comment)
+  commentRef.current = comment
+
+  // Focus input when popover opens
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        inputRef.current?.focus()
+        // Select all text in edit mode for easy replacement
+        if (isEditing) {
+          inputRef.current?.select()
+        }
+      })
+    })
+  }, [isEditing])
+
+  // Sync textarea height to content (avoids rows vs scrollHeight mismatch)
+  useLayoutEffect(() => {
+    const el = inputRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    // scrollHeight excludes border; add it back for border-box sizing
+    const border = el.offsetHeight - el.clientHeight
+    const desired = el.scrollHeight + border
+    const maxH = parseFloat(getComputedStyle(el).maxHeight) || Infinity
+    el.style.height = desired + 'px'
+    // Only allow scrolling when content actually exceeds max-height
+    el.style.overflowY = desired >= maxH ? 'auto' : 'hidden'
+  }, [comment])
+
+  // Dismiss: auto-save non-empty comment, then close
+  const dismiss = useCallback(() => {
+    const trimmed = commentRef.current.trim()
+    if (trimmed) {
+      if (isEditing && editingAnnotation) {
+        updateAnnotation(editingAnnotation.id, trimmed)
+      } else {
+        addAnnotation(trimmed)
+      }
+    }
+    setComment('')
+    setPendingSelection(null)
+    setEditingAnnotation(null)
+  }, [isEditing, editingAnnotation, addAnnotation, updateAnnotation, setPendingSelection, setEditingAnnotation])
+
+  // Dismiss on ESC. The parent overlay's Dialog.Content onEscapeKeyDown
+  // checks for [data-annotation-popover] and calls preventDefault() to
+  // keep the overlay open — so we only need to dismiss ourselves here.
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        dismiss()
+      }
+    }
+    document.addEventListener('keydown', handleKey, true)
+    return () => document.removeEventListener('keydown', handleKey, true)
+  }, [dismiss])
+
+  // Dismiss on click outside (but not on markers — their click handler updates the popover)
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        if ((e.target as HTMLElement).closest('[data-annotation-marker]')) return
+        dismiss()
+      }
+    }
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handleClick)
+    }, 100)
+    return () => {
+      clearTimeout(timer)
+      document.removeEventListener('mousedown', handleClick)
+    }
+  }, [dismiss])
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = comment.trim()
+    if (!trimmed) return
+
+    if (isEditing && editingAnnotation) {
+      updateAnnotation(editingAnnotation.id, trimmed)
+    } else {
+      addAnnotation(trimmed)
+    }
+    setComment('')
+  }, [comment, isEditing, editingAnnotation, addAnnotation, updateAnnotation])
+
+  const handleDelete = useCallback(() => {
+    if (editingAnnotation) {
+      removeAnnotation(editingAnnotation.id)
+      setComment('')
+    }
+  }, [editingAnnotation, removeAnnotation])
+
+  // Compute position from the active rect
+  const rect = isEditing ? editingAnnotation!.rect : pendingSelection!.rect
+  const citation = isEditing ? editedAnnotation?.citation : pendingSelection!.citation
+
+  let top = rect.bottom + POPOVER_GAP
+  let left = rect.left + rect.width / 2 - POPOVER_WIDTH / 2
+
+  // Clamp horizontally
+  if (left < 8) left = 8
+  if (left + POPOVER_WIDTH > window.innerWidth - 8) {
+    left = window.innerWidth - POPOVER_WIDTH - 8
+  }
+
+  // If not enough space below, flip above
+  if (top + 180 > window.innerHeight - 8) {
+    top = rect.top - 180 - POPOVER_GAP
+  }
+
+  const portalTarget = getPortalTarget(contentRef.current)
+
+  return ReactDOM.createPortal(
+    <motion.div
+      ref={popoverRef}
+      data-annotation-popover
+      initial={{ opacity: 0, scale: 0.95, y: -4 }}
+      animate={{ opacity: 1, scale: 1, y: 0 }}
+      transition={{ duration: 0.15, ease: 'easeOut' }}
+      className={cn(
+        "fixed z-[400] p-3",
+        "bg-background rounded-[8px] shadow-strong border border-border/50",
+      )}
+      style={{ top, left, width: POPOVER_WIDTH }}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      {/* Truncated citation preview */}
+      {citation && (
+        <div className="text-[11px] text-muted-foreground mb-2 line-clamp-2 italic">
+          &ldquo;{citation.slice(0, 80)}{citation.length > 80 ? '…' : ''}&rdquo;
+        </div>
+      )}
+
+      <textarea
+        ref={inputRef}
+        rows={2}
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault()
+            handleSubmit()
+          }
+        }}
+        placeholder="Add your comment…"
+        className={cn(
+          "w-full px-2.5 py-1.5 text-sm rounded-[6px] outline-none resize-none",
+          "bg-muted/30 border border-border/50",
+          "placeholder:text-muted-foreground/50",
+          "focus:border-accent/50 focus:ring-1 focus:ring-accent/20",
+          "max-h-[calc(6*1.5em)]"
+        )}
+      />
+
+      <div className="flex items-center justify-between mt-2">
+        {/* Delete button (edit mode only) */}
+        {isEditing ? (
+          <button
+            onClick={handleDelete}
+            className={cn(
+              "flex items-center gap-1 px-2 py-1 text-xs rounded-[4px] transition-colors",
+              "text-muted-foreground hover:text-destructive"
+            )}
+          >
+            <Trash2 className="w-3 h-3" />
+            <span>Delete</span>
+          </button>
+        ) : (
+          <div />
+        )}
+
+        <button
+          onClick={handleSubmit}
+          disabled={!comment.trim()}
+          className={cn(
+            "px-2.5 py-1 text-xs font-medium rounded-[6px] transition-colors",
+            comment.trim()
+              ? "bg-accent text-white hover:bg-accent/90"
+              : "bg-muted text-muted-foreground cursor-not-allowed"
+          )}
+        >
+          {isEditing ? 'Save' : 'Add'}
+        </button>
+      </div>
+    </motion.div>,
+    portalTarget
+  )
+}

--- a/packages/ui/src/components/markdown-annotations/MarkdownAnnotationContext.tsx
+++ b/packages/ui/src/components/markdown-annotations/MarkdownAnnotationContext.tsx
@@ -1,0 +1,224 @@
+/**
+ * MarkdownAnnotationContext — State for markdown text annotations.
+ *
+ * Stores annotations (citation + comment), the pending selection waiting for a
+ * comment, editing state, hover state, and helpers to copy / format output.
+ * When a planId is provided, annotations are persisted in a module-scoped store
+ * so they survive component unmounts (e.g. session switches). Cleared on app restart.
+ */
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { getStoredAnnotations, setStoredAnnotations } from './annotationStore'
+
+export interface SerializedRange {
+  startContainerPath: string
+  startOffset: number
+  endContainerPath: string
+  endOffset: number
+}
+
+export interface Annotation {
+  id: string
+  citation: string
+  comment: string
+  rangeInfo: SerializedRange
+}
+
+export interface PendingSelection {
+  rect: DOMRect
+  citation: string
+  range: Range
+}
+
+export interface EditingAnnotation {
+  id: string
+  rect: DOMRect
+}
+
+export interface MarkdownAnnotationContextValue {
+  annotations: Annotation[]
+  pendingSelection: PendingSelection | null
+  editingAnnotation: EditingAnnotation | null
+  hoveredAnnotationId: string | null
+  addAnnotation: (comment: string) => void
+  updateAnnotation: (id: string, comment: string) => void
+  removeAnnotation: (id: string) => void
+  clearAll: () => void
+  setPendingSelection: (sel: PendingSelection | null) => void
+  setEditingAnnotation: (editing: EditingAnnotation | null) => void
+  setHoveredAnnotationId: (id: string | null) => void
+  getCommentsText: () => string
+  copyComments: () => Promise<void>
+  contentRef: React.RefObject<HTMLDivElement | null>
+}
+
+const MarkdownAnnotationCtx = createContext<MarkdownAnnotationContextValue | null>(null)
+
+let nextId = 0
+function uid() {
+  return `ann-${++nextId}-${Date.now().toString(36)}`
+}
+
+function nodeToPath(node: Node, root: Node): string {
+  const parts: string[] = []
+  let cur: Node | null = node
+  while (cur && cur !== root) {
+    const parent: ParentNode | null = cur.parentNode
+    if (!parent) break
+    let idx = 0
+    for (let i = 0; i < parent.childNodes.length; i++) {
+      if (parent.childNodes[i] === cur) { idx = i; break }
+    }
+    parts.unshift(String(idx))
+    cur = parent
+  }
+  return parts.join('/')
+}
+
+export function pathToNode(path: string, root: Node): Node | null {
+  if (!path) return root
+  const parts = path.split('/')
+  let cur: Node | null = root
+  for (const p of parts) {
+    if (!cur) return null
+    cur = cur.childNodes[Number(p)] ?? null
+  }
+  return cur
+}
+
+/** Returns null if nodes are gone (e.g. DOM changed between serialize and restore). */
+export function restoreRange(info: SerializedRange, root: Node): Range | null {
+  try {
+    const startNode = pathToNode(info.startContainerPath, root)
+    const endNode = pathToNode(info.endContainerPath, root)
+    if (!startNode || !endNode) return null
+    const r = document.createRange()
+    r.setStart(startNode, info.startOffset)
+    r.setEnd(endNode, info.endOffset)
+    return r
+  } catch {
+    return null
+  }
+}
+
+function serializeRange(range: Range, root: Node): SerializedRange {
+  return {
+    startContainerPath: nodeToPath(range.startContainer, root),
+    startOffset: range.startOffset,
+    endContainerPath: nodeToPath(range.endContainer, root),
+    endOffset: range.endOffset,
+  }
+}
+
+function trimCitation(text: string, max = 120): string {
+  const trimmed = text.replace(/\s+/g, ' ').trim()
+  if (trimmed.length <= max) return trimmed
+  return trimmed.slice(0, max) + '…'
+}
+
+/** Default comment formatter — used when no custom formatter is provided. */
+function defaultFormatComments(annotations: Annotation[]): string {
+  if (annotations.length === 0) return ''
+  const lines = annotations.map(a => `- "${a.citation}" — ${a.comment}`)
+  return `I have comments on the plan. Please revise it accordingly:\n\n${lines.join('\n')}\n\nPresent the updated plan.`
+}
+
+interface MarkdownAnnotationProviderProps {
+  children: ReactNode
+  /** Stable identifier for this plan — used to persist annotations across unmounts. */
+  planId?: string
+  /** Custom formatter for comments text. Receives annotations, returns string. */
+  formatComments?: (annotations: Annotation[]) => string
+}
+
+export function MarkdownAnnotationProvider({ children, planId, formatComments }: MarkdownAnnotationProviderProps) {
+  const [annotations, setAnnotations] = useState<Annotation[]>(
+    () => planId ? getStoredAnnotations(planId) : []
+  )
+  const [pendingSelection, setPendingSelection] = useState<PendingSelection | null>(null)
+  const [editingAnnotation, setEditingAnnotation] = useState<EditingAnnotation | null>(null)
+  const [hoveredAnnotationId, setHoveredAnnotationId] = useState<string | null>(null)
+  const contentRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (planId) {
+      setStoredAnnotations(planId, annotations)
+    }
+  }, [planId, annotations])
+
+  const addAnnotation = useCallback((comment: string) => {
+    setPendingSelection(prev => {
+      if (!prev || !contentRef.current) return null
+
+      const rangeInfo = serializeRange(prev.range, contentRef.current)
+      const annotation: Annotation = {
+        id: uid(),
+        citation: trimCitation(prev.citation),
+        comment,
+        rangeInfo,
+      }
+      setAnnotations(a => [...a, annotation])
+      return null
+    })
+  }, [])
+
+  const updateAnnotation = useCallback((id: string, comment: string) => {
+    setAnnotations(a => a.map(ann =>
+      ann.id === id ? { ...ann, comment } : ann
+    ))
+    setEditingAnnotation(null)
+  }, [])
+
+  const removeAnnotation = useCallback((id: string) => {
+    setAnnotations(a => a.filter(ann => ann.id !== id))
+    setEditingAnnotation(null)
+  }, [])
+
+  const clearAll = useCallback(() => {
+    setAnnotations([])
+    setEditingAnnotation(null)
+    setHoveredAnnotationId(null)
+  }, [])
+
+  const formatter = formatComments ?? defaultFormatComments
+
+  const getCommentsText = useCallback(() => {
+    return formatter(annotations)
+  }, [annotations, formatter])
+
+  const copyComments = useCallback(async () => {
+    const text = getCommentsText()
+    if (text) {
+      await navigator.clipboard.writeText(text)
+    }
+  }, [getCommentsText])
+
+  const value = useMemo<MarkdownAnnotationContextValue>(() => ({
+    annotations,
+    pendingSelection,
+    editingAnnotation,
+    hoveredAnnotationId,
+    addAnnotation,
+    updateAnnotation,
+    removeAnnotation,
+    clearAll,
+    setPendingSelection,
+    setEditingAnnotation,
+    setHoveredAnnotationId,
+    getCommentsText,
+    copyComments,
+    contentRef,
+  }), [annotations, pendingSelection, editingAnnotation, hoveredAnnotationId, addAnnotation, updateAnnotation, removeAnnotation, clearAll, getCommentsText, copyComments])
+
+  return (
+    <MarkdownAnnotationCtx.Provider value={value}>
+      {children}
+    </MarkdownAnnotationCtx.Provider>
+  )
+}
+
+export function useMarkdownAnnotations() {
+  const ctx = useContext(MarkdownAnnotationCtx)
+  if (!ctx) throw new Error('useMarkdownAnnotations must be used within MarkdownAnnotationProvider')
+  return ctx
+}

--- a/packages/ui/src/components/markdown-annotations/MarkdownAnnotationLayer.tsx
+++ b/packages/ui/src/components/markdown-annotations/MarkdownAnnotationLayer.tsx
@@ -1,0 +1,381 @@
+/**
+ * MarkdownAnnotationLayer — Wraps markdown content to detect text selection,
+ * manage CSS Custom Highlights, render numbered margin markers, and handle
+ * bidirectional hover/click interactions between markers and highlighted text.
+ */
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { motion, AnimatePresence } from 'motion/react'
+import { Pencil } from 'lucide-react'
+import { useMarkdownAnnotations, pathToNode, restoreRange, type Annotation } from './MarkdownAnnotationContext'
+import { cn } from '../../lib/utils'
+
+const HL_BASE = 'md-annotation'
+const HL_HOVER = 'md-annotation-hover'
+const HL_PENDING = 'md-annotation-pending'
+
+// Injected at runtime because Tailwind CSS v4 doesn't reliably process ::highlight() rules.
+let highlightStylesInjected = false
+function ensureHighlightStyles() {
+  if (highlightStylesInjected) return
+  highlightStylesInjected = true
+  const style = document.createElement('style')
+  style.textContent = `
+    ::highlight(${HL_BASE}) {
+      background-color: oklch(from var(--accent) l c h / 0.25);
+    }
+    ::highlight(${HL_HOVER}) {
+      background-color: oklch(from var(--accent) l c h / 0.40);
+    }
+    ::highlight(${HL_PENDING}) {
+      background-color: oklch(from var(--accent) l c h / 0.35);
+    }
+  `
+  document.head.appendChild(style)
+}
+
+function syncHighlights(
+  annotations: Annotation[],
+  hoveredId: string | null,
+  pendingRange: Range | null,
+  root: Node | null,
+) {
+  if (!root || typeof CSS === 'undefined' || !('highlights' in CSS)) return
+  ensureHighlightStyles()
+
+  const baseRanges: Range[] = []
+  const hoverRanges: Range[] = []
+
+  for (const ann of annotations) {
+    const r = restoreRange(ann.rangeInfo, root)
+    if (!r) continue
+    baseRanges.push(r)
+    if (ann.id === hoveredId) {
+      hoverRanges.push(r)
+    }
+  }
+
+  if (baseRanges.length > 0) {
+    // @ts-expect-error — Highlight API types not yet in lib.dom
+    CSS.highlights.set(HL_BASE, new Highlight(...baseRanges))
+  } else {
+    // @ts-expect-error
+    CSS.highlights.delete(HL_BASE)
+  }
+
+  if (hoverRanges.length > 0) {
+    // @ts-expect-error
+    CSS.highlights.set(HL_HOVER, new Highlight(...hoverRanges))
+  } else {
+    // @ts-expect-error
+    CSS.highlights.delete(HL_HOVER)
+  }
+
+  if (pendingRange) {
+    // @ts-expect-error
+    CSS.highlights.set(HL_PENDING, new Highlight(pendingRange))
+  } else {
+    // @ts-expect-error
+    CSS.highlights.delete(HL_PENDING)
+  }
+}
+
+function annotationAtPoint(
+  x: number,
+  y: number,
+  annotations: Annotation[],
+  root: Node,
+): string | null {
+  for (const ann of annotations) {
+    const range = restoreRange(ann.rangeInfo, root)
+    if (!range) continue
+    const rects = range.getClientRects()
+    for (let i = 0; i < rects.length; i++) {
+      const r = rects[i]!
+      if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) {
+        return ann.id
+      }
+    }
+  }
+  return null
+}
+
+interface MarkerPosition {
+  annotation: Annotation
+  index: number
+  top: number
+  rightOffset: number
+}
+
+function computeMarkerPositions(annotations: Annotation[], root: Node | null): MarkerPosition[] {
+  if (!root) return []
+
+  const positions: MarkerPosition[] = annotations.map((ann, i) => ({
+    annotation: ann,
+    index: i,
+    top: computeTop(ann.rangeInfo, root),
+    rightOffset: 0,
+  }))
+
+  // Group by top (within 6px tolerance) and assign horizontal offsets
+  const used = new Set<number>()
+  for (let i = 0; i < positions.length; i++) {
+    if (used.has(i)) continue
+    const group = [i]
+    for (let j = i + 1; j < positions.length; j++) {
+      if (used.has(j)) continue
+      if (Math.abs(positions[j]!.top - positions[i]!.top) < 6) {
+        group.push(j)
+      }
+    }
+    group.forEach((idx, slot) => {
+      positions[idx]!.rightOffset = (group.length - 1 - slot) * 24
+      used.add(idx)
+    })
+  }
+
+  return positions
+}
+
+const MARKER_SIZE = 20
+
+function computeTop(rangeInfo: Annotation['rangeInfo'], root: Node): number {
+  try {
+    const startNode = pathToNode(rangeInfo.startContainerPath, root)
+    const endNode = pathToNode(rangeInfo.endContainerPath, root)
+    if (!startNode || !endNode) return 0
+    const r = document.createRange()
+    r.setStart(startNode, rangeInfo.startOffset)
+    r.setEnd(endNode, rangeInfo.endOffset)
+    const rects = r.getClientRects()
+    if (rects.length === 0) return 0
+    const firstRect = rects[0]!
+    const rootRect = (root as HTMLElement).getBoundingClientRect()
+    return firstRect.top + firstRect.height / 2 - rootRect.top - MARKER_SIZE / 2
+  } catch {
+    return 0
+  }
+}
+
+function AnnotationMarker({
+  index,
+  top,
+  rightOffset,
+  isHovered,
+  onHover,
+  onLeave,
+  onClick,
+}: {
+  index: number
+  top: number
+  rightOffset: number
+  isHovered: boolean
+  onHover: () => void
+  onLeave: () => void
+  onClick: () => void
+}) {
+  return (
+    <button
+      aria-label={`Comment ${index + 1}`}
+      className={cn(
+        "absolute w-5 h-5 rounded-full flex items-center justify-center overflow-hidden",
+        "bg-accent text-white text-[10px] font-semibold leading-none",
+        "cursor-pointer select-none shadow-sm",
+        "transition-transform duration-100 will-change-transform",
+        isHovered && "scale-110"
+      )}
+      style={{ top, right: rightOffset }}
+      title={`Comment #${index + 1}`}
+      onMouseDown={(e) => e.preventDefault()}
+      onMouseEnter={onHover}
+      onMouseLeave={onLeave}
+      onClick={(e) => { e.stopPropagation(); onClick() }}
+    >
+      <AnimatePresence mode="popLayout" initial={false}>
+        {isHovered ? (
+          <motion.span
+            key="edit"
+            className="flex items-center justify-center"
+            initial={{ scale: 0.7, filter: 'blur(2px)', opacity: 0 }}
+            animate={{ scale: 1, filter: 'blur(0px)', opacity: 1 }}
+            exit={{ scale: 0.7, filter: 'blur(2px)', opacity: 0 }}
+            transition={{ duration: 0.15, ease: 'easeOut' }}
+          >
+            <Pencil className="w-2.5 h-2.5" />
+          </motion.span>
+        ) : (
+          <motion.span
+            key="number"
+            className="flex items-center justify-center"
+            initial={{ scale: 0.7, filter: 'blur(2px)', opacity: 0 }}
+            animate={{ scale: 1, filter: 'blur(0px)', opacity: 1 }}
+            exit={{ scale: 0.7, filter: 'blur(2px)', opacity: 0 }}
+            transition={{ duration: 0.15, ease: 'easeOut' }}
+          >
+            {index + 1}
+          </motion.span>
+        )}
+      </AnimatePresence>
+    </button>
+  )
+}
+
+export function MarkdownAnnotationLayer({ children }: { children: ReactNode }) {
+  const {
+    annotations,
+    pendingSelection,
+    hoveredAnnotationId,
+    editingAnnotation,
+    setPendingSelection,
+    setEditingAnnotation,
+    setHoveredAnnotationId,
+    contentRef,
+  } = useMarkdownAnnotations()
+
+  const localRef = useRef<HTMLDivElement>(null)
+
+  // Stack-based ref management: last mounted layer wins.
+  // When this layer unmounts the previous layer's DOM is restored,
+  // ensuring addAnnotation serializes ranges against the correct root.
+  useLayoutEffect(() => {
+    const prev = contentRef.current
+    contentRef.current = localRef.current
+    return () => {
+      contentRef.current = prev
+    }
+  }, [contentRef])
+
+  // No dependency array — re-syncs on every render. Necessary because when the
+  // fullscreen layer unmounts (clearing highlights), the inline layer must
+  // immediately re-apply highlights from its own DOM.
+  useLayoutEffect(() => {
+    if (!localRef.current) return
+    syncHighlights(annotations, hoveredAnnotationId, pendingSelection?.range ?? null, localRef.current)
+    return () => {
+      if (typeof CSS !== 'undefined' && 'highlights' in CSS) {
+        // @ts-expect-error
+        CSS.highlights.delete(HL_BASE)
+        // @ts-expect-error
+        CSS.highlights.delete(HL_HOVER)
+        // @ts-expect-error
+        CSS.highlights.delete(HL_PENDING)
+      }
+    }
+  })
+
+  const [markerPositions, setMarkerPositions] = useState<MarkerPosition[]>([])
+  useLayoutEffect(() => {
+    setMarkerPositions(computeMarkerPositions(annotations, localRef.current))
+  }, [annotations])
+
+  // Listen on document so we catch mouseup even when the cursor drifts outside the layer
+  useEffect(() => {
+    const onMouseUp = (e: MouseEvent) => {
+      if ((e.target as HTMLElement).closest('[data-annotation-marker]')) return
+
+      const sel = window.getSelection()
+      if (!sel || sel.isCollapsed || !localRef.current) return
+
+      const text = sel.toString().trim()
+      if (!text) return
+
+      const range = sel.getRangeAt(0)
+      if (!localRef.current.contains(range.commonAncestorContainer)) return
+
+      const rect = range.getBoundingClientRect()
+      setEditingAnnotation(null)
+      setPendingSelection({ rect, citation: text, range: range.cloneRange() })
+      sel.removeAllRanges()
+    }
+    document.addEventListener('mouseup', onMouseUp)
+    return () => document.removeEventListener('mouseup', onMouseUp)
+  }, [setPendingSelection, setEditingAnnotation])
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    if ((e.target as HTMLElement).closest('[data-annotation-marker]')) return
+    if (!localRef.current || annotations.length === 0) return
+    if (!editingAnnotation && !pendingSelection) return
+
+    const hitId = annotationAtPoint(e.clientX, e.clientY, annotations, localRef.current)
+    if (hitId) {
+      e.preventDefault()
+    }
+  }, [annotations, editingAnnotation, pendingSelection])
+
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    if ((e.target as HTMLElement).closest('[data-annotation-marker]')) return
+    const sel = window.getSelection()
+    if (sel && !sel.isCollapsed) return
+
+    if (!localRef.current || annotations.length === 0) return
+
+    const hitId = annotationAtPoint(e.clientX, e.clientY, annotations, localRef.current)
+    if (hitId) {
+      const ann = annotations.find(a => a.id === hitId)
+      if (!ann) return
+      const range = restoreRange(ann.rangeInfo, localRef.current)
+      if (!range) return
+      const rect = range.getBoundingClientRect()
+      setEditingAnnotation({ id: hitId, rect })
+    }
+  }, [annotations, setEditingAnnotation])
+
+  const hoveredIdRef = useRef(hoveredAnnotationId)
+  hoveredIdRef.current = hoveredAnnotationId
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!localRef.current || annotations.length === 0) {
+      if (hoveredIdRef.current) setHoveredAnnotationId(null)
+      return
+    }
+
+    if ((e.target as HTMLElement).closest('[data-annotation-marker]')) return
+
+    const hitId = annotationAtPoint(e.clientX, e.clientY, annotations, localRef.current)
+    if (hitId !== hoveredIdRef.current) {
+      setHoveredAnnotationId(hitId)
+    }
+  }, [annotations, setHoveredAnnotationId])
+
+  const handleMouseLeave = useCallback(() => {
+    if (hoveredIdRef.current) setHoveredAnnotationId(null)
+  }, [setHoveredAnnotationId])
+
+  const handleMarkerClick = useCallback((ann: Annotation) => {
+    if (!localRef.current) return
+    const range = restoreRange(ann.rangeInfo, localRef.current)
+    if (!range) return
+    const rect = range.getBoundingClientRect()
+    setEditingAnnotation({ id: ann.id, rect })
+  }, [setEditingAnnotation])
+
+  return (
+    <div
+      ref={localRef}
+      className={cn(
+        "relative pr-7",
+        annotations.length > 0 && "cursor-text",
+      )}
+      onMouseDown={handleMouseDown}
+      onClick={handleClick}
+      onMouseMove={annotations.length > 0 ? handleMouseMove : undefined}
+      onMouseLeave={annotations.length > 0 ? handleMouseLeave : undefined}
+    >
+      {children}
+
+      {markerPositions.map(({ annotation, index, top, rightOffset }) => (
+        <div key={annotation.id} data-annotation-marker>
+          <AnnotationMarker
+            index={index}
+            top={top}
+            rightOffset={rightOffset}
+            isHovered={hoveredAnnotationId === annotation.id}
+            onHover={() => setHoveredAnnotationId(annotation.id)}
+            onLeave={() => setHoveredAnnotationId(null)}
+            onClick={() => handleMarkerClick(annotation)}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/ui/src/components/markdown-annotations/annotationStore.ts
+++ b/packages/ui/src/components/markdown-annotations/annotationStore.ts
@@ -1,0 +1,19 @@
+import type { Annotation } from './MarkdownAnnotationContext'
+
+const store = new Map<string, Annotation[]>()
+
+export function getStoredAnnotations(planId: string): Annotation[] {
+  return store.get(planId) ?? []
+}
+
+export function setStoredAnnotations(planId: string, annotations: Annotation[]): void {
+  if (annotations.length === 0) {
+    store.delete(planId)
+  } else {
+    store.set(planId, annotations)
+  }
+}
+
+export function clearStoredAnnotations(planId: string): void {
+  store.delete(planId)
+}

--- a/packages/ui/src/components/markdown-annotations/index.ts
+++ b/packages/ui/src/components/markdown-annotations/index.ts
@@ -1,0 +1,7 @@
+export { MarkdownAnnotationProvider, useMarkdownAnnotations } from './MarkdownAnnotationContext'
+export type { Annotation, MarkdownAnnotationContextValue, EditingAnnotation } from './MarkdownAnnotationContext'
+export { MarkdownAnnotationLayer } from './MarkdownAnnotationLayer'
+export { AnnotationPopover } from './AnnotationPopover'
+export { AnnotationControls } from './AnnotationControls'
+export { AnnotationIsland } from './AnnotationIsland'
+export { clearStoredAnnotations } from './annotationStore'

--- a/packages/ui/src/components/overlay/DocumentFormattedMarkdownOverlay.tsx
+++ b/packages/ui/src/components/overlay/DocumentFormattedMarkdownOverlay.tsx
@@ -6,6 +6,7 @@
  * - Copy button via FullscreenOverlayBase's built-in copyContent prop
  * - Optional "Plan" header variant
  * - Optional filePath badge with dual-trigger menu (Open / Reveal in {file manager})
+ * - Plan annotation support: select text → add comments → copy/reply
  *
  * Background and scenic blur are provided by FullscreenOverlayBase.
  * Uses FullscreenOverlayBase for portal, traffic lights, ESC handling, and header.
@@ -15,6 +16,7 @@ import { ListTodo } from 'lucide-react'
 import { Markdown } from '../markdown'
 import { FullscreenOverlayBase } from './FullscreenOverlayBase'
 import type { OverlayTypeBadge } from './FullscreenOverlayBaseHeader'
+import { MarkdownAnnotationLayer, AnnotationPopover, AnnotationIsland } from '../markdown-annotations'
 
 export interface DocumentFormattedMarkdownOverlayProps {
   /** The content to display (markdown) */
@@ -35,6 +37,8 @@ export interface DocumentFormattedMarkdownOverlayProps {
   typeBadge?: OverlayTypeBadge
   /** Optional error message — renders a tinted error banner above the content card */
   error?: string
+  /** Callback to send structured comments text to the chat input (plan annotations) */
+  onSendToChat?: (text: string) => void
 }
 
 export function DocumentFormattedMarkdownOverlay({
@@ -47,8 +51,22 @@ export function DocumentFormattedMarkdownOverlay({
   filePath,
   typeBadge,
   error,
+  onSendToChat,
 }: DocumentFormattedMarkdownOverlayProps) {
-  return (
+  const isPlan = variant === 'plan'
+
+  const markdownContent = (
+    <Markdown
+      mode="minimal"
+      onUrlClick={onOpenUrl}
+      onFileClick={onOpenFile}
+      hideFirstMermaidExpand={false}
+    >
+      {content}
+    </Markdown>
+  )
+
+  const overlayContent = (
     <FullscreenOverlayBase
       isOpen={isOpen}
       onClose={onClose}
@@ -56,6 +74,12 @@ export function DocumentFormattedMarkdownOverlay({
       typeBadge={typeBadge}
       copyContent={content}
       error={error ? { label: 'Write Failed', message: error } : undefined}
+      onEscapeKeyDown={(e) => {
+        // If annotation popover is open, let it handle ESC — don't close the overlay
+        if (document.querySelector('[data-annotation-popover]')) {
+          e.preventDefault()
+        }
+      }}
     >
       {/* Content wrapper — min-h-full for vertical centering within FullscreenOverlayBase's scroll container.
           Scrolling and gradient fade mask are handled by FullscreenOverlayBase. */}
@@ -63,7 +87,7 @@ export function DocumentFormattedMarkdownOverlay({
         {/* Content card - my-auto centers vertically when content is small, flows naturally when large */}
         <div className="bg-background rounded-[16px] shadow-strong w-full max-w-[960px] h-fit mx-auto my-auto">
           {/* Plan header (variant="plan" only) */}
-          {variant === 'plan' && (
+          {isPlan && (
             <div className="px-4 py-2 border-b border-border/30 flex items-center gap-2 bg-success/5 rounded-t-[16px]">
               <ListTodo className="w-3 h-3 text-success" />
               <span className="text-[13px] font-medium text-success">Plan</span>
@@ -73,18 +97,21 @@ export function DocumentFormattedMarkdownOverlay({
           {/* Content area */}
           <div className="px-10 pt-8 pb-8">
             <div className="text-sm">
-              <Markdown
-                mode="minimal"
-                onUrlClick={onOpenUrl}
-                onFileClick={onOpenFile}
-                hideFirstMermaidExpand={false}
-              >
-                {content}
-              </Markdown>
+              {isPlan ? (
+                <MarkdownAnnotationLayer>{markdownContent}</MarkdownAnnotationLayer>
+              ) : (
+                markdownContent
+              )}
             </div>
           </div>
         </div>
       </div>
+
+      {/* Plan annotation UI (portals) */}
+      {isPlan && <AnnotationPopover />}
+      {isPlan && <AnnotationIsland onSendToChat={onSendToChat} onDone={onClose} />}
     </FullscreenOverlayBase>
   )
+
+  return overlayContent
 }

--- a/packages/ui/src/components/overlay/FullscreenOverlayBase.tsx
+++ b/packages/ui/src/components/overlay/FullscreenOverlayBase.tsx
@@ -82,6 +82,8 @@ export interface FullscreenOverlayBaseProps {
 
   /** Optional error banner — rendered between header and children */
   error?: OverlayErrorBannerProps
+  /** Intercept ESC key before the dialog closes — call e.preventDefault() to keep it open */
+  onEscapeKeyDown?: (e: KeyboardEvent) => void
 }
 
 export function FullscreenOverlayBase({
@@ -98,6 +100,7 @@ export function FullscreenOverlayBase({
   headerActions,
   copyContent,
   error,
+  onEscapeKeyDown,
 }: FullscreenOverlayBaseProps) {
   const { onSetTrafficLightsVisible } = usePlatform()
 
@@ -129,6 +132,7 @@ export function FullscreenOverlayBase({
           )}
           style={{ zIndex: Z_FULLSCREEN }}
           onOpenAutoFocus={(e) => e.preventDefault()}
+          onEscapeKeyDown={onEscapeKeyDown}
         >
           {/* Visually hidden title for accessibility - required by Radix Dialog */}
           <Dialog.Title className="sr-only">{accessibleTitle}</Dialog.Title>


### PR DESCRIPTION
## Summary

Proof-of-concept for a better plan feedback UX (can be also extended on general .md files feedback) — instead of typing free-form chat messages, users can select text directly in a plan card, leave inline comments on specific passages, and send all collected comments back to the agent as a structured reply.

Inspired by [agentation.dev](https://agentation.dev).

### How it works
1. Select text in a plan → floating popover appears for adding a comment
2. Annotated ranges get persistent highlights with numbered margin markers
3. "Reply with Comments" formats all annotations into a structured message and sends it to chat
4. Works in both inline plan cards and the fullscreen plan overlay

Demo:
 
https://github.com/user-attachments/assets/e1c55724-9fa2-440a-8f6d-c16f674208af

