### PR TITLE
fix: Amazon Bedrock provider — missing module, ABSK decode, HTTP/2 compat

### DIFF
--- a/packages/pi-agent-server/src/index.ts
+++ b/packages/pi-agent-server/src/index.ts
@@ -435,6 +435,33 @@ function createAuthenticatedRegistry(): {
     const { provider, credential } = initConfig.piAuth;
     authStorage.set(provider, credential);
     debugLog(`Injected ${credential.type} credential for provider: ${provider}`);
+
+    // Bedrock ABSK API key support: the Pi SDK's Bedrock provider reads credentials
+    // from AWS SDK's default credential chain (env vars / profiles), not from
+    // options.apiKey. When the UI passes an ABSK token, decode it and set standard
+    // AWS env vars so the SDK can find them.
+    if (provider === 'amazon-bedrock' && credential.type === 'api_key' && credential.key) {
+      const abskKey = credential.key;
+      try {
+        const raw = abskKey.startsWith('ABSK') ? abskKey.slice(4) : abskKey;
+        const decoded = Buffer.from(raw, 'base64').toString('utf-8');
+        const colonIdx = decoded.indexOf(':');
+        if (colonIdx > 0) {
+          process.env.AWS_ACCESS_KEY_ID = decoded.substring(0, colonIdx);
+          process.env.AWS_SECRET_ACCESS_KEY = decoded.substring(colonIdx + 1);
+          debugLog('Decoded ABSK token into AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY');
+        }
+      } catch {
+        // Not an ABSK token — fall through to default credential chain
+      }
+
+      // Electron's http2 module is incompatible with AWS SDK v3's NodeHttp2Handler.
+      // Force HTTP/1.1 to avoid "http2 request did not get a response" errors.
+      if (!process.env.AWS_BEDROCK_FORCE_HTTP1) {
+        process.env.AWS_BEDROCK_FORCE_HTTP1 = '1';
+        debugLog('Auto-set AWS_BEDROCK_FORCE_HTTP1=1 (Electron HTTP/2 compatibility)');
+      }
+    }
   } else if (initConfig?.apiKey) {
     authStorage.set('anthropic', { type: 'api_key', key: initConfig.apiKey });
     debugLog('Injected API key into auth storage (legacy fallback)');

--- a/scripts/electron-build-main.ts
+++ b/scripts/electron-build-main.ts
@@ -251,6 +251,36 @@ async function buildPiAgentServer(): Promise<void> {
     process.exit(1);
   }
 
+  // Copy amazon-bedrock.js to dist/ — the Pi SDK lazy-loads this module via
+  // dynamic import("./amazon-bedrock.js") to keep the AWS SDK out of the main
+  // bundle. Without this file next to index.js, Bedrock provider fails at runtime
+  // with "Cannot find module './amazon-bedrock.js'".
+  //
+  // The source file uses relative imports (e.g. "../models.js") that resolve
+  // within pi-ai's dist/ tree. Since we place this file in pi-agent-server/dist/,
+  // rewrite them to package specifiers so bun resolves from node_modules.
+  const bedrockSrc = join(ROOT_DIR, "node_modules/@mariozechner/pi-ai/dist/providers/amazon-bedrock.js");
+  const bedrockDest = join(distDir, "amazon-bedrock.js");
+  if (existsSync(bedrockSrc)) {
+    let bedrockCode = readFileSync(bedrockSrc, "utf-8");
+    const importRewrites: [RegExp, string][] = [
+      [/from\s+"\.\.\/models\.js"/g,                   'from "@mariozechner/pi-ai/dist/models.js"'],
+      [/from\s+"\.\.\/utils\/event-stream\.js"/g,      'from "@mariozechner/pi-ai/dist/utils/event-stream.js"'],
+      [/from\s+"\.\.\/utils\/json-parse\.js"/g,        'from "@mariozechner/pi-ai/dist/utils/json-parse.js"'],
+      [/from\s+"\.\.\/utils\/sanitize-unicode\.js"/g,  'from "@mariozechner/pi-ai/dist/utils/sanitize-unicode.js"'],
+      [/from\s+"\.\/simple-options\.js"/g,             'from "@mariozechner/pi-ai/dist/providers/simple-options.js"'],
+      [/from\s+"\.\/transform-messages\.js"/g,         'from "@mariozechner/pi-ai/dist/providers/transform-messages.js"'],
+    ];
+    for (const [pattern, replacement] of importRewrites) {
+      bedrockCode = bedrockCode.replace(pattern, replacement);
+    }
+    const { writeFileSync } = await import("fs");
+    writeFileSync(bedrockDest, bedrockCode, "utf-8");
+    console.log("✅ Copied amazon-bedrock.js to pi-agent-server dist (imports rewritten)");
+  } else {
+    console.warn("⚠️  amazon-bedrock.js source not found — Bedrock provider will not work");
+  }
+
   console.log("✅ Pi agent server built successfully");
 }
 


