### PR TITLE
feat: add Minimax provider preset

### DIFF
--- a/apps/electron/src/renderer/assets/provider-icons/minimax.svg
+++ b/apps/electron/src/renderer/assets/provider-icons/minimax.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="6" fill="#6366F1"/>
+  <path d="M8 10h4v12H8V10zm6 0h4v12h-4V10zm6 0h4v12h-4V10z" fill="white"/>
+</svg>

--- a/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
+++ b/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
@@ -75,6 +75,7 @@ const ANTHROPIC_PRESETS: Preset[] = [
   { key: 'openai', label: 'OpenAI', url: 'https://api.openai.com/v1', placeholder: 'sk-...' },
   { key: 'google', label: 'Google AI Studio', url: 'https://generativelanguage.googleapis.com/v1beta', placeholder: 'AIza...' },
   { key: 'openrouter', label: 'OpenRouter', url: 'https://openrouter.ai/api/v1', placeholder: 'sk-or-...' },
+  { key: 'minimax', label: 'Minimax', url: 'https://api.minimax.io/anthropic', placeholder: 'Paste your key here...' },
   { key: 'azure-openai-responses', label: 'Azure OpenAI', url: '', placeholder: 'Paste your key here...' },
   { key: 'amazon-bedrock', label: 'Amazon Bedrock', url: 'https://bedrock-runtime.us-east-1.amazonaws.com', placeholder: 'AKIA...' },
   { key: 'groq', label: 'Groq', url: 'https://api.groq.com/openai/v1', placeholder: 'gsk_...' },
@@ -108,6 +109,7 @@ const GOOGLE_PRESETS: Preset[] = [
 
 const COMPAT_ANTHROPIC_DEFAULTS = 'anthropic/claude-opus-4.6, anthropic/claude-sonnet-4.6, anthropic/claude-haiku-4.5'
 const COMPAT_OPENAI_DEFAULTS = 'openai/gpt-5.2-codex, openai/gpt-5.1-codex-mini'
+const COMPAT_MINIMAX_DEFAULTS = 'MiniMax-M2.5, MiniMax-M2.5-highspeed'
 
 function getPresetsForProvider(providerType: 'anthropic' | 'openai' | 'pi' | 'google' | 'pi_api_key'): Preset[] {
   if (providerType === 'pi_api_key') return ANTHROPIC_PRESETS
@@ -229,6 +231,8 @@ export function ApiKeyInput({
     // (Default provider presets hide the field entirely, others default to provider model IDs when empty)
     if (preset.key === 'ollama') {
       setConnectionDefaultModel('qwen3-coder')
+    } else if (preset.key === 'minimax') {
+      setConnectionDefaultModel(COMPAT_MINIMAX_DEFAULTS)
     } else if (preset.key === 'openrouter' || preset.key === 'vercel-ai-gateway') {
       setConnectionDefaultModel(providerType === 'openai' ? COMPAT_OPENAI_DEFAULTS : COMPAT_ANTHROPIC_DEFAULTS)
     } else if (preset.key === 'custom') {
@@ -256,6 +260,8 @@ export function ApiKeyInput({
     if (!connectionDefaultModel.trim()) {
       if (presetKey === 'ollama') {
         setConnectionDefaultModel('qwen3-coder')
+      } else if (presetKey === 'minimax') {
+        setConnectionDefaultModel(COMPAT_MINIMAX_DEFAULTS)
       } else if (presetKey === 'openrouter' || presetKey === 'vercel-ai-gateway' || presetKey === 'custom') {
         setConnectionDefaultModel(providerType === 'openai' ? COMPAT_OPENAI_DEFAULTS : COMPAT_ANTHROPIC_DEFAULTS)
       }

--- a/apps/electron/src/renderer/lib/provider-icons.ts
+++ b/apps/electron/src/renderer/lib/provider-icons.ts
@@ -11,6 +11,7 @@ import claudeIcon from '@/assets/provider-icons/claude.svg'
 import copilotIcon from '@/assets/provider-icons/copilot.svg'
 import googleIcon from '@/assets/provider-icons/google.svg'
 import huggingfaceIcon from '@/assets/provider-icons/huggingface.svg'
+import minimaxIcon from '@/assets/provider-icons/minimax.svg'
 import mistralIcon from '@/assets/provider-icons/mistral.svg'
 import ollamaIcon from '@/assets/provider-icons/ollama.svg'
 import openaiIcon from '@/assets/provider-icons/openai.svg'
@@ -30,6 +31,7 @@ export const providerIcons = {
   copilot: copilotIcon,
   google: googleIcon,
   huggingface: huggingfaceIcon,
+  minimax: minimaxIcon,
   mistral: mistralIcon,
   ollama: ollamaIcon,
   openai: openaiIcon,
@@ -52,6 +54,7 @@ const providerDisplayNames: Record<string, string> = {
   pi: 'Craft Agents Backend',
   pi_compat: 'Craft Agents Backend',
   vercel: 'Vercel',
+  minimax: 'Minimax',
 }
 
 /** Get a human-readable provider name from provider type and optional base URL */
@@ -62,6 +65,7 @@ export function getProviderDisplayName(providerType: string, baseUrl?: string | 
     if (url.includes('openrouter.ai')) return 'OpenRouter'
     if (url.includes('ollama')) return 'Ollama'
     if (url.includes('v0.dev') || url.includes('vercel')) return 'Vercel'
+    if (url.includes('minimax.io') || url.includes('minimaxi.com')) return 'Minimax'
   }
   return providerDisplayNames[providerType] || providerType
 }
@@ -81,6 +85,7 @@ function detectProviderFromUrl(baseUrl: string): ProviderIconKey | null {
   if (url.includes('mistral.ai')) return 'mistral'
   if (url.includes('bedrock')) return 'aws'
   if (url.includes('huggingface.co')) return 'huggingface'
+  if (url.includes('minimax.io') || url.includes('minimaxi.com')) return 'minimax'
 
   return null
 }
@@ -113,6 +118,8 @@ function piAuthProviderToIcon(piAuthProvider: string): ProviderIconKey | null {
       return 'huggingface'
     case 'vercel-ai-gateway':
       return 'vercel'
+    case 'minimax':
+      return 'minimax'
     default:
       return null
   }

--- a/packages/shared/src/config/models-pi.ts
+++ b/packages/shared/src/config/models-pi.ts
@@ -129,6 +129,7 @@ const PI_PROVIDER_DISPLAY: Partial<Record<KnownProvider, { label: string; placeh
   'vercel-ai-gateway':      { label: 'Vercel AI Gateway',  placeholder: 'Paste your key here...' },
   'huggingface':            { label: 'Hugging Face',       placeholder: 'hf_...' },
   'zai':                    { label: 'z.ai (GLM)',         placeholder: 'Paste your key here...' },
+  'minimax':                { label: 'Minimax',            placeholder: 'Paste your key here...' },
 };
 
 /**


### PR DESCRIPTION
## Summary
- Add Minimax as an Anthropic-compatible endpoint preset
- Supports MiniMax-M2.5 and MiniMax-M2.5-highspeed models
- Add Minimax icon and provider mappings

## Changes
- `ApiKeyInput.tsx`: Add Minimax to `ANTHROPIC_PRESETS`
- `provider-icons.ts`: Add Minimax icon and URL detection
- `models-pi.ts`: Add Minimax to `PI_PROVIDER_DISPLAY`
- `minimax.svg`: New provider icon

## Usage
Users can now select **Minimax** from the Endpoint dropdown when configuring API Key authentication.

## Reference
https://platform.minimax.io/docs/coding-plan/intro