### PR TITLE
Fix bun.lock, status icon overrides, and Pi custom-endpoint routing

### DIFF
--- a/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
+++ b/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
@@ -23,6 +23,11 @@ import {
 import { cn } from "@/lib/utils"
 import { Check, ChevronDown, Eye, EyeOff, Loader2 } from "lucide-react"
 import { pickTierDefaults, resolveTierModels, type PiModelInfo } from "./tier-models"
+import {
+  resolvePiAuthProviderForSubmit,
+  resolvePresetStateForBaseUrlChange,
+  type PresetKey,
+} from "./submit-helpers"
 
 export type ApiKeyStatus = 'idle' | 'validating' | 'success' | 'error'
 
@@ -57,9 +62,6 @@ export interface ApiKeyInputProps {
     models?: string[]
   }
 }
-
-// Preset key — string to support dynamic Pi SDK providers
-type PresetKey = string
 
 interface Preset {
   key: PresetKey
@@ -153,6 +155,9 @@ export function ApiKeyInput({
   const [showValue, setShowValue] = useState(false)
   const [baseUrl, setBaseUrl] = useState(initialValues?.baseUrl ?? defaultPreset.url)
   const [activePreset, setActivePreset] = useState<PresetKey>(initialPreset)
+  const [lastNonCustomPreset, setLastNonCustomPreset] = useState<PresetKey | null>(
+    initialPreset !== 'custom' ? initialPreset : defaultPreset.key
+  )
   const [connectionDefaultModel, setConnectionDefaultModel] = useState(initialValues?.connectionDefaultModel ?? '')
   const [modelError, setModelError] = useState<string | null>(null)
 
@@ -219,6 +224,9 @@ export function ApiKeyInput({
 
   const handlePresetSelect = (preset: Preset) => {
     setActivePreset(preset.key)
+    if (preset.key !== 'custom') {
+      setLastNonCustomPreset(preset.key)
+    }
     if (preset.key === 'custom') {
       setBaseUrl('')
     } else {
@@ -241,17 +249,15 @@ export function ApiKeyInput({
   const handleBaseUrlChange = (value: string) => {
     setBaseUrl(value)
     const presetKey = getPresetForUrl(value, presets)
-    if (presetKey !== 'custom') {
-      setActivePreset(presetKey)
-    } else {
-      const currentPresetObj = presets.find(p => p.key === activePreset)
-      // Only fall back to 'custom' if the current preset has a non-empty default URL.
-      // Presets with empty URLs (e.g. Azure OpenAI) expect user-provided endpoints;
-      // switching them to custom would drop piAuthProvider routing metadata.
-      if (currentPresetObj && currentPresetObj.url !== '') {
-        setActivePreset('custom')
-      }
-    }
+    const currentPresetObj = presets.find(p => p.key === activePreset)
+    const nextPresetState = resolvePresetStateForBaseUrlChange({
+      matchedPreset: presetKey,
+      activePreset,
+      activePresetHasEmptyUrl: currentPresetObj?.url === '',
+      lastNonCustomPreset,
+    })
+    setActivePreset(nextPresetState.activePreset)
+    setLastNonCustomPreset(nextPresetState.lastNonCustomPreset)
     setModelError(null)
     if (!connectionDefaultModel.trim()) {
       if (presetKey === 'ollama') {
@@ -265,6 +271,10 @@ export function ApiKeyInput({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
 
+    const effectivePiAuthProvider = isPiApiKeyFlow
+      ? resolvePiAuthProviderForSubmit(activePreset, lastNonCustomPreset)
+      : undefined
+
     // Pi API key flow with tier dropdowns — submit selected models
     if (hasPiModels) {
       if (!bestModel || !defaultModel || !cheapModel) {
@@ -277,7 +287,7 @@ export function ApiKeyInput({
         baseUrl: baseUrl.trim() || undefined,
         connectionDefaultModel: bestModel,
         models,
-        piAuthProvider: activePreset !== 'custom' ? activePreset : undefined,
+        piAuthProvider: effectivePiAuthProvider,
         modelSelectionMode: 'userDefined3Tier',
       })
       return
@@ -299,7 +309,7 @@ export function ApiKeyInput({
       baseUrl: isUsingDefaultEndpoint ? undefined : effectiveBaseUrl,
       connectionDefaultModel: parsedModels[0],
       models: parsedModels.length > 0 ? parsedModels : undefined,
-      piAuthProvider: isPiApiKeyFlow && activePreset !== 'custom' ? activePreset : undefined,
+      piAuthProvider: effectivePiAuthProvider,
       modelSelectionMode: isPiApiKeyFlow
         ? (parsedModels.length > 0 ? 'userDefined3Tier' : 'automaticallySyncedFromProvider')
         : undefined,

--- a/apps/electron/src/renderer/components/apisetup/__tests__/ApiKeyInput.test.ts
+++ b/apps/electron/src/renderer/components/apisetup/__tests__/ApiKeyInput.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from 'bun:test'
+import {
+  resolvePiAuthProviderForSubmit,
+  resolvePresetStateForBaseUrlChange,
+} from '../submit-helpers'
 import { pickTierDefaults, resolveTierModels } from '../tier-models'
 
 const MODELS = [
@@ -38,6 +42,58 @@ describe('ApiKeyInput tier hydration helpers', () => {
       best: 'pi/zai-best',
       default_: defaults.default_,
       cheap: defaults.cheap,
+    })
+  })
+})
+
+describe('resolvePiAuthProviderForSubmit', () => {
+  it('preserves the last non-custom provider when custom endpoint mode is selected', () => {
+    expect(resolvePiAuthProviderForSubmit('custom', 'openai')).toBe('openai')
+  })
+
+  it('defaults custom endpoint mode to anthropic routing when none was selected yet', () => {
+    expect(resolvePiAuthProviderForSubmit('custom', null)).toBe('anthropic')
+  })
+
+  it('passes through non-custom presets unchanged', () => {
+    expect(resolvePiAuthProviderForSubmit('google', 'anthropic')).toBe('google')
+  })
+})
+
+describe('resolvePresetStateForBaseUrlChange', () => {
+  it('updates the remembered provider when the typed URL matches a known preset', () => {
+    expect(resolvePresetStateForBaseUrlChange({
+      matchedPreset: 'openrouter',
+      activePreset: 'custom',
+      activePresetHasEmptyUrl: true,
+      lastNonCustomPreset: 'anthropic',
+    })).toEqual({
+      activePreset: 'openrouter',
+      lastNonCustomPreset: 'openrouter',
+    })
+  })
+
+  it('preserves provider routing when editing a provider with an empty default URL', () => {
+    expect(resolvePresetStateForBaseUrlChange({
+      matchedPreset: 'custom',
+      activePreset: 'azure-openai-responses',
+      activePresetHasEmptyUrl: true,
+      lastNonCustomPreset: 'azure-openai-responses',
+    })).toEqual({
+      activePreset: 'azure-openai-responses',
+      lastNonCustomPreset: 'azure-openai-responses',
+    })
+  })
+
+  it('falls back to custom while keeping the most recent matched provider', () => {
+    expect(resolvePresetStateForBaseUrlChange({
+      matchedPreset: 'custom',
+      activePreset: 'openrouter',
+      activePresetHasEmptyUrl: false,
+      lastNonCustomPreset: 'openrouter',
+    })).toEqual({
+      activePreset: 'custom',
+      lastNonCustomPreset: 'openrouter',
     })
   })
 })

--- a/apps/electron/src/renderer/components/apisetup/submit-helpers.ts
+++ b/apps/electron/src/renderer/components/apisetup/submit-helpers.ts
@@ -1,0 +1,42 @@
+export type PresetKey = string
+
+export function resolvePiAuthProviderForSubmit(
+  activePreset: PresetKey,
+  lastNonCustomPreset: PresetKey | null
+): string | undefined {
+  if (activePreset === 'custom') {
+    return lastNonCustomPreset && lastNonCustomPreset !== 'custom'
+      ? lastNonCustomPreset
+      : 'anthropic'
+  }
+
+  return activePreset
+}
+
+export function resolvePresetStateForBaseUrlChange(params: {
+  matchedPreset: PresetKey
+  activePreset: PresetKey
+  activePresetHasEmptyUrl: boolean
+  lastNonCustomPreset: PresetKey | null
+}): { activePreset: PresetKey; lastNonCustomPreset: PresetKey | null } {
+  const { matchedPreset, activePreset, activePresetHasEmptyUrl, lastNonCustomPreset } = params
+
+  if (matchedPreset !== 'custom') {
+    return {
+      activePreset: matchedPreset,
+      lastNonCustomPreset: matchedPreset,
+    }
+  }
+
+  if (activePresetHasEmptyUrl) {
+    return {
+      activePreset,
+      lastNonCustomPreset,
+    }
+  }
+
+  return {
+    activePreset: 'custom',
+    lastNonCustomPreset,
+  }
+}

--- a/apps/electron/src/renderer/components/ui/EditPopover.tsx
+++ b/apps/electron/src/renderer/components/ui/EditPopover.tsx
@@ -366,7 +366,7 @@ const EDIT_CONFIGS: Record<EditContextKey, (location: string) => EditConfig> = {
         'The user wants to customize session statuses (workflow states). ' +
         'Statuses are stored in statuses/config.json with fields: id, label, icon, category (open/closed), order, isFixed, isDefault. ' +
         'Fixed statuses (todo, done, cancelled) cannot be deleted but can be reordered or have their label changed. ' +
-        'Icon can be { type: "file", value: "name.svg" } for custom icons in statuses/icons/ or { type: "lucide", value: "icon-name" } for Lucide icons. ' +
+        'Icon can be an emoji, an https URL, or a local filename like "name.svg" that maps to statuses/icons/name.svg. ' +
         'Category "open" shows in inbox, "closed" shows in archive. ' +
         'After editing, call config_validate with target "statuses" to verify the changes. ' +
         'Confirm clearly when done.',

--- a/apps/electron/src/renderer/components/ui/__tests__/status-icon.test.ts
+++ b/apps/electron/src/renderer/components/ui/__tests__/status-icon.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test'
+import { resolveStatusIconSource } from '../status-icon'
+
+describe('resolveStatusIconSource', () => {
+  it('treats bare icon filenames as local overrides in statuses/icons', () => {
+    expect(resolveStatusIconSource('todo', 'in-progress.svg')).toEqual({
+      iconPath: 'statuses/icons/in-progress.svg',
+    })
+  })
+
+  it('rejects nested paths from being treated as local overrides', () => {
+    expect(resolveStatusIconSource('todo', '../in-progress.svg')).toEqual({
+      iconValue: '../in-progress.svg',
+      iconFileName: 'todo',
+    })
+  })
+
+  it('preserves emoji and url icon values', () => {
+    expect(resolveStatusIconSource('todo', '✅')).toEqual({
+      iconValue: '✅',
+      iconFileName: 'todo',
+    })
+
+    expect(resolveStatusIconSource('todo', 'https://example.com/icon.svg')).toEqual({
+      iconValue: 'https://example.com/icon.svg',
+      iconFileName: 'todo',
+    })
+  })
+})

--- a/apps/electron/src/renderer/components/ui/status-icon.tsx
+++ b/apps/electron/src/renderer/components/ui/status-icon.tsx
@@ -13,6 +13,8 @@ import { EntityIcon } from '@/components/ui/entity-icon'
 import { useEntityIcon } from '@/lib/icon-cache'
 import type { IconSize } from '@craft-agent/shared/icons'
 
+const LOCAL_STATUS_ICON_FILENAME_PATTERN = /^[^/\\]+\.(svg|png|jpe?g)$/i
+
 interface StatusIconProps {
   /** Status identifier (used to discover icon file) */
   statusId: string
@@ -30,6 +32,24 @@ interface StatusIconProps {
   bare?: boolean
 }
 
+export function resolveStatusIconSource(
+  statusId: string,
+  icon?: string
+): { iconPath?: string; iconValue?: string; iconFileName?: string } {
+  const trimmedIcon = typeof icon === 'string' ? icon.trim() : undefined
+
+  if (trimmedIcon && LOCAL_STATUS_ICON_FILENAME_PATTERN.test(trimmedIcon)) {
+    return {
+      iconPath: `statuses/icons/${trimmedIcon}`,
+    }
+  }
+
+  return {
+    iconValue: trimmedIcon,
+    iconFileName: statusId,
+  }
+}
+
 export function StatusIcon({
   statusId,
   icon,
@@ -39,14 +59,16 @@ export function StatusIcon({
   chromeless,
   bare,
 }: StatusIconProps) {
+  const { iconPath, iconValue, iconFileName } = resolveStatusIconSource(statusId, icon)
   const resolved = useEntityIcon({
     workspaceId,
     entityType: 'status',
     identifier: statusId,
+    iconPath,
     iconDir: 'statuses/icons',
-    iconValue: icon,
+    iconValue,
     // Status icons use {statusId}.ext naming (not icon.ext)
-    iconFileName: statusId,
+    iconFileName,
   })
 
   return (

--- a/bun.lock
+++ b/bun.lock
@@ -161,29 +161,6 @@
         "@types/ws": "^8.18.1",
       },
     },
-    "apps/marketing": {
-      "name": "@craft-agent/marketing",
-      "version": "0.7.1",
-      "dependencies": {
-        "@craft-agent/ui": "workspace:*",
-        "@paper-design/shaders-react": "^0.0.70",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-router-dom": "^7.13.0",
-        "shiki": "^3.21.0",
-        "three": "^0.170.0",
-      },
-      "devDependencies": {
-        "@tailwindcss/vite": "^4.1.18",
-        "@types/react": "^18.3.0",
-        "@types/react-dom": "^18.3.0",
-        "@types/three": "^0.170.0",
-        "@vitejs/plugin-react": "^5.1.2",
-        "tailwindcss": "^4.1.18",
-        "typescript": "^5.0.0",
-        "vite": "^6.2.4",
-      },
-    },
     "apps/viewer": {
       "name": "@craft-agent/viewer",
       "version": "0.7.1",
@@ -546,8 +523,6 @@
     "@craft-agent/core": ["@craft-agent/core@workspace:packages/core"],
 
     "@craft-agent/electron": ["@craft-agent/electron@workspace:apps/electron"],
-
-    "@craft-agent/marketing": ["@craft-agent/marketing@workspace:apps/marketing"],
 
     "@craft-agent/pi-agent-server": ["@craft-agent/pi-agent-server@workspace:packages/pi-agent-server"],
 
@@ -1395,8 +1370,6 @@
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
-    "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
-
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -1469,11 +1442,7 @@
 
     "@types/shell-quote": ["@types/shell-quote@1.7.5", "", {}, "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw=="],
 
-    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
-
     "@types/tedious": ["@types/tedious@4.0.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
-
-    "@types/three": ["@types/three@0.170.0", "", { "dependencies": { "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": "*", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~0.18.1" } }, "sha512-CUm2uckq+zkCY7ZbFpviRttY+6f9fvwm6YqSqPfA5K22s9w7R4VnA3rzJse8kHVvuzLcTx+CjNCs2NYe0QFAyg=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -1482,8 +1451,6 @@
     "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
     "@types/verror": ["@types/verror@1.10.11", "", {}, "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg=="],
-
-    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -1516,8 +1483,6 @@
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.1.2", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.53", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ=="],
-
-    "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
 
@@ -2551,8 +2516,6 @@
 
     "merge-refs": ["merge-refs@2.0.0", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg=="],
 
-    "meshoptimizer": ["meshoptimizer@0.18.1", "", {}, "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw=="],
-
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
@@ -2937,10 +2900,6 @@
 
     "react-resizable-panels": ["react-resizable-panels@3.0.6", "", { "peerDependencies": { "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew=="],
 
-    "react-router": ["react-router@7.13.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw=="],
-
-    "react-router-dom": ["react-router-dom@7.13.0", "", { "dependencies": { "react-router": "7.13.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g=="],
-
     "react-simple-code-editor": ["react-simple-code-editor@0.14.1", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-BR5DtNRy+AswWJECyA17qhUDvrrCZ6zXOCfkQY5zSmb96BVUbpVAv03WpcjcwtCwiLbIANx3gebHOcXYn1EHow=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
@@ -3046,8 +3005,6 @@
     "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -3190,8 +3147,6 @@
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
-
-    "three": ["three@0.170.0", "", {}, "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ=="],
 
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
 
@@ -3502,8 +3457,6 @@
     "@craft-agent/cli/@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
 
     "@craft-agent/cli/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
-
-    "@craft-agent/marketing/@paper-design/shaders-react": ["@paper-design/shaders-react@0.0.70", "", { "dependencies": { "@paper-design/shaders": "0.0.70" }, "peerDependencies": { "@types/react": "^18 || ^19", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-9DkZXcyehorsZzyWnYV3OOO1i7rF7a5CkasjKJ1h1tLlY3JJLUEX9W+gZz7JgWHyvCimUu0OSq1sbHTb2OntRw=="],
 
     "@craft-agent/pi-agent-server/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
 
@@ -3847,8 +3800,6 @@
 
     "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
-    "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
-
     "read-pkg-up/find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "^2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
 
     "readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
@@ -3986,8 +3937,6 @@
     "@craft-agent/cli/@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "@craft-agent/cli/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
-
-    "@craft-agent/marketing/@paper-design/shaders-react/@paper-design/shaders": ["@paper-design/shaders@0.0.70", "", {}, "sha512-d9LQcmPoEm3+Y6Vuz7cvsnSelfTM5QD63yQ3ddLM7QGYfoSjbQiU38kzjA4O3oCQ6zv23o/IGvGA8k9S/L+kZw=="],
 
     "@craft-agent/pi-agent-server/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/packages/shared/src/config/validators.ts
+++ b/packages/shared/src/config/validators.ts
@@ -875,9 +875,10 @@ const STATUS_CONFIG_FILE = 'statuses/config.json';
 const REQUIRED_FIXED_STATUS_IDS = ['todo', 'done', 'cancelled'] as const;
 
 /**
- * Status icons are simple strings: emoji characters (e.g., "✅") or URLs.
- * Local icon files (statuses/icons/{id}.svg) are auto-discovered at runtime,
- * not referenced in the config.
+ * Status icons are simple strings: emoji characters, URLs, or local filenames
+ * such as "in-progress.svg" which resolve to statuses/icons/in-progress.svg.
+ * When icon is omitted, local icon files (statuses/icons/{id}.svg) are still
+ * auto-discovered at runtime.
  */
 const StatusIconSchema = z.string();
 

--- a/packages/shared/src/statuses/types.ts
+++ b/packages/shared/src/statuses/types.ts
@@ -4,12 +4,13 @@
  * Types for configurable session statuses.
  * Statuses are stored at {workspaceRootPath}/statuses/config.json
  *
- * Icon format: Simple string (emoji or URL)
+ * Icon format: Simple string
  * - Emoji: "✅", "🔥" - rendered as text
  * - URL: "https://..." - auto-downloaded to statuses/icons/{id}.{ext}
- * - Local files: Stored in statuses/icons/{id}.svg (auto-discovered)
+ * - Local filename: "in-progress.svg" - loaded from statuses/icons/in-progress.svg
+ * - Local files: Stored in statuses/icons/{id}.svg when icon is omitted (auto-discovered)
  *
- * Priority: local file > URL (downloaded) > emoji
+ * Priority: explicit local filename > local file by status ID > URL (downloaded) > emoji
  *
  * Color format: EntityColor (system color string or custom color object)
  * - System: "accent", "foreground/50", "info/80" (uses CSS variables, auto light/dark)
@@ -39,9 +40,10 @@ export interface StatusConfig {
   color?: EntityColor;
 
   /**
-   * Icon: emoji or URL (auto-downloaded)
+   * Icon: emoji, URL (auto-downloaded), or local filename in statuses/icons/
    * - Emoji: "✅", "🔥" - rendered as text
    * - URL: "https://..." - auto-downloaded to statuses/icons/{id}.{ext}
+   * - Local filename: "in-progress.svg" → statuses/icons/in-progress.svg
    * - Omit to use auto-discovered local file (statuses/icons/{id}.svg)
    */
   icon?: string;


### PR DESCRIPTION
## Summary
- refresh `bun.lock` so `bun install --frozen-lockfile` passes again on `main`
- resolve status icon config values like `in-progress.svg` from `statuses/icons/` and cover the override logic with tests
- preserve Pi provider routing when switching to custom endpoints, including manual URL edits, and add helper-level tests

Fixes #358
Fixes #359
Fixes #363

## Verification
- bun test apps/electron/src/renderer/components/apisetup/__tests__/ApiKeyInput.test.ts apps/electron/src/renderer/components/ui/__tests__/status-icon.test.ts apps/electron/src/renderer/hooks/__tests__/useOnboarding.test.ts apps/electron/src/main/__tests__/connection-setup-logic.test.ts
- bun run typecheck:electron
- bun install --frozen-lockfile