### PR TITLE
feat: add OpenCode Zen and Go provider presets

### DIFF
--- a/apps/electron/src/main/__tests__/connection-setup-logic.test.ts
+++ b/apps/electron/src/main/__tests__/connection-setup-logic.test.ts
@@ -4,6 +4,7 @@ import {
   createBuiltInConnection,
   validateModelList,
   validateSetupTestInput,
+  piAuthProviderDisplayName,
   BUILT_IN_CONNECTION_TEMPLATES,
 } from '@craft-agent/server-core/domain'
 import type { ModelDefinition } from '@craft-agent/shared/config/models'
@@ -130,6 +131,11 @@ describe('createBuiltInConnection', () => {
   it('sets piAuthProvider for github-copilot', () => {
     const conn = createBuiltInConnection('github-copilot')
     expect(conn.piAuthProvider).toBe('github-copilot')
+  })
+
+  it('maps OpenCode provider IDs to human-readable names', () => {
+    expect(piAuthProviderDisplayName('opencode')).toBe('OpenCode Zen')
+    expect(piAuthProviderDisplayName('opencode-go')).toBe('OpenCode Go')
   })
 })
 

--- a/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
+++ b/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
@@ -98,6 +98,8 @@ const ANTHROPIC_PRESETS: Preset[] = [
   { key: 'minimax-global', label: 'Minimax Global', url: 'https://api.minimax.io/anthropic', placeholder: 'Paste your key here...' },
   { key: 'minimax-cn', label: 'Minimax CN', url: 'https://api.minimaxi.com/anthropic', placeholder: 'Paste your key here...' },
   { key: 'kimi-coding', label: 'Kimi (Coding)', url: 'https://api.kimi.com/coding', placeholder: 'sk-kimi-...' },
+  { key: 'opencode', label: 'OpenCode Zen', url: '', placeholder: 'Paste your key here...' },
+  { key: 'opencode-go', label: 'OpenCode Go', url: '', placeholder: 'Paste your key here...' },
   { key: 'vercel-ai-gateway', label: 'Vercel AI Gateway', url: 'https://ai-gateway.vercel.sh', placeholder: 'Paste your key here...' },
   { key: 'custom', label: 'Custom', url: '', placeholder: 'Paste your key here...' },
 ]
@@ -122,7 +124,9 @@ const GOOGLE_PRESETS: Preset[] = [
 ]
 
 /** Presets that require the Pi SDK for authentication — hidden in Anthropic API Key mode */
-const PI_ONLY_PRESET_KEYS: ReadonlySet<string> = new Set(['minimax-global', 'minimax-cn'])
+const PI_ONLY_PRESET_KEYS: ReadonlySet<string> = new Set(['minimax-global', 'minimax-cn', 'opencode', 'opencode-go'])
+const PI_AUTO_SYNC_PRESET_KEYS: ReadonlySet<string> = new Set(['anthropic', 'openai', 'pi', 'google'])
+const PI_MANAGED_ENDPOINT_PRESET_KEYS: ReadonlySet<string> = new Set([...PI_AUTO_SYNC_PRESET_KEYS, 'opencode', 'opencode-go'])
 
 const COMPAT_ANTHROPIC_DEFAULTS = 'anthropic/claude-opus-4.6, anthropic/claude-sonnet-4.6, anthropic/claude-haiku-4.5'
 const COMPAT_OPENAI_DEFAULTS = 'openai/gpt-5.2-codex, openai/gpt-5.1-codex-mini'
