### PR TITLE
fix: wire craftagents:// deep link handler to core OPEN_URL

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -619,6 +619,13 @@ app.whenReady().then(async () => {
         windowManager,
         browserPaneManager,
         oauthFlowStore,
+        handleDeepLink: async (url, clientId) => {
+          const wm = windowManager
+          if (!wm) return
+          const { handleDeepLink } = await import('./deep-link')
+          const resolver = (wcId: number) => wm.getClientIdForWindow(wcId)
+          await handleDeepLink(url, wm, server.push.bind(server), resolver, clientId)
+        },
       }
 
       // Register RPC handlers (must happen before window creation)

--- a/packages/server-core/src/handlers/handler-deps.ts
+++ b/packages/server-core/src/handlers/handler-deps.ts
@@ -25,4 +25,6 @@ export interface HandlerDeps<
   windowManager?: TWindowManager
   browserPaneManager?: TBrowserPaneManager
   oauthFlowStore: TOAuthFlowStore
+  /** Optional handler for craftagents:// deep link URLs. Provided by GUI hosts (Electron). */
+  handleDeepLink?: (url: string, clientId: string) => Promise<void>
 }

--- a/packages/server-core/src/handlers/rpc/system.ts
+++ b/packages/server-core/src/handlers/rpc/system.ts
@@ -174,9 +174,14 @@ export function registerSystemCoreHandlers(server: RpcServer, deps: HandlerDeps)
     try {
       const parsed = new URL(url)
 
-      // craftagents:// URLs require the GUI deep-link handler (Electron only)
+      // craftagents:// deep links — delegate to GUI host if available
       if (parsed.protocol === 'craftagents:') {
-        deps.platform.logger.info('[OPEN_URL] craftagents:// URLs require GUI deep-link handler — skipping in core')
+        if (deps.handleDeepLink) {
+          deps.platform.logger.info('[OPEN_URL] Handling as deep link')
+          await deps.handleDeepLink(url, ctx.clientId)
+          return
+        }
+        deps.platform.logger.info('[OPEN_URL] craftagents:// deep link — no handler registered, skipping')
         return
       }
 


### PR DESCRIPTION
## Summary

UI actions like "Add Skill", "Add Source", and other sidebar buttons generate
`craftagents://` deep link URLs to open new sessions with pre-filled context.
These deep links are dispatched through the `OPEN_URL` RPC channel, but the
handler silently drops them — the button appears to do nothing.

### Why deep links?

The app uses `craftagents://` protocol URLs as an internal routing mechanism.
When you click "Add Skill", the renderer builds a URL like:

```
craftagents://action/new-session?input=<context>&send=true&mode=allow-all
```

This URL is sent via the `shell:OPEN_URL` RPC channel to the main process,
which is supposed to parse it and navigate to a new session with the skill
creation context pre-loaded.

### What went wrong

During a refactor, RPC handlers were split into two layers:

- **Core handlers** (\`packages/server-core\`) — platform-agnostic logic
- **GUI handlers** (\`apps/electron\`) — Electron-specific logic (windows, menus, etc.)

The \`OPEN_URL\` handler was moved to the core layer, but \`craftagents://\` deep
links require access to Electron's \`WindowManager\` and \`handleDeepLink\` function
to create/focus windows and send navigation events to the renderer.

The core handler had no way to process these URLs, so it logged a message and
returned silently:

```
[OPEN_URL] craftagents:// URLs require GUI deep-link handler — skipping in core
```

The original Electron-specific handler (which properly called \`handleDeepLink\`)
was left behind as dead code — defined but never registered, since the handler
index imported core handlers from \`server-core\` instead of the local Electron
module.

### The fix

Added an optional \`handleDeepLink\` callback to the shared \`HandlerDeps\`
interface. The core OPEN_URL handler now delegates \`craftagents://\` URLs through
this callback when available. The Electron app wires in the real implementation
via deps at startup.

## Changes

- Added optional \`handleDeepLink\` callback to \`HandlerDeps\` (\`packages/server-core/src/handlers/handler-deps.ts\`)
- Core OPEN_URL handler now calls \`deps.handleDeepLink(url, clientId)\` for \`craftagents://\` URLs (\`packages/server-core/src/handlers/rpc/system.ts\`)
- Electron \`index.ts\` provides the callback implementation using \`handleDeepLink\` from \`deep-link.ts\` (\`apps/electron/src/main/index.ts\`)

## Testing

- \`bun run typecheck:electron\` — passes clean
- Handler registration tests (9/9) — all pass
- Manual: "Add Skill" / "Add Source" buttons now correctly open new sessions with context