### PR TITLE
fix: add missing dependencies in v0.7.1 packages

### DIFF
--- a/packages/pi-agent-server/package.json
+++ b/packages/pi-agent-server/package.json
@@ -15,7 +15,11 @@
     "@mariozechner/pi-coding-agent": "0.56.2",
     "@mariozechner/pi-agent-core": "0.56.2",
     "@mariozechner/pi-ai": "0.56.2",
-    "duck-duck-scrape": "^2.2.7"
+    "@sinclair/typebox": "^0.34.0",
+    "duck-duck-scrape": "^2.2.7",
+    "node-html-parser": "^7.0.0",
+    "pdfjs-dist": "^4.9.246",
+    "turndown": "^7.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"

--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@craft-agent/core": "workspace:*",
     "@craft-agent/shared": "workspace:*",
+    "@mariozechner/pi-ai": "^0.56.2",
     "ws": "^8.19.0",
     "sharp": "0.34.5"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -63,9 +63,11 @@
     "@craft-agent/session-tools-core": "workspace:*",
     "@isaacs/ttlcache": "^2.1.4",
     "@leeoniya/ufuzzy": "^1.0.19",
+    "@mariozechner/pi-ai": "^0.56.2",
     "bash-parser": "^0.5.0",
     "croner": "^10.0.1",
     "filtrex": "^3.1.0",
+    "glob": "^11.0.0",
     "incr-regex-package": "^1.0.4",
     "shell-quote": "^1.8.3"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -40,6 +40,7 @@
     "motion": ">=11.0.0",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0",
+    "react-pdf": ">=10.0.0",
     "katex": ">=0.16.0",
     "react-markdown": ">=9.0.0",
     "rehype-katex": ">=7.0.0",


### PR DESCRIPTION
## Problem

Several packages in v0.7.1 use dependencies that are not declared in their `package.json`, causing build failures when these dependencies are not transitively available through other packages.

## Changes

### packages/pi-agent-server/package.json
- ➕ `@sinclair/typebox` - used in `create-search-tool.ts`, `web-fetch.ts`
- ➕ `turndown` - used in `web-fetch.ts` for HTML→Markdown conversion
- ➕ `node-html-parser` - used in `web-fetch.ts`, `ddg.ts` for HTML parsing
- ➕ `pdfjs-dist` - used in `web-fetch.ts` for PDF text extraction

### packages/shared/package.json  
- ➕ `@mariozechner/pi-ai` - used in `models-pi.ts`
- ➕ `glob` - used in `prompts/system.ts`

### packages/server-core/package.json
- ➕ `@mariozechner/pi-ai` - dynamically imported in `llm-connections.ts`

### packages/ui/package.json
- ➕ `react-pdf` to peerDependencies - used in `PDFPreviewOverlay.tsx`

## Testing

Verified with:
```bash
bun install
bun run electron:build:main
bun run electron:build
```

All builds now succeed without dependency resolution errors.

## Impact

- ✅ Fixes build failures in monorepo setups
- ✅ Makes dependencies explicit rather than relying on transitive deps
- ✅ No breaking changes - only additions to package.json

---

_Discovered while merging v0.7.1 into our fork_