### PR TITLE
fix(electron): use openUrl with fallback for OAuth browser launch on Windows

### DIFF
--- a/apps/electron/src/preload/bootstrap.ts
+++ b/apps/electron/src/preload/bootstrap.ts
@@ -19,6 +19,7 @@ import { buildClientApi } from '../transport/build-api'
 import { CHANNEL_MAP } from '../transport/channel-map'
 import { createCallbackServer } from '@craft-agent/shared/auth/callback-server'
 import { CHATGPT_OAUTH_CONFIG } from '@craft-agent/shared/auth/chatgpt-oauth-config'
+import { openUrl } from '@craft-agent/shared/utils/open-url'
 import {
   CLIENT_OPEN_EXTERNAL,
   CLIENT_OPEN_PATH,
@@ -193,7 +194,7 @@ if (wsMode === 'remote') {
     state = startResult.state
 
     // 3. Open browser for user consent (local — must open on the user's machine, not remote server)
-    await shell.openExternal(startResult.authUrl)
+    await openUrl(startResult.authUrl)
 
     // 4. Wait for OAuth provider to redirect to our callback server
     const callback = await callbackServer.promise
@@ -240,7 +241,7 @@ if (wsMode === 'remote') {
   try {
     const result = await client.invoke('onboarding:startClaudeOAuth')
     if (result.success && result.authUrl) {
-      await shell.openExternal(result.authUrl)
+      await openUrl(result.authUrl)
     }
     return result
   } catch (err) {
@@ -276,7 +277,7 @@ if (wsMode === 'remote') {
     state = startResult.state
 
     // 3. Open browser for user consent
-    await shell.openExternal(startResult.authUrl)
+    await openUrl(startResult.authUrl)
 
     // 4. Wait for OpenAI to redirect to our callback server
     const callback = await callbackServer.promise


### PR DESCRIPTION
## Problem

The OAuth browser window never opens on Windows (issue #414). When clicking "Sign in with Google", the UI briefly flashes "Complete authentication in your browser" then silently reverts - no browser window opens.

## Root Cause

The 
	bootstrap.ts` preload script calls 
	shell.openExternal()` directly to open the browser for OAuth. On Windows, this can fail silently due to:
- Sandbox restrictions in the preload context
- Missing https:// handler registration
- Windows 11 Smart App Control

The main process has a robust 
	openUrl()` helper with a fallback to the 'open' npm package, but the preload script was not using it.

## Solution

Import and use 
	openUrl()` from 
	@craft-agent/shared/utils/open-url` instead of direct 
	shell.openExternal()` calls in all three OAuth flows:
- 
	performOAuth()` (Google Drive, Docs, Sheets, Gmail)
- 
	startClaudeOAuth()` (Claude OAuth)
- 
	startChatGptOAuth()` (ChatGPT OAuth)

The 
	openUrl()` function tries Electron's 
	shell.openExternal()` first, then falls back to the 'open' npm package if that fails.

## Changes

- Import 
	openUrl` from shared utils
- Replace 3 direct 
	shell.openExternal()` calls with 
	openUrl()`

## Testing

This fix addresses the silent failure on Windows by ensuring a fallback browser launch mechanism is available when Electron's native API fails.

Fixes #414