### PR TITLE
fix: normalize macOS installer checksum verification

### DIFF
--- a/scripts/install-app.sh
+++ b/scripts/install-app.sh
@@ -221,8 +221,8 @@ echo ""
 # Verify checksum (sha512, base64 encoded)
 info "Verifying checksum..."
 if [ "$OS_TYPE" = "darwin" ]; then
-    # macOS: shasum outputs hex, convert to base64
-    actual=$(shasum -a 512 "$installer_path" | cut -d' ' -f1 | xxd -r -p | base64)
+    # macOS: base64 wraps at 76 chars, so normalize before comparing
+    actual=$(shasum -a 512 "$installer_path" | cut -d' ' -f1 | xxd -r -p | base64 | tr -d '\n')
 else
     # Linux: sha512sum outputs hex, convert to base64
     actual=$(sha512sum "$installer_path" | cut -d' ' -f1 | xxd -r -p | base64 | tr -d '\n')


### PR DESCRIPTION
## Summary
This fixes a false checksum mismatch in `scripts/install-app.sh` on macOS.

## Root cause
The Darwin checksum path converts the SHA-512 digest to base64, but BSD `base64` wraps output at 76 characters. That leaves an embedded newline in the computed checksum, so the string comparison fails even when the downloaded ZIP is correct.

## Change
Strip newlines from the macOS base64 output before comparing it to the checksum from `latest-mac.yml`.

## Verification
- Reproduced the failure against the current `Craft-Agent-arm64.zip` release artifact.
- Confirmed the manifest checksum length was `88` while the unnormalized macOS output was `89` because of the wrapped newline.
- Re-ran the same checksum calculation with newline normalization and verified it matches the manifest checksum.