### PR TITLE
feat(automations): emit SessionEnd when session transitions to terminal state

### DIFF
--- a/packages/shared/src/automations/automation-system.ts
+++ b/packages/shared/src/automations/automation-system.ts
@@ -397,6 +397,19 @@ export class AutomationSystem implements AutomationsConfigProvider {
         newState: next.sessionStatus ?? '',
       });
       emittedEvents.push('SessionStatusChange');
+
+      // Emit SessionEnd when transitioning to a terminal state so that
+      // automations and hooks can react to the session closing.
+      if (next.sessionStatus === 'done' || next.sessionStatus === 'cancelled') {
+        await this.eventBus.emit('SessionEnd', {
+          sessionId,
+          sessionName,
+          workspaceId: this.options.workspaceId,
+          timestamp,
+          data: {},
+        });
+        emittedEvents.push('SessionEnd');
+      }
     }
 
     // Update stored metadata


### PR DESCRIPTION
## Problem

`SessionEnd` is defined in the event bus and `sdk-bridge.ts` but is never emitted anywhere in the codebase. This means hooks and automations configured to fire on `SessionEnd` never actually trigger, making session-close automation unreliable.

## Fix

In `AutomationSystem.updateSessionMetadata()`, when a session's status transitions to `'done'` or `'cancelled'`, emit `SessionEnd` immediately after `SessionStatusChange`. Both events fire from the same lifecycle point so the ordering is deterministic.

```ts
if (next.sessionStatus === 'done' || next.sessionStatus === 'cancelled') {
  await this.eventBus.emit('SessionEnd', {
    sessionId,
    sessionName,
    workspaceId: this.options.workspaceId,
    timestamp,
    data: {},
  });
  emittedEvents.push('SessionEnd');
}
```

## Why this location

`updateSessionMetadata()` is the single place where all session metadata diffs are processed and app events are emitted. Placing `SessionEnd` here keeps it consistent with `SessionStatusChange` and ensures it fires after the persistence queue has written the terminal status to disk — avoiding any race between the hook and the app's own final header write.

## Impact

- No behaviour change for sessions not transitioning to `done`/`cancelled`
- Automations registered under `SessionEnd` in `automations.json` will now fire as documented
- Hooks (where supported) will now receive the `SessionEnd` event reliably