### PR TITLE
fix: restore production packaging for Pi runtime

### DIFF
--- a/apps/electron/build/entitlements.mac.plist
+++ b/apps/electron/build/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/apps/electron/scripts/build-dmg.sh
+++ b/apps/electron/scripts/build-dmg.sh
@@ -130,12 +130,20 @@ echo "Copying SDK..."
 mkdir -p "$ELECTRON_DIR/node_modules/@anthropic-ai"
 cp -r "$SDK_SOURCE" "$ELECTRON_DIR/node_modules/@anthropic-ai/"
 
-# 5. Copy interceptor
-INTERCEPTOR_SOURCE="$ROOT_DIR/packages/shared/src/network-interceptor.ts"
-require_path "$INTERCEPTOR_SOURCE" "Interceptor" "Ensure packages/shared/src/network-interceptor.ts exists."
-echo "Copying interceptor..."
+# 5. Copy interceptor sources required at runtime
+INTERCEPTOR_FILES=(
+    "unified-network-interceptor.ts"
+    "interceptor-common.ts"
+    "feature-flags.ts"
+    "interceptor-request-utils.ts"
+)
+echo "Copying interceptor sources..."
 mkdir -p "$ELECTRON_DIR/packages/shared/src"
-cp "$INTERCEPTOR_SOURCE" "$ELECTRON_DIR/packages/shared/src/"
+for interceptor_file in "${INTERCEPTOR_FILES[@]}"; do
+    INTERCEPTOR_SOURCE="$ROOT_DIR/packages/shared/src/$interceptor_file"
+    require_path "$INTERCEPTOR_SOURCE" "Interceptor source" "Ensure packages/shared/src/$interceptor_file exists."
+    cp "$INTERCEPTOR_SOURCE" "$ELECTRON_DIR/packages/shared/src/"
+done
 
 # 6. Build Electron app
 echo "Building Electron app..."

--- a/apps/electron/scripts/build-linux.sh
+++ b/apps/electron/scripts/build-linux.sh
@@ -122,12 +122,20 @@ echo "Copying SDK..."
 mkdir -p "$ELECTRON_DIR/node_modules/@anthropic-ai"
 cp -r "$SDK_SOURCE" "$ELECTRON_DIR/node_modules/@anthropic-ai/"
 
-# 5. Copy interceptor
-INTERCEPTOR_SOURCE="$ROOT_DIR/packages/shared/src/network-interceptor.ts"
-require_path "$INTERCEPTOR_SOURCE" "Interceptor" "Ensure packages/shared/src/network-interceptor.ts exists."
-echo "Copying interceptor..."
+# 5. Copy interceptor sources required at runtime
+INTERCEPTOR_FILES=(
+    "unified-network-interceptor.ts"
+    "interceptor-common.ts"
+    "feature-flags.ts"
+    "interceptor-request-utils.ts"
+)
+echo "Copying interceptor sources..."
 mkdir -p "$ELECTRON_DIR/packages/shared/src"
-cp "$INTERCEPTOR_SOURCE" "$ELECTRON_DIR/packages/shared/src/"
+for interceptor_file in "${INTERCEPTOR_FILES[@]}"; do
+    INTERCEPTOR_SOURCE="$ROOT_DIR/packages/shared/src/$interceptor_file"
+    require_path "$INTERCEPTOR_SOURCE" "Interceptor source" "Ensure packages/shared/src/$interceptor_file exists."
+    cp "$INTERCEPTOR_SOURCE" "$ELECTRON_DIR/packages/shared/src/"
+done
 
 # 6. Build Electron app
 echo "Building Electron app..."

--- a/apps/electron/scripts/build-win.ps1
+++ b/apps/electron/scripts/build-win.ps1
@@ -165,15 +165,23 @@ Write-Host "Copying SDK..."
 New-Item -ItemType Directory -Force -Path "$ElectronDir\node_modules\@anthropic-ai" | Out-Null
 Copy-Item -Recurse -Force $SdkSource "$ElectronDir\node_modules\@anthropic-ai\"
 
-# 5. Copy interceptor
-$InterceptorSource = "$RootDir\packages\shared\src\network-interceptor.ts"
-if (-not (Test-Path $InterceptorSource)) {
-    Write-Host "ERROR: Interceptor not found at $InterceptorSource" -ForegroundColor Red
-    exit 1
-}
-Write-Host "Copying interceptor..."
+# 5. Copy interceptor sources required at runtime
+$InterceptorFiles = @(
+    "unified-network-interceptor.ts",
+    "interceptor-common.ts",
+    "feature-flags.ts",
+    "interceptor-request-utils.ts"
+)
+Write-Host "Copying interceptor sources..."
 New-Item -ItemType Directory -Force -Path "$ElectronDir\packages\shared\src" | Out-Null
