### PR TITLE
Fix source and skill add popovers running the wrong flow

### DIFF
--- a/apps/electron/src/renderer/components/ui/EditPopover.tsx
+++ b/apps/electron/src/renderer/components/ui/EditPopover.tsx
@@ -19,6 +19,7 @@ import type { ContentBadge, Session, CreateSessionOptions } from '../../../share
 import { useActiveWorkspace, useAppShellContext, useSession } from '@/context/AppShellContext'
 import { useEscapeInterrupt } from '@/context/EscapeInterruptContext'
 import { ChatDisplay } from '../app-shell/ChatDisplay'
+import { usesInlineExecutionForEditPopoverContext } from './edit-popover-inline'
 
 /** Rotating placeholders for compact mode input - short, action-oriented */
 const COMPACT_PLACEHOLDERS = [
@@ -286,6 +287,9 @@ const EDIT_CONFIGS: Record<EditContextKey, (location: string) => EditConfig> = {
     },
     example: 'Connect to my Craft space',
     overridePlaceholder: 'What would you like to connect?',
+    model: 'haiku',
+    systemPromptPreset: 'mini',
+    inlineExecution: usesInlineExecutionForEditPopoverContext('add-source'),
   }),
 
   // Filter-specific add-source contexts: user is viewing a filtered list and wants to add that type
@@ -304,6 +308,9 @@ const EDIT_CONFIGS: Record<EditContextKey, (location: string) => EditConfig> = {
     },
     example: 'Connect to the OpenAI API',
     overridePlaceholder: 'What API would you like to connect?',
+    model: 'haiku',
+    systemPromptPreset: 'mini',
+    inlineExecution: usesInlineExecutionForEditPopoverContext('add-source-api'),
   }),
 
   'add-source-mcp': (location) => ({
@@ -321,6 +328,9 @@ const EDIT_CONFIGS: Record<EditContextKey, (location: string) => EditConfig> = {
     },
     example: 'Connect to Linear',
     overridePlaceholder: 'What MCP server would you like to connect?',
+    model: 'haiku',
+    systemPromptPreset: 'mini',
+    inlineExecution: usesInlineExecutionForEditPopoverContext('add-source-mcp'),
   }),
 
   'add-source-local': (location) => ({
@@ -339,6 +349,9 @@ const EDIT_CONFIGS: Record<EditContextKey, (location: string) => EditConfig> = {
     },
     example: 'Connect to my Obsidian vault',
     overridePlaceholder: 'What folder would you like to connect?',
+    model: 'haiku',
+    systemPromptPreset: 'mini',
+    inlineExecution: usesInlineExecutionForEditPopoverContext('add-source-local'),
   }),
 
   'add-skill': (location) => ({
@@ -355,6 +368,9 @@ const EDIT_CONFIGS: Record<EditContextKey, (location: string) => EditConfig> = {
     },
     example: 'Review PRs following our code standards',
     overridePlaceholder: 'What should I learn to do?',
+    model: 'haiku',
+    systemPromptPreset: 'mini',
+    inlineExecution: usesInlineExecutionForEditPopoverContext('add-skill'),
   }),
 
   // Status configuration context

--- a/apps/electron/src/renderer/components/ui/__tests__/edit-popover.test.ts
+++ b/apps/electron/src/renderer/components/ui/__tests__/edit-popover.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  INLINE_EDIT_POPOVER_CONTEXT_KEYS,
+  usesInlineExecutionForEditPopoverContext,
+} from '../edit-popover-inline'
+
+describe('usesInlineExecutionForEditPopoverContext', () => {
+  it('runs source and skill creation flows inline', () => {
+    expect(INLINE_EDIT_POPOVER_CONTEXT_KEYS).toEqual([
+      'add-source',
+      'add-source-api',
+      'add-source-mcp',
+      'add-source-local',
+      'add-skill',
+    ])
+
+    for (const key of INLINE_EDIT_POPOVER_CONTEXT_KEYS) {
+      expect(usesInlineExecutionForEditPopoverContext(key)).toBe(true)
+    }
+  })
+
+  it('leaves unrelated edit contexts on the legacy path', () => {
+    expect(usesInlineExecutionForEditPopoverContext('edit-statuses')).toBe(false)
+  })
+})

--- a/apps/electron/src/renderer/components/ui/edit-popover-inline.ts
+++ b/apps/electron/src/renderer/components/ui/edit-popover-inline.ts
@@ -1,0 +1,13 @@
+export const INLINE_EDIT_POPOVER_CONTEXT_KEYS = [
+  'add-source',
+  'add-source-api',
+  'add-source-mcp',
+  'add-source-local',
+  'add-skill',
+] as const
+
+const INLINE_EDIT_POPOVER_CONTEXT_KEY_SET = new Set<string>(INLINE_EDIT_POPOVER_CONTEXT_KEYS)
+
+export function usesInlineExecutionForEditPopoverContext(key: string): boolean {
+  return INLINE_EDIT_POPOVER_CONTEXT_KEY_SET.has(key)
+}


### PR DESCRIPTION
## Summary
The source and skill add popovers were still using the old deep-link session handoff. That matched the bug report: the popover would close, and on some machines nothing else happened.

This change moves those creation flows onto the inline popover path instead:
- `Add Source`
- `Add API`
- `Add MCP`
- `Add Local Folder`
- `Add Skill`

It also adds a small regression test so those contexts stay on the inline path.

Fixes #354

## Automated checks
- `bun test apps/electron/src/renderer/components/ui/__tests__/edit-popover.test.ts apps/electron/src/renderer/components/apisetup/__tests__/ApiKeyInput.test.ts apps/electron/src/renderer/hooks/__tests__/useOnboarding.test.ts apps/electron/src/main/__tests__/connection-setup-logic.test.ts`
- `bun run typecheck:electron`

## Manual checks
- `Add Source` with `Connect to the OpenAI API with a bearer token` no longer closed and did nothing. The popover kept running inline and advanced into the API key setup flow.
- `Add Skill` with a PR test coverage prompt completed inline, created the skill, and reported validation passed.