### PR TITLE
fix: pass Azure OpenAI base URL to Pi agent subprocess

### DIFF
--- a/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
+++ b/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
@@ -254,7 +254,18 @@ export function ApiKeyInput({
   const handleBaseUrlChange = (value: string) => {
     setBaseUrl(value)
     const presetKey = getPresetForUrl(value, presets)
-    setActivePreset(presetKey)
+    if (presetKey !== 'custom') {
+      setActivePreset(presetKey)
+    } else {
+      const currentPresetObj = presets.find(p => p.key === activePreset)
+      // Only fall back to 'custom' if the current preset has a non-empty default URL,
+      // meaning the user is deviating from a known endpoint. Presets with empty URLs
+      // (e.g. Azure OpenAI) expect user-provided URLs — switching to 'custom' would
+      // lose the piAuthProvider and break credential routing.
+      if (currentPresetObj && currentPresetObj.url !== '') {
+        setActivePreset('custom')
+      }
+    }
     setModelError(null)
     if (!connectionDefaultModel.trim()) {
       if (presetKey === 'ollama') {

--- a/packages/pi-agent-server/src/index.ts
+++ b/packages/pi-agent-server/src/index.ts
@@ -61,7 +61,7 @@ import { createGoogleSearchTool } from './tools/google-search.ts';
 
 /** Messages from main process (stdin) */
 type InboundMessage =
-  | { type: 'init'; apiKey: string; model: string; cwd: string; thinkingLevel: string; workspaceRootPath: string; sessionId: string; sessionPath: string; workingDirectory: string; plansFolderPath: string; miniModel?: string; agentDir?: string; providerType?: string; authType?: string; workspaceId?: string; branchFromSdkSessionId?: string; branchFromSessionPath?: string; piAuth?: { provider: string; credential: { type: 'api_key'; key: string } | { type: 'oauth'; access: string; refresh: string; expires: number } } }
+  | { type: 'init'; apiKey: string; model: string; cwd: string; thinkingLevel: string; workspaceRootPath: string; sessionId: string; sessionPath: string; workingDirectory: string; plansFolderPath: string; miniModel?: string; agentDir?: string; providerType?: string; authType?: string; workspaceId?: string; baseUrl?: string; branchFromSdkSessionId?: string; branchFromSessionPath?: string; piAuth?: { provider: string; credential: { type: 'api_key'; key: string } | { type: 'oauth'; access: string; refresh: string; expires: number } } }
   | { type: 'prompt'; id: string; message: string; systemPrompt: string; images?: Array<{ type: 'image'; data: string; mimeType: string }> }
   | { type: 'register_tools'; tools: ProxyToolDef[] }
   | { type: 'tool_execute_response'; requestId: string; result: { content: string; isError: boolean } }
@@ -877,6 +877,13 @@ async function handleInit(msg: Extract<InboundMessage, { type: 'init' }>): Promi
   }
 
   initConfig = msg;
+
+  // Azure OpenAI requires a base URL (customer-specific deployment endpoint).
+  // The Pi SDK (via Vercel AI SDK) reads AZURE_OPENAI_BASE_URL from the environment.
+  if (msg.piAuth?.provider === 'azure-openai-responses' && msg.baseUrl) {
+    process.env.AZURE_OPENAI_BASE_URL = msg.baseUrl;
+    debugLog(`Set AZURE_OPENAI_BASE_URL=${msg.baseUrl}`);
+  }
 
   // Start callback server for call_llm (idempotent — skips if already running)
   await startCallbackServer();

--- a/packages/session-tools-core/tsconfig.json
+++ b/packages/session-tools-core/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",

--- a/packages/shared/src/agent/backend/internal/driver-types.ts
+++ b/packages/shared/src/agent/backend/internal/driver-types.ts
@@ -23,6 +23,8 @@ export interface BackendRuntimePaths {
 export interface BackendRuntimePayload extends Record<string, unknown> {
   paths?: BackendRuntimePaths;
   piAuthProvider?: string;
+  /** Custom base URL from the LLM connection (e.g. Azure OpenAI endpoint) */
+  baseUrl?: string;
 }
 
 export interface BackendResolutionContext {

--- a/packages/shared/src/agent/backend/internal/drivers/pi.ts
+++ b/packages/shared/src/agent/backend/internal/drivers/pi.ts
@@ -88,6 +88,7 @@ export const piDriver: ProviderDriver = {
       node: resolvedPaths.nodeRuntimePath,
     },
     piAuthProvider: providerOptions?.piAuthProvider || context.connection?.piAuthProvider,
+    baseUrl: context.connection?.baseUrl,
   }),
   fetchModels: async ({ connection, credentials, resolvedPaths, timeoutMs }) => {
     // Copilot OAuth: fetch models dynamically from the Copilot API

--- a/packages/shared/src/agent/pi-agent.ts
+++ b/packages/shared/src/agent/pi-agent.ts
@@ -383,6 +383,7 @@ export class PiAgent extends BaseAgent {
       authType: this.config.authType,
       workspaceId: this.config.workspace.id,
       piAuth,
+      baseUrl: runtime.baseUrl,
       // Branch params for Pi SDK session fork
       branchFromSdkSessionId: this.config.session?.branchFromSdkSessionId,
       branchFromSessionPath: this.config.session?.branchFromSessionPath,


### PR DESCRIPTION
## Summary

Azure OpenAI connections always fail with "Azure OpenAI base URL is required" because the connection's `baseUrl` (customer-specific deployment endpoint) was never forwarded from the LLM connection config to the Pi agent subprocess.

## Changes

- **`driver-types.ts`**: Add `baseUrl` to `BackendRuntimePayload` type
- **`drivers/pi.ts`**: Pass `connection.baseUrl` through Pi driver's `buildRuntime`
- **`pi-agent.ts`**: Include `baseUrl` in the init message sent to the subprocess
- **`pi-agent-server/index.ts`**: Accept `baseUrl` in `InboundMessage` and set `AZURE_OPENAI_BASE_URL` env var when the provider is `azure-openai-responses`
- **`ApiKeyInput.tsx`**: Prevent preset from switching to `custom` when typing a URL for presets with empty default URLs (e.g. Azure OpenAI), which would lose the `piAuthProvider` and break credential routing
- **`session-tools-core/tsconfig.json`**: Fix `extends` path referencing non-existent `tsconfig.base.json`

## Testing
- bun test 
- bun run typecheck:all
- Verified the `baseUrl` flows from `LlmConnection` → Pi driver runtime → PiAgent init message → subprocess env var
- The `AZURE_OPENAI_BASE_URL` env var is only set when `piAuth.provider === 'azure-openai-responses'` — no impact on other providers
- Confirmed the tsconfig fix resolves all 17 pre-existing type errors in `session-tools-core`

Made with [Cursor](https://cursor.com)