@@ -197,12 +201,10 @@ export function ApiKeyInput({
   const isDisabled = disabled || status === 'validating'
 
   const isPiApiKeyFlow = providerType === 'pi_api_key'
-  // Hide endpoint/model fields for providers with well-known endpoints handled by the SDK
-  const DEFAULT_ENDPOINT_PROVIDERS = new Set(['anthropic', 'openai', 'pi', 'google'])
-  const isDefaultProviderPreset = DEFAULT_ENDPOINT_PROVIDERS.has(activePreset)
-
   // Provider-specific placeholders from the active preset
   const activePresetObj = presets.find(p => p.key === activePreset)
+  const isAutoSyncPreset = PI_AUTO_SYNC_PRESET_KEYS.has(activePreset)
+  const isManagedEndpointPreset = PI_MANAGED_ENDPOINT_PRESET_KEYS.has(activePreset)
   const apiKeyPlaceholder = activePresetObj?.placeholder
     ?? (providerType === 'google' ? 'AIza...'
     : providerType === 'pi' ? 'pi-...'
@@ -212,7 +214,7 @@ export function ApiKeyInput({
   // Fetch Pi SDK models when a provider is selected in pi_api_key flow.
   // Returns all models sorted by cost (expensive-first) for the searchable tier dropdowns.
   const loadPiModels = useCallback(async (provider: string) => {
-    if (!isPiApiKeyFlow || !provider || provider === 'custom' || DEFAULT_ENDPOINT_PROVIDERS.has(provider)) {
+    if (!isPiApiKeyFlow || !provider || provider === 'custom' || PI_AUTO_SYNC_PRESET_KEYS.has(provider)) {
       setPiModels([])
       return
     }
@@ -241,7 +243,7 @@ export function ApiKeyInput({
   }, [activePreset, loadPiModels])
 
   // Whether to show 3 tier dropdowns instead of text input
-  const hasPiModels = isPiApiKeyFlow && piModels.length > 0 && !isDefaultProviderPreset && activePreset !== 'custom'
+  const hasPiModels = isPiApiKeyFlow && piModels.length > 0 && !isAutoSyncPreset && activePreset !== 'custom'
 
   const handlePresetSelect = (preset: Preset) => {
     setActivePreset(preset.key)
@@ -326,8 +328,8 @@ export function ApiKeyInput({
 
     const parsedModels = parseModelList(connectionDefaultModel)
 
-    const isUsingDefaultEndpoint = isDefaultProviderPreset || !effectiveBaseUrl
-    const requiresModel = !isDefaultProviderPreset && !!effectiveBaseUrl
+    const isUsingDefaultEndpoint = isManagedEndpointPreset || !effectiveBaseUrl
+    const requiresModel = !isManagedEndpointPreset && !!effectiveBaseUrl
     if (requiresModel && parsedModels.length === 0) {
       setModelError('Default model is required for custom endpoints.')
       return
@@ -424,8 +426,8 @@ export function ApiKeyInput({
             </StyledDropdownMenuContent>
           </DropdownMenu>
         </div>
-        {/* Base URL input - hidden for default provider presets (Anthropic/OpenAI) */}
-        {!isDefaultProviderPreset && (
+        {/* Base URL input - hidden for providers whose endpoint is managed by the SDK */}
+        {!isManagedEndpointPreset && (
           <div className={cn(
             "rounded-md shadow-minimal transition-colors",
             "bg-foreground-2 focus-within:bg-background"
@@ -445,7 +447,7 @@ export function ApiKeyInput({
       )}
 
       {/* Protocol Toggle — visible as soon as Custom preset is selected */}
-      {activePreset === 'custom' && !isDefaultProviderPreset && (
+      {activePreset === 'custom' && !isManagedEndpointPreset && (
         <div className="space-y-2">
           <Label>Protocol</Label>
           <div className={cn(
@@ -589,7 +591,7 @@ export function ApiKeyInput({
             </>
           )}
         </div>
-      ) : !isDefaultProviderPreset && (
+      ) : !isManagedEndpointPreset && (
         <div className="space-y-2">
           <Label htmlFor="connection-default-model" className="text-muted-foreground font-normal">
             Default Model{' '}

--- a/apps/electron/src/renderer/lib/provider-icons.ts
+++ b/apps/electron/src/renderer/lib/provider-icons.ts
@@ -65,6 +65,8 @@ export function getProviderDisplayName(providerType: string, baseUrl?: string | 
   // Try URL detection first for compat providers
   if (baseUrl) {
     const url = baseUrl.toLowerCase()
+    if (url.includes('opencode.ai/zen/go')) return 'OpenCode Go'
+    if (url.includes('opencode.ai/zen')) return 'OpenCode Zen'
     if (url.includes('openrouter.ai')) return 'OpenRouter'
     if (url.includes('ollama')) return 'Ollama'
     if (url.includes('kimi.com')) return 'Kimi'
@@ -140,6 +142,8 @@ function piAuthProviderToIcon(piAuthProvider: string): ProviderIconKey | null {
  */
 const PI_AUTH_PROVIDER_DOMAINS: Record<string, string> = {
   groq: 'groq.com',
+  opencode: 'opencode.ai',
+  'opencode-go': 'opencode.ai',
   xai: 'x.ai',
   cerebras: 'cerebras.ai',
   zai: 'z.ai',

--- a/packages/server-core/src/domain/connection-setup-logic.ts
+++ b/packages/server-core/src/domain/connection-setup-logic.ts
@@ -156,6 +156,8 @@ const PI_AUTH_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   minimax: 'Minimax',
   'minimax-cn': 'Minimax CN',
   'kimi-coding': 'Kimi (Coding)',
+  opencode: 'OpenCode Zen',
+  'opencode-go': 'OpenCode Go',
   'vercel-ai-gateway': 'Vercel AI Gateway',
 }
 

--- a/packages/shared/src/config/__tests__/llm-connections.test.ts
+++ b/packages/shared/src/config/__tests__/llm-connections.test.ts
@@ -81,6 +81,14 @@ describe('getDefaultModelForConnection', () => {
     expect(modelIds).toContain(defaultModel)
   })
 
+  it('Pi OpenCode Zen prefers Claude Sonnet 4.6 by default', () => {
+    expect(getDefaultModelForConnection('pi', 'opencode')).toBe('pi/claude-sonnet-4-6')
+  })
+
+  it('Pi OpenCode Go prefers Kimi K2.5 by default', () => {
+    expect(getDefaultModelForConnection('pi', 'opencode-go')).toBe('pi/kimi-k2.5')
+  })
+
   it('returns empty string for anthropic_compat (dynamic provider)', () => {
     const defaultModel = getDefaultModelForConnection('anthropic_compat')
     expect(defaultModel).toBe('')

--- a/packages/shared/src/config/llm-connections.ts
+++ b/packages/shared/src/config/llm-connections.ts
@@ -457,6 +457,8 @@ export const PI_PREFERRED_DEFAULTS: Record<string, string[]> = {
   'openai-codex': ['gpt-5.2', 'gpt-5.1', 'gpt-5', 'o4-mini', 'o3', 'gpt-4o'],
   google: ['gemini-3-pro-preview', 'gemini-3-flash-preview', 'gemini-3.1-flash-lite-preview', 'gemini-2.5-pro', 'gemini-2.5-flash'],
   'github-copilot': ['claude-sonnet-4-6', 'gpt-5', 'o4-mini', 'claude-haiku-4-5'],
+  opencode: ['claude-sonnet-4-6'],
+  'opencode-go': ['kimi-k2.5'],
 };
 
 export function getDefaultModelsForConnection(providerType: LlmProviderType, piAuthProvider?: string): Array<ModelDefinition | string> {

--- a/packages/shared/src/config/models-pi.ts
+++ b/packages/shared/src/config/models-pi.ts
@@ -130,6 +130,8 @@ const PI_PROVIDER_DISPLAY: Partial<Record<KnownProvider, { label: string; placeh
   'huggingface':            { label: 'Hugging Face',       placeholder: 'hf_...' },
   'minimax':                { label: 'Minimax',            placeholder: 'Paste your key here...' },
   'kimi-coding':            { label: 'Kimi (Coding)',      placeholder: 'sk-kimi-...' },
+  'opencode':               { label: 'OpenCode Zen',       placeholder: 'Paste your key here...' },
+  'opencode-go':            { label: 'OpenCode Go',        placeholder: 'Paste your key here...' },
   'zai':                    { label: 'z.ai (GLM)',         placeholder: 'Paste your key here...' },
 };
 

--- a/packages/shared/tests/models-pi.test.ts
+++ b/packages/shared/tests/models-pi.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { getPiModelsForAuthProvider } from '../src/config/models-pi.ts';
+import { getPiApiKeyProviders, getPiModelsForAuthProvider } from '../src/config/models-pi.ts';
 
 describe('models-pi filtering', () => {
   it('excludes codex-mini-latest for openai models', () => {
@@ -12,5 +12,24 @@ describe('models-pi filtering', () => {
     const models = getPiModelsForAuthProvider('openai');
     const ids = models.map(m => m.id);
     expect(ids.some(id => id.startsWith('pi/gpt-4'))).toBe(false);
+  });
+
+  it('exposes OpenCode Zen and OpenCode Go in Pi API key providers', () => {
+    const providers = getPiApiKeyProviders();
+    expect(providers).toContainEqual({
+      key: 'opencode',
+      label: 'OpenCode Zen',
+      placeholder: 'Paste your key here...',
+    });
+    expect(providers).toContainEqual({
+      key: 'opencode-go',
+      label: 'OpenCode Go',
+      placeholder: 'Paste your key here...',
+    });
+  });
+
+  it('loads models for OpenCode Zen and OpenCode Go', () => {
+    expect(getPiModelsForAuthProvider('opencode').length).toBeGreaterThan(0);
+    expect(getPiModelsForAuthProvider('opencode-go').length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
Adds OpenCode Zen and OpenCode Go to the Craft Agents Backend API key flow.

## Change
- expose OpenCode Zen and OpenCode Go as Pi-backed API presets in the onboarding/settings API input
- map the current bundled Pi provider IDs correctly (`opencode` for Zen, `opencode-go` for Go)
- add display-name, icon fallback, and default-model preferences for those providers
- add targeted tests for provider discovery and default model selection

## Notes
The current bundled Pi SDK in this repo exposes OpenCode Zen as the `opencode` provider ID rather than `opencode-zen`, so the UI label is "OpenCode Zen" while the saved provider key remains `opencode`.

## Verification
- `bun test packages/shared/tests/models-pi.test.ts`
- `bun test packages/shared/src/config/__tests__/llm-connections.test.ts`
- `bun test apps/electron/src/main/__tests__/connection-setup-logic.test.ts`