### PR TITLE
feat: add OpenAI regional data zone presets (EU & US)

### DIFF
--- a/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
+++ b/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
@@ -70,6 +70,8 @@ interface Preset {
 const ANTHROPIC_PRESETS: Preset[] = [
   { key: 'anthropic', label: 'Anthropic', url: 'https://api.anthropic.com', placeholder: 'sk-ant-...' },
   { key: 'openai', label: 'OpenAI', url: 'https://api.openai.com/v1', placeholder: 'sk-...' },
+  { key: 'openai-eu', label: 'OpenAI EU', url: 'https://eu.api.openai.com/v1', placeholder: 'sk-...' },
+  { key: 'openai-us', label: 'OpenAI US', url: 'https://us.api.openai.com/v1', placeholder: 'sk-...' },
   { key: 'google', label: 'Google AI Studio', url: 'https://generativelanguage.googleapis.com/v1beta', placeholder: 'AIza...' },
   { key: 'openrouter', label: 'OpenRouter', url: 'https://openrouter.ai/api/v1', placeholder: 'sk-or-...' },
   { key: 'azure-openai-responses', label: 'Azure OpenAI', url: '', placeholder: 'Paste your key here...' },


### PR DESCRIPTION
### Summary
This PR adds two new presets for OpenAI's regional data zone processing. This allows users to route their requests through specific geographic endpoints (eu and us) to comply with local data residency requirements.

### Changes
Added openai-eu preset pointing to https://eu.api.openai.com/v1.

Added openai-us preset pointing to https://us.api.openai.com/v1.

Standardized placeholders for these endpoints to match existing OpenAI key formats (sk-...).

### Motivation
Enterprise users and developers in the EU often require data to stay within specific geographic boundaries for GDPR compliance. 