### PR DESCRIPTION
## Summary

Amazon Bedrock provider is completely broken in production builds (v0.7.4–v0.7.7). This PR fixes three independent bugs:

1. **Missing `amazon-bedrock.js`** — The Pi SDK lazy-loads this module via dynamic `import("./amazon-" + "bedrock.js")` (deliberate anti-bundling pattern), but the build script never copies it to `pi-agent-server/dist/`. Runtime error: `Cannot find module './amazon-bedrock.js'`

2. **ABSK token not decoded** — The UI stores the raw ABSK token as `options.apiKey`, but the Bedrock provider reads credentials from AWS SDK's default chain (env vars), ignoring `options.apiKey` entirely. The AWS SDK then tries to use the ABSK string as a bearer token, failing with: `request could not be signed with 'token' since the 'token' is not defined`

3. **Electron HTTP/2 incompatibility** — AWS SDK v3.798+ defaults to `NodeHttp2Handler` for Bedrock Runtime, which is incompatible with Electron's `http2` module. Auto-set `AWS_BEDROCK_FORCE_HTTP1=1` for Bedrock sessions.

## Changes

### `scripts/electron-build-main.ts`
- After building `pi-agent-server/dist/index.js`, copy `amazon-bedrock.js` from `node_modules/@mariozechner/pi-ai/dist/providers/`
- Rewrite 6 relative imports to package specifiers (since the file is relocated outside pi-ai's tree)
- Warn (don't fail) if source file not found

### `packages/pi-agent-server/src/index.ts`
- In `createAuthenticatedRegistry()`, after injecting credential into PiAuthStorage:
  - Detect Bedrock provider + ABSK api_key
  - Decode ABSK format (`ABSK` + Base64(`accessKeyId:secretAccessKey`)) → set `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` env vars
  - Auto-set `AWS_BEDROCK_FORCE_HTTP1=1` if not already set
- Non-Bedrock providers and non-ABSK keys are completely unaffected (condition: `provider === 'amazon-bedrock' && credential.type === 'api_key' && credential.key`)

## Test plan

- [x] Non-Bedrock providers (anthropic, openai, google) — ABSK logic completely skipped
- [x] Bedrock + oauth credential type — skipped
- [x] Bedrock + empty/undefined key — skipped
- [x] Bedrock + valid ABSK token — correctly decoded to AccessKeyId + SecretAccessKey
- [x] Bedrock + key with colons in secret — correctly splits at first colon only
- [x] Bedrock + invalid base64 — graceful fallthrough, no crash
- [x] Build succeeds: `bun run electron:build:main` completes with all verifications passing
- [x] Generated `amazon-bedrock.js` has 0 remaining relative imports (all rewritten to package specifiers)
- [x] Manual testing: Craft Agents connects to Bedrock, browser automation works (navigation, search, form filling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)