-Copy-Item $InterceptorSource "$ElectronDir\packages\shared\src\"
+foreach ($InterceptorFile in $InterceptorFiles) {
+    $InterceptorSource = "$RootDir\packages\shared\src\$InterceptorFile"
+    if (-not (Test-Path $InterceptorSource)) {
+        Write-Host "ERROR: Interceptor source not found at $InterceptorSource" -ForegroundColor Red
+        exit 1
+    }
+    Copy-Item $InterceptorSource "$ElectronDir\packages\shared\src\"
+}
 
 # 6. Build Electron app
 Write-Host "Building Electron app..."

--- a/scripts/electron-build-resources.ts
+++ b/scripts/electron-build-resources.ts
@@ -2,7 +2,7 @@
  * Cross-platform resources copy script
  */
 
-import { existsSync, cpSync } from "fs";
+import { existsSync, cpSync, mkdirSync } from "fs";
 import { join } from "path";
 
 const ROOT_DIR = join(import.meta.dir, "..");
@@ -10,6 +10,20 @@ const ELECTRON_DIR = join(ROOT_DIR, "apps/electron");
 
 const srcDir = join(ELECTRON_DIR, "resources");
 const destDir = join(ELECTRON_DIR, "dist/resources");
+const piSource = join(ROOT_DIR, "packages/pi-agent-server/dist/index.js");
+const piDestDir = join(destDir, "pi-agent-server");
+const koffiSource = join(ROOT_DIR, "node_modules/koffi");
+const koffiDest = join(piDestDir, "node_modules/koffi");
+
+function koffiPlatformDir(): string {
+  const platform = process.platform === "win32"
+    ? "win32"
+    : process.platform === "linux"
+      ? "linux"
+      : "darwin";
+  const arch = process.arch === "arm64" ? "arm64" : "x64";
+  return `${platform}_${arch}`;
+}
 
 if (existsSync(srcDir)) {
   cpSync(srcDir, destDir, { recursive: true, force: true });
@@ -17,3 +31,38 @@ if (existsSync(srcDir)) {
 } else {
   console.log("⚠️ No resources directory found");
 }
+
+if (!existsSync(piSource)) {
+  console.log("⚠️ Pi agent server not found, skipping resource staging");
+  process.exit(0);
+}
+
+mkdirSync(piDestDir, { recursive: true });
+cpSync(piSource, join(piDestDir, "index.js"), { force: true });
+
+if (!existsSync(koffiSource)) {
+  console.log("⚠️ koffi not found, staged Pi agent server without native runtime");
+  process.exit(0);
+}
+
+mkdirSync(koffiDest, { recursive: true });
+
+for (const entry of ["package.json", "index.js", "indirect.js", "index.d.ts", "lib"]) {
+  const src = join(koffiSource, entry);
+  if (existsSync(src)) {
+    cpSync(src, join(koffiDest, entry), { recursive: true, force: true });
+  }
+}
+
+const targetDir = koffiPlatformDir();
+const nativeSrc = join(koffiSource, "build", "koffi", targetDir);
+const nativeDest = join(koffiDest, "build", "koffi", targetDir);
+
+if (existsSync(nativeSrc)) {
+  mkdirSync(nativeDest, { recursive: true });
+  cpSync(nativeSrc, nativeDest, { recursive: true, force: true });
+} else {
+  cpSync(join(koffiSource, "build"), join(koffiDest, "build"), { recursive: true, force: true });
+}
+
+console.log(`🥧 Staged Pi agent server resources (${targetDir})`);


### PR DESCRIPTION
## Summary
This fixes several production packaging regressions in the macOS/Linux/Windows build scripts and shared Electron resource staging.

## Root cause
The current repository state has drift between the packaging scripts and the source tree:
- the platform build scripts still reference `packages/shared/src/network-interceptor.ts`, but the repo now uses `unified-network-interceptor.ts`
- the packaged mac build references `apps/electron/build/entitlements.mac.plist`, but that file is missing from the OSS repo
- `electron:build` compiles `packages/pi-agent-server/dist/index.js`, but the shared resources copy step never stages `pi-agent-server` into the packaged app resources, so packaged Pi sessions fail at runtime with `piServerPath not configured`

## Change
- update platform packaging scripts to copy the current interceptor source set required at runtime
- add the missing macOS entitlements plist used by electron-builder signing
- stage `pi-agent-server` and its `koffi` runtime into `apps/electron/dist/resources/pi-agent-server`

## Verification
- reproduced the stale production build failures from `main`
- ran `bash apps/electron/scripts/build-dmg.sh arm64` successfully on the patched branch
- verified the produced arm64 app bundle contains:
  - `Contents/Resources/app/dist/resources/pi-agent-server/index.js`
  - `Contents/Resources/app/dist/resources/pi-agent-server/node_modules/koffi/...`
  - `Contents/Resources/app/packages/shared/src/unified-network-interceptor.ts` and its helper files