### PR TITLE
feat: support model display aliases

### DIFF
--- a/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
+++ b/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
@@ -44,6 +44,8 @@ export interface ApiKeySubmitData {
   modelSelectionMode?: 'automaticallySyncedFromProvider' | 'userDefined3Tier'
   /** Custom endpoint protocol — set when user configures an arbitrary API endpoint */
   customEndpoint?: CustomEndpointConfig
+  /** User-defined display aliases for models (from "model_id:alias" format) */
+  modelAliases?: Record<string, string>
 }
 
 export interface ApiKeyInputProps {
@@ -148,6 +150,31 @@ function parseModelList(value: string): string[] {
     .split(',')
     .map((entry) => entry.trim())
     .filter(Boolean)
+    .map((entry) => {
+      // Support "model_id:alias" format — extract just the model ID
+      const colonIdx = entry.indexOf(':')
+      return colonIdx > 0 ? entry.substring(0, colonIdx).trim() : entry
+    })
+}
+
+/**
+ * Parse model aliases from a comma-separated model string.
+ * Entries with "model_id:alias" format produce alias mappings.
+ * Returns a Record<modelId, alias> (empty if no aliases found).
+ */
+function parseModelAliases(value: string): Record<string, string> {
+  const aliases: Record<string, string> = {}
+  for (const entry of value.split(',').map(e => e.trim()).filter(Boolean)) {
+    const colonIdx = entry.indexOf(':')
+    if (colonIdx > 0) {
+      const id = entry.substring(0, colonIdx).trim()
+      const alias = entry.substring(colonIdx + 1).trim()
+      if (id && alias) {
+        aliases[id] = alias
+      }
+    }
+  }
+  return aliases
 }
 
 // ============================================================
@@ -325,6 +352,7 @@ export function ApiKeyInput({
     const effectiveBaseUrl = baseUrl.trim()
 
     const parsedModels = parseModelList(connectionDefaultModel)
+    const parsedAliases = parseModelAliases(connectionDefaultModel)
 
     const isUsingDefaultEndpoint = isDefaultProviderPreset || !effectiveBaseUrl
     const requiresModel = !isDefaultProviderPreset && !!effectiveBaseUrl
@@ -350,6 +378,7 @@ export function ApiKeyInput({
         ? (parsedModels.length > 0 ? 'userDefined3Tier' : 'automaticallySyncedFromProvider')
         : undefined,
       customEndpoint,
+      modelAliases: Object.keys(parsedAliases).length > 0 ? parsedAliases : undefined,
     })
   }
 

--- a/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
+++ b/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
@@ -336,6 +336,9 @@ export function FreeFormInput({
   // Get display name for current model (full name, not short name)
   const currentModelDisplayName = React.useMemo(() => {
     const modelToDisplay = connectionDefaultModel ?? currentModel
+    // Check connection-level alias first
+    const alias = effectiveConnectionDetails?.modelAliases?.[modelToDisplay]
+    if (alias) return alias
     const model = availableModels.find(m =>
       typeof m === 'string' ? m === modelToDisplay : m.id === modelToDisplay
     )
@@ -343,8 +346,8 @@ export function FreeFormInput({
       // Fallback: use helper function to format unknown model IDs nicely
       return stripPiPrefixForDisplay(getModelDisplayName(modelToDisplay))
     }
-    return typeof model === 'string' ? stripPiPrefixForDisplay(model) : model.name
-  }, [availableModels, currentModel, connectionDefaultModel])
+    return typeof model === 'string' ? stripPiPrefixForDisplay(model) : (model.displayAlias || model.name)
+  }, [availableModels, currentModel, connectionDefaultModel, effectiveConnectionDetails])
 
   // Group connections by provider type for hierarchical dropdown
   // Each provider (Anthropic, Pi) can have multiple connections (API Key, OAuth, etc.)
@@ -1833,7 +1836,7 @@ Model
                               {/* Show models for this connection - use provider-specific models as fallback */}
                               {(conn.models || ANTHROPIC_MODELS).map((model) => {
                                 const modelId = typeof model === 'string' ? model : model.id
-                                const modelName = typeof model === 'string' ? stripPiPrefixForDisplay(getModelShortName(model)) : model.name
+                                const modelName = conn.modelAliases?.[modelId] || (typeof model === 'string' ? stripPiPrefixForDisplay(getModelShortName(model)) : (model.displayAlias || model.name))
                                 const isSelectedModel = isCurrentConnection && currentModel === modelId
                                 return (
                                   <StyledDropdownMenuItem
@@ -1880,7 +1883,7 @@ Model
                   {/* Model options based on effective connection's provider type */}
                   {availableModels.map((model) => {
                     const modelId = typeof model === 'string' ? model : model.id
-                    const modelName = typeof model === 'string' ? stripPiPrefixForDisplay(getModelShortName(model)) : model.name
+                    const modelName = effectiveConnectionDetails?.modelAliases?.[modelId] || (typeof model === 'string' ? stripPiPrefixForDisplay(getModelShortName(model)) : (model.displayAlias || model.name))
                     const isSelected = currentModel === modelId
                     const description = typeof model !== 'string' && 'description' in model ? (model.description as string) : ''
                     return (

--- a/apps/electron/src/renderer/hooks/useOnboarding.ts
+++ b/apps/electron/src/renderer/hooks/useOnboarding.ts
@@ -141,6 +141,7 @@ export function apiSetupMethodToConnectionSetup(
     piAuthProvider?: string
     modelSelectionMode?: 'automaticallySyncedFromProvider' | 'userDefined3Tier'
     customEndpoint?: CustomEndpointConfig
+    modelAliases?: Record<string, string>
   },
   editingSlug: string | null,
   existingSlugs: Set<string>,
@@ -156,6 +157,7 @@ export function apiSetupMethodToConnectionSetup(
         defaultModel: options.connectionDefaultModel,
         models: options.models,
         customEndpoint: options.customEndpoint,
+        modelAliases: options.modelAliases,
       }
     case 'claude_oauth':
       return {
@@ -178,6 +180,7 @@ export function apiSetupMethodToConnectionSetup(
         piAuthProvider: options.piAuthProvider,
         modelSelectionMode: options.modelSelectionMode,
         customEndpoint: options.customEndpoint,
+        modelAliases: options.modelAliases,
       }
   }
 }
@@ -240,6 +243,7 @@ export function useOnboarding({
       piAuthProvider?: string
       modelSelectionMode?: 'automaticallySyncedFromProvider' | 'userDefined3Tier'
       customEndpoint?: CustomEndpointConfig
+      modelAliases?: Record<string, string>
     },
     methodOverride?: ApiSetupMethod,
     connectionSlugOverride?: string,
@@ -262,6 +266,7 @@ export function useOnboarding({
         piAuthProvider: options?.piAuthProvider,
         modelSelectionMode: options?.modelSelectionMode,
         customEndpoint: options?.customEndpoint,
+        modelAliases: options?.modelAliases,
       }, connectionSlugOverride ?? editingSlug, existingSlugs)
       // Use new unified API
       const result = await window.electronAPI.setupLlmConnection(
@@ -377,6 +382,7 @@ export function useOnboarding({
           piAuthProvider: data.piAuthProvider,
           modelSelectionMode: data.modelSelectionMode,
           customEndpoint: data.customEndpoint,
+          modelAliases: data.modelAliases,
         })
         if (saved) {
           setState(s => ({ ...s, credentialStatus: 'success', step: 'complete' }))
@@ -438,6 +444,7 @@ export function useOnboarding({
         piAuthProvider: data.piAuthProvider,
         modelSelectionMode: data.modelSelectionMode,
         customEndpoint: data.customEndpoint,
+        modelAliases: data.modelAliases,
       })
 
       if (saved) {

--- a/apps/electron/src/renderer/pages/settings/AiSettingsPage.tsx
+++ b/apps/electron/src/renderer/pages/settings/AiSettingsPage.tsx
@@ -63,12 +63,14 @@ function getModelOptionsForConnection(
   // If connection has explicit models, use those
   if (connection.models && connection.models.length > 0) {
     return connection.models.map((m) => {
+      const modelId = typeof m === 'string' ? m : m.id
+      const alias = connection.modelAliases?.[modelId]
       if (typeof m === 'string') {
-        return { value: m, label: getModelShortName(m), description: '' }
+        return { value: m, label: alias || getModelShortName(m), description: '' }
       }
       // ModelDefinition object
       const def = m as ModelDefinition
-      return { value: def.id, label: def.name, description: def.description }
+      return { value: def.id, label: alias || def.displayAlias || def.name, description: def.description }
     })
   }
 
@@ -76,7 +78,7 @@ function getModelOptionsForConnection(
   const registryModels = getModelsForProviderType(connection.providerType, connection.piAuthProvider)
   return registryModels.map((m) => ({
     value: m.id,
-    label: m.name,
+    label: connection.modelAliases?.[m.id] || m.name,
     description: m.description,
   }))
 }
@@ -733,9 +735,13 @@ export default function AiSettingsPage() {
       // IPC method may not exist if app wasn't restarted after code change
     }
 
-    // Build model string from connection's models array
+    // Build model string from connection's models array (including aliases)
     const modelStr = connection.models
-      ?.map((m: string | ModelDefinition) => typeof m === 'string' ? m : m.id)
+      ?.map((m: string | ModelDefinition) => {
+        const id = typeof m === 'string' ? m : m.id
+        const alias = connection.modelAliases?.[id]
+        return alias ? `${id}:${alias}` : id
+      })
       .join(', ') || connection.defaultModel || ''
 
     // Set initial values before opening overlay so ApiKeyInput mounts with them

--- a/packages/server-core/src/handlers/rpc/llm-connections.ts
+++ b/packages/server-core/src/handlers/rpc/llm-connections.ts
@@ -98,6 +98,9 @@ export function registerLlmConnectionsHandlers(server: RpcServer, deps: HandlerD
       if (setup.modelSelectionMode !== undefined) {
         updates.modelSelectionMode = setup.modelSelectionMode
       }
+      if (setup.modelAliases !== undefined) {
+        updates.modelAliases = setup.modelAliases
+      }
 
       const customEndpoint = hasConfiguredBaseUrl ? setup.customEndpoint : undefined
       const isCustomEndpointCompat = !!customEndpoint

--- a/packages/shared/src/config/llm-connections.ts
+++ b/packages/shared/src/config/llm-connections.ts
@@ -183,6 +183,14 @@ export interface LlmConnection {
 
   /** Timestamp when connection was last used */
   lastUsedAt?: number;
+
+  /**
+   * User-defined display aliases for models, keyed by model ID.
+   * When set, UI shows the alias instead of the model's default name.
+   * Does not affect the model ID sent to the provider.
+   * e.g., { "claude-sonnet-4-6": "My Sonnet", "gpt-5.2": "GPT5" }
+   */
+  modelAliases?: Record<string, string>;
 }
 
 /**

--- a/packages/shared/src/config/models.ts
+++ b/packages/shared/src/config/models.ts
@@ -38,6 +38,8 @@ export interface ModelDefinition {
   contextWindow: number;
   /** Whether this model supports thinking/reasoning effort. Defaults to true when undefined. */
   supportsThinking?: boolean;
+  /** User-defined display alias. When set, UI shows this instead of name/shortName. */
+  displayAlias?: string;
 }
 
 // ============================================
@@ -172,7 +174,7 @@ export function getModelById(modelId: string): ModelDefinition | undefined {
  */
 export function getModelDisplayName(modelId: string): string {
   const model = getModelById(modelId);
-  if (model) return model.name;
+  if (model) return model.displayAlias || model.name;
   // Fallback: strip prefix and date suffix, format nicely
   // e.g., "claude-opus-4-5-20251101" → "Opus 4.5"
   const stripped = modelId
@@ -192,7 +194,7 @@ export function getModelDisplayName(modelId: string): string {
  */
 export function getModelShortName(modelId: string): string {
   const model = getModelById(modelId);
-  if (model) return model.shortName;
+  if (model) return model.displayAlias || model.shortName;
   // For provider-prefixed IDs (e.g. "openai/gpt-5"), show just the model part
   if (modelId.includes('/')) {
     return modelId.split('/').pop() || modelId;

--- a/packages/shared/src/protocol/dto.ts
+++ b/packages/shared/src/protocol/dto.ts
@@ -310,6 +310,8 @@ export interface LlmConnectionSetup {
   updateOnly?: boolean
   /** Custom endpoint protocol for arbitrary OpenAI/Anthropic-compatible APIs */
   customEndpoint?: CustomEndpointConfig
+  /** User-defined display aliases for models, keyed by model ID */
+  modelAliases?: Record<string, string>
 }
 
 export interface TestLlmConnectionParams {


### PR DESCRIPTION
## Summary
- Allow users to define display aliases for models using `model_id:alias` syntax in the model input field (e.g., `claude-sonnet-4-6:My Sonnet, gpt-5.2:GPT5`)
- Aliases are purely cosmetic — the underlying model ID sent to the provider stays the same
- Aliases are stored per-connection via `modelAliases: Record<string, string>` and shown in model selectors and settings

## Motivation
When many models are configured (especially with custom providers), they can be hard to distinguish. Display aliases let users assign memorable short names.

## Changes
- **`packages/shared/src/config/models.ts`** — Add `displayAlias` to `ModelDefinition`; update `getModelDisplayName()` and `getModelShortName()` to prefer alias
- **`packages/shared/src/config/llm-connections.ts`** — Add `modelAliases` field to `LlmConnection`
- **`packages/shared/src/protocol/dto.ts`** — Add `modelAliases` to `LlmConnectionSetup` DTO
- **`packages/server-core/src/handlers/rpc/llm-connections.ts`** — Persist `modelAliases` in setup handler
- **`apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx`** — Parse `model_id:alias` format, pass aliases through submit
- **`apps/electron/src/renderer/hooks/useOnboarding.ts`** — Thread `modelAliases` through save config pipeline
- **`apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx`** — Show aliases in model selector dropdown
- **`apps/electron/src/renderer/pages/settings/AiSettingsPage.tsx`** — Show aliases in settings; serialize back to `id:alias` format when editing

## Test plan
- [ ] Configure a connection with models using alias syntax: `model-id-1:Alias1, model-id-2:Alias2`
- [ ] Verify aliases appear in the model selector dropdown and settings page
- [ ] Verify the actual model ID (not alias) is sent to the provider
- [ ] Verify editing an existing connection preserves aliases in the input field
- [ ] Verify connections without aliases continue to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)