### PR TITLE
fix: emit session_created event in spawn_session so name displays in UI

### DIFF
--- a/packages/server-core/src/sessions/SessionManager.ts
+++ b/packages/server-core/src/sessions/SessionManager.ts
@@ -2947,6 +2947,8 @@ export class SessionManager implements ISessionManager {
           if (attachments.length > 0) fileAttachments = attachments
         }
 
+        this.sendEvent({ type: 'session_created', sessionId: session.id }, managed.workspace.id)
+
         // Fire and forget — send the message but don't await completion
         this.sendMessage(session.id, request.prompt, fileAttachments).catch(err => {
           sessionLog.error(`Failed to send message to spawned session ${session.id}:`, err)


### PR DESCRIPTION
## Summary

Sessions created via `spawn_session` tool always showed **"New Chat"** in the sidebar, ignoring the `name` parameter. This PR fixes the issue by emitting a `session_created` event before streaming begins.

## Root Cause

The bug had two contributing causes:

1. **Missing `session_created` event** — When `spawn_session` creates a session, the renderer never received a `session_created` event. This event was only emitted in the `executeAutomation` path, not in `onSpawnSession`.

2. **Synthetic empty session without `name`** — Without `session_created`, the renderer only learned about the session when streaming events (`user_message`, `delta`) arrived for an unknown `sessionId`. At that point, it created a synthetic empty session via `createEmptySession()` with **no `name` field**, so `getSessionTitle()` fell through to "New chat".

3. **No title recovery** — Since the backend correctly had `managed.name` set, it skipped auto-title generation (`!managed.name` was `false`), so no `title_generated` event was ever sent to the renderer. The title stayed as "New chat" permanently.

**Why restart fixed it:** On restart, the app loads sessions from JSONL files on disk, where the `name` was correctly persisted. So it showed the right name after a restart, but never during the live session.

## Fix

Added `session_created` event emission in the `onSpawnSession` handler (1 line), following the exact same pattern already used by `executeAutomation` (SessionManager.ts:5779). This allows the renderer to hydrate full session metadata (including `name`) before streaming events arrive.

## Testing

- Spawned multiple sessions with custom names via `spawn_session` tool
- Verified names appear correctly in the sidebar immediately (no "New Chat" flash)
- Verified existing session creation flows (UI, automations) are unaffected

## Screenshots

-- Screen with bug, spawn a session as new chat
<img width="1405" height="867" alt="image" src="https://github.com/user-attachments/assets/09d86240-40ee-4152-9aaf-c8f285b321ff" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Craft Agent <agents-noreply@craft.do>