### PR TITLE
feat: support mid-session model switching and response runtime metadata

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/ChatDisplay.tsx
+++ b/apps/electron/src/renderer/components/app-shell/ChatDisplay.tsx
@@ -40,7 +40,7 @@ import {
 } from "@craft-agent/ui"
 import { useFocusZone } from "@/hooks/keyboard"
 import { useTheme } from "@/hooks/useTheme"
-import type { Session, Message, FileAttachment, StoredAttachment, PermissionRequest, CredentialRequest, CredentialResponse, LoadedSource, LoadedSkill } from "../../../shared/types"
+import type { Session, Message, FileAttachment, StoredAttachment, PermissionRequest, CredentialRequest, CredentialResponse, LoadedSource, LoadedSkill, LlmConnectionWithStatus } from "../../../shared/types"
 import type { PermissionMode } from "@craft-agent/shared/agent/modes"
 import type { ThinkingLevel } from "@craft-agent/shared/agent/thinking-levels"
 import {
@@ -70,6 +70,8 @@ import { useNavigation } from "@/contexts/NavigationContext"
 import { useAppShellContext } from "@/context/AppShellContext"
 import { routes } from "@/lib/navigate"
 import { CHAT_LAYOUT } from "@/config/layout"
+import { getModelDisplayName, getModelShortName } from '@config/models'
+import { ConnectionIcon } from '@/components/icons/ConnectionIcon'
 import { resolveBranchNewPanelOption } from "./branching"
 
 // ============================================================================
@@ -120,8 +122,8 @@ interface ChatDisplayProps {
   // Model selection
   currentModel: string
   onModelChange: (model: string, connection?: string) => void
-  // Connection selection (locked after first message)
-  /** Callback when LLM connection changes (only works when session is empty) */
+  // Connection selection
+  /** Callback when LLM connection changes */
   onConnectionChange?: (connectionSlug: string) => void
   /** Ref for the input, used for external focus control */
   textareaRef?: React.RefObject<RichTextInputHandle>
@@ -365,6 +367,18 @@ function formatElapsed(seconds: number): string {
   return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`
 }
 
+function stripPiPrefixForDisplay(value: string): string {
+  return value.startsWith('pi/') ? value.slice(3) : value
+}
+
+function formatResponseModelLabel(modelId: string): string {
+  const displayName = stripPiPrefixForDisplay(getModelDisplayName(modelId))
+  if (displayName && displayName !== modelId && !displayName.includes('/')) {
+    return displayName
+  }
+  return stripPiPrefixForDisplay(getModelShortName(modelId))
+}
+
 interface ProcessingIndicatorProps {
   /** Start timestamp (persists across remounts) */
   startTime?: number
@@ -438,6 +452,67 @@ function ProcessingIndicator({ startTime, statusMessage }: ProcessingIndicatorPr
           </span>
         )}
       </span>
+    </div>
+  )
+}
+
+function getResponseRuntimeLabel(response?: AssistantTurn['response']): string | null {
+  if (!response?.responseModel) return null
+  const modelLabel = formatResponseModelLabel(response.responseModel)
+  return response.responseConnectionName
+    ? `${response.responseConnectionName} · ${modelLabel}`
+    : modelLabel
+}
+
+function ResponseRuntimeBadge({
+  response,
+  connection,
+  className,
+}: {
+  response: NonNullable<AssistantTurn['response']>
+  connection?: Pick<LlmConnectionWithStatus, 'name' | 'providerType' | 'baseUrl' | 'piAuthProvider'> & { type?: string; defaultModel?: string } | null
+  className?: string
+}) {
+  const modelLabel = response.responseModel ? formatResponseModelLabel(response.responseModel) : null
+  if (!modelLabel) return null
+
+  const title = response.responseConnectionName
+    ? `${response.responseConnectionName} · ${response.responseModel}`
+    : response.responseModel
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-background/85 px-2.5 py-1 text-[11px] leading-none normal-case tracking-normal text-foreground/80 shadow-minimal",
+        className,
+      )}
+      title={title}
+      aria-label={`Response model ${title}`}
+    >
+      {connection && <ConnectionIcon connection={connection} size={12} />}
+      <span className="max-w-[240px] truncate">{modelLabel}</span>
+    </div>
+  )
+}
+
+function ModelChangeDivider({
+  response,
+  connection,
+}: {
+  response: NonNullable<AssistantTurn['response']>
+  connection?: Pick<LlmConnectionWithStatus, 'name' | 'providerType' | 'baseUrl' | 'piAuthProvider'> & { type?: string; defaultModel?: string } | null
+}) {
+  const label = getResponseRuntimeLabel(response)
+  if (!label) return null
+
+  return (
+    <div className="flex items-center gap-3 px-1 py-2 text-[11px] uppercase tracking-[0.16em] text-muted-foreground/75 select-none">
+      <div className="h-px flex-1 bg-border/60" />
+      <div className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/80 px-2 py-1 shadow-minimal">
+        <span className="font-medium normal-case tracking-normal text-[11px] text-foreground/80">Model changed</span>
+        <ResponseRuntimeBadge response={response} connection={connection} className="border-0 bg-transparent px-0 py-0 shadow-none" />
+      </div>
+      <div className="h-px flex-1 bg-border/60" />
     </div>
   )
 }
@@ -1804,9 +1879,22 @@ export const ChatDisplay = React.forwardRef<ChatDisplayHandle, ChatDisplayProps>
 
                     // Assistant turns - render with TurnCard (buffered streaming)
                     const assistantUiKey = getAssistantTurnUiKey(turn, index)
+                    const previousAssistantTurn = [...turns.slice(0, index)].reverse().find((candidate): candidate is AssistantTurn => candidate.type === 'assistant')
+                    const currentRuntimeLabel = getResponseRuntimeLabel(turn.response)
+                    const previousRuntimeLabel = previousAssistantTurn ? getResponseRuntimeLabel(previousAssistantTurn.response) : null
+                    const currentResponseConnection = turn.response?.responseConnectionSlug
+                      ? appShellContext.llmConnections.find((connection) => connection.slug === turn.response?.responseConnectionSlug) ?? null
+                      : null
+                    const showModelChangeDivider = !!currentRuntimeLabel && (
+                      !!turn.response?.responseRuntimeChanged
+                      || (!!previousRuntimeLabel && currentRuntimeLabel !== previousRuntimeLabel)
+                    )
                     return (
+                      <React.Fragment key={turnKey}>
+                      {showModelChangeDivider && turn.response && (
+                        <ModelChangeDivider response={turn.response} connection={currentResponseConnection} />
+                      )}
                       <div
-                        key={turnKey}
                         ref={el => { if (el) turnRefs.current.set(turnKey, el); else turnRefs.current.delete(turnKey) }}
                         className={cn(
                           "pt-2",
@@ -1909,6 +1997,12 @@ export const ChatDisplay = React.forwardRef<ChatDisplayHandle, ChatDisplayProps>
                           }
                         }}
                         onSaveAndSendFollowUp={handleSaveAndSendFollowUp}
+                        renderResponseMeta={(response) => {
+                          const responseConnection = response.responseConnectionSlug
+                            ? appShellContext.llmConnections.find((connection) => connection.slug === response.responseConnectionSlug) ?? null
+                            : null
+                          return <ResponseRuntimeBadge response={response} connection={responseConnection} />
+                        }}
                         onAcceptPlan={() => {
                           const planMessage = session?.messages.findLast(m => m.role === 'plan')
                           const planPath = planMessage?.planPath
@@ -1995,6 +2089,7 @@ export const ChatDisplay = React.forwardRef<ChatDisplayHandle, ChatDisplayProps>
                         }}
                       />
                       </div>
+                      </React.Fragment>
                     )
                   })}
                     </motion.div>

--- a/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
+++ b/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
@@ -65,6 +65,8 @@ import { SourceAvatar } from '@/components/ui/source-avatar'
 import { SourceSelectorPopover } from '@/components/ui/SourceSelectorPopover'
 import { ConnectionIcon } from '@/components/icons/ConnectionIcon'
 import { FreeFormInputContextBadge } from './FreeFormInputContextBadge'
+import { groupConnectionsByProvider } from './llm-provider-groups'
+import { getCurrentModelDisplayName } from './llm-model-display'
 import type { FileAttachment, LoadedSource, LoadedSkill } from '../../../../shared/types'
 import type { PermissionMode } from '@craft-agent/shared/agent/modes'
 import { type ThinkingLevel, THINKING_LEVELS, getThinkingLevelName } from '@craft-agent/shared/agent/thinking-levels'
@@ -230,9 +232,9 @@ export interface FreeFormInputProps {
   /** Enable compact mode - hides attach, sources, working directory for popover embedding */
   compactMode?: boolean
   // Connection selection (hierarchical connection → model selector)
-  /** Current LLM connection slug (locked after first message) */
+  /** Current LLM connection slug */
   currentConnection?: string
-  /** Callback when connection changes (only works when session is empty) */
+  /** Callback when connection changes (used by dedicated connection-only flows) */
   onConnectionChange?: (connectionSlug: string) => void
   /** When true, the session's locked connection has been removed */
   connectionUnavailable?: boolean
@@ -288,7 +290,7 @@ export function FreeFormInput({
   onFollowUpIndexClick,
   compactMode = false,
   currentConnection,
-  onConnectionChange,
+  onConnectionChange: _onConnectionChange,
   connectionUnavailable = false,
 }: FreeFormInputProps) {
   // Read connection default model, connections, and workspace info from context.
@@ -337,35 +339,13 @@ export function FreeFormInput({
 
   // Get display name for current model (full name, not short name)
   const currentModelDisplayName = React.useMemo(() => {
-    const modelToDisplay = connectionDefaultModel ?? currentModel
-    const model = availableModels.find(m =>
-      typeof m === 'string' ? m === modelToDisplay : m.id === modelToDisplay
-    )
-    if (!model) {
-      // Fallback: use helper function to format unknown model IDs nicely
-      return stripPiPrefixForDisplay(getModelDisplayName(modelToDisplay))
-    }
-    return typeof model === 'string' ? stripPiPrefixForDisplay(model) : model.name
+    return getCurrentModelDisplayName(availableModels, currentModel, connectionDefaultModel)
   }, [availableModels, currentModel, connectionDefaultModel])
 
   // Group connections by provider type for hierarchical dropdown
-  // Each provider (Anthropic, Pi) can have multiple connections (API Key, OAuth, etc.)
+  // Each provider (Anthropic, Pi, etc.) can have multiple connections (API Key, OAuth, etc.)
   const connectionsByProvider = React.useMemo(() => {
-    const groups: Record<string, typeof llmConnections> = {
-      'Anthropic': [],
-      'Craft Agents Backend': [],
-    }
-    for (const conn of llmConnections) {
-      const provider = conn.providerType || 'anthropic'
-      // Group by SDK: anthropic/anthropic_compat/bedrock/vertex use Anthropic SDK
-      if (provider === 'anthropic' || provider === 'anthropic_compat' || provider === 'bedrock' || provider === 'vertex') {
-        groups['Anthropic'].push(conn)
-      } else if (provider === 'pi' || provider === 'pi_compat') {
-        groups['Craft Agents Backend'].push(conn)
-      }
-    }
-    // Return only non-empty groups
-    return Object.entries(groups).filter(([, conns]) => conns.length > 0)
+    return groupConnectionsByProvider(llmConnections)
   }, [llmConnections])
 
   // Find current connection details for display
@@ -1800,8 +1780,8 @@ Model
                   </div>
                   <Check className="h-3 w-3 text-foreground shrink-0 ml-3" />
                 </StyledDropdownMenuItem>
-              ) : isEmptySession && llmConnections.length > 1 ? (
-                /* Hierarchical view: Provider → Connection → Models (for new sessions with multiple connections) */
+              ) : llmConnections.length > 1 ? (
+                /* Hierarchical view: Provider → Connection → Models */
                 connectionsByProvider.map(([providerName, connections], index) => (
                   <React.Fragment key={providerName}>
                     {/* Provider group label */}
@@ -1842,11 +1822,8 @@ Model
                                   <StyledDropdownMenuItem
                                     key={modelId}
                                     onSelect={() => {
-                                      // If selecting a different connection, update both connection and model
-                                      if (!isCurrentConnection && onConnectionChange) {
-                                        onConnectionChange(conn.slug)
-                                      }
-                                      // Always pass connection with model for proper persistence
+                                      // Pass the selected connection with the model so the backend can
+                                      // retarget the session in one update path.
                                       onModelChange(modelId, conn.slug)
                                     }}
                                     className="flex items-center justify-between px-2 py-2 rounded-lg cursor-pointer"

--- a/apps/electron/src/renderer/components/app-shell/input/__tests__/connection-provider-grouping.test.ts
+++ b/apps/electron/src/renderer/components/app-shell/input/__tests__/connection-provider-grouping.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'bun:test'
+
+import { getConnectionProviderGroupName, groupConnectionsByProvider } from '../llm-provider-groups'
+
+type TestConnection = {
+  providerType?: string
+  type?: string
+  baseUrl?: string
+}
+
+describe('FreeFormInput connection provider grouping', () => {
+  it('maps known providers to stable group labels', () => {
+    expect(getConnectionProviderGroupName({ providerType: 'anthropic' })).toBe('Anthropic')
+    expect(getConnectionProviderGroupName({ providerType: 'bedrock' })).toBe('Anthropic')
+    expect(getConnectionProviderGroupName({ providerType: 'pi' })).toBe('Craft Agents Backend')
+    expect(getConnectionProviderGroupName({ providerType: 'openai' })).toBe('OpenAI')
+    expect(getConnectionProviderGroupName({ providerType: 'openai_compat' })).toBe('OpenAI')
+  })
+
+  it('uses legacy type when providerType is missing', () => {
+    expect(getConnectionProviderGroupName({ type: 'openai' } as TestConnection)).toBe('OpenAI')
+  })
+
+  it('detects provider from compatible base URL when needed', () => {
+    expect(getConnectionProviderGroupName({
+      providerType: 'custom',
+      baseUrl: 'https://openrouter.ai/api/v1',
+    })).toBe('OpenRouter')
+
+    expect(getConnectionProviderGroupName({
+      providerType: 'custom',
+      baseUrl: 'http://localhost:11434/v1',
+    })).toBe('Custom')
+  })
+
+  it('keeps unknown provider names as title-cased labels', () => {
+    expect(getConnectionProviderGroupName({ providerType: 'super_llm_service' })).toBe('Super Llm Service')
+  })
+
+  it('groups connections by provider label while preserving connection order', () => {
+    const connections: TestConnection[] = [
+      { providerType: 'pi', },
+      { providerType: 'openai', },
+      { type: 'openai' } as TestConnection,
+      {
+        providerType: 'custom',
+        baseUrl: 'https://openrouter.ai/api/v1',
+      },
+      {
+        providerType: 'minimax',
+        baseUrl: 'https://api.minimax.io/v1',
+      },
+    ]
+
+    const groups = groupConnectionsByProvider(connections)
+
+    expect(groups).toHaveLength(4)
+    expect(groups[0]?.[0]).toBe('Craft Agents Backend')
+    expect(groups[1]?.[0]).toBe('OpenAI')
+    expect(groups[2]?.[0]).toBe('OpenRouter')
+    expect(groups[3]?.[0]).toBe('Minimax')
+
+    expect(groups[1]?.[1]).toHaveLength(2)
+    expect(groups[1]?.[1]?.[0]).toMatchObject({ providerType: 'openai' })
+    expect(groups[1]?.[1]?.[1]).toMatchObject({ type: 'openai' })
+  })
+})

--- a/apps/electron/src/renderer/components/app-shell/input/__tests__/llm-model-display.test.ts
+++ b/apps/electron/src/renderer/components/app-shell/input/__tests__/llm-model-display.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'bun:test'
+
+import { getCurrentModelDisplayName } from '../llm-model-display'
+
+describe('getCurrentModelDisplayName', () => {
+  it('formats provider-prefixed string models like the selector menu', () => {
+    expect(getCurrentModelDisplayName(['openai/gpt-5'], 'openai/gpt-5')).toBe('gpt-5')
+    expect(getCurrentModelDisplayName(['pi/qwen3-coder'], 'pi/qwen3-coder')).toBe('qwen3-coder')
+  })
+
+  it('prefers typed model definitions when available', () => {
+    expect(getCurrentModelDisplayName([
+      {
+        id: 'gpt-4.1',
+        name: 'GPT-4.1',
+        shortName: 'GPT-4.1',
+        description: 'Test model',
+        provider: 'pi',
+        contextWindow: 128000,
+      },
+    ], 'gpt-4.1')).toBe('GPT-4.1')
+  })
+
+  it('falls back to the connection default model when one is pinned', () => {
+    expect(getCurrentModelDisplayName(['openai/gpt-5'], 'ignored-model', 'openai/gpt-5')).toBe('gpt-5')
+  })
+})

--- a/apps/electron/src/renderer/components/app-shell/input/llm-model-display.ts
+++ b/apps/electron/src/renderer/components/app-shell/input/llm-model-display.ts
@@ -1,0 +1,24 @@
+import { getModelDisplayName, getModelShortName, type ModelDefinition } from '@config/models'
+
+function stripPiPrefixForDisplay(value: string): string {
+  return value.startsWith('pi/') ? value.slice(3) : value
+}
+
+export function getCurrentModelDisplayName(
+  availableModels: Array<ModelDefinition | string>,
+  currentModel: string,
+  connectionDefaultModel?: string | null,
+): string {
+  const modelToDisplay = connectionDefaultModel ?? currentModel
+  const model = availableModels.find((candidate) =>
+    typeof candidate === 'string' ? candidate === modelToDisplay : candidate.id === modelToDisplay,
+  )
+
+  if (!model) {
+    return stripPiPrefixForDisplay(getModelDisplayName(modelToDisplay))
+  }
+
+  return typeof model === 'string'
+    ? stripPiPrefixForDisplay(getModelShortName(model))
+    : model.name
+}

--- a/apps/electron/src/renderer/components/app-shell/input/llm-provider-groups.ts
+++ b/apps/electron/src/renderer/components/app-shell/input/llm-provider-groups.ts
@@ -1,0 +1,71 @@
+import { getProviderDisplayName } from '@/lib/provider-icons'
+
+export type ProviderAwareConnection = {
+  providerType?: string
+  type?: string
+  baseUrl?: string | null
+}
+
+const KNOWN_PROVIDER_LABELS: Record<string, string> = {
+  anthropic: 'Anthropic',
+  anthropic_compat: 'Anthropic',
+  bedrock: 'Anthropic',
+  vertex: 'Anthropic',
+  pi: 'Craft Agents Backend',
+  pi_compat: 'Craft Agents Backend',
+  openai: 'OpenAI',
+  openai_compat: 'OpenAI',
+}
+
+function toTitleCase(value: string): string {
+  return value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ')
+}
+
+/**
+ * Resolve a connection's provider label for the model selector grouping.
+ *
+ * - Supports known canonical providers with fixed grouping labels.
+ * - Uses getProviderDisplayName() for migrated/compat provider types.
+ * - Falls back to title-cased provider identifier.
+ */
+export function getConnectionProviderGroupName(connection: ProviderAwareConnection): string {
+  const providerType = (connection.providerType || connection.type || '').toLowerCase()
+  if (!providerType) {
+    return 'Other'
+  }
+
+  const explicitLabel = KNOWN_PROVIDER_LABELS[providerType]
+  if (explicitLabel) {
+    return explicitLabel
+  }
+
+  const detectedLabel = getProviderDisplayName(providerType, connection.baseUrl)
+  if (detectedLabel !== providerType) {
+    return detectedLabel
+  }
+
+  return toTitleCase(providerType)
+}
+
+/**
+ * Group LLM connections by provider label while preserving first-seen order.
+ */
+export function groupConnectionsByProvider<T extends ProviderAwareConnection>(connections: readonly T[]): Array<[string, T[]]> {
+  const grouped = new Map<string, T[]>()
+
+  for (const conn of connections) {
+    const providerLabel = getConnectionProviderGroupName(conn)
+    const bucket = grouped.get(providerLabel)
+    if (bucket) {
+      bucket.push(conn)
+    } else {
+      grouped.set(providerLabel, [conn])
+    }
+  }
+
+  return Array.from(grouped.entries())
+}

--- a/apps/electron/src/renderer/event-processor/handlers/text.ts
+++ b/apps/electron/src/renderer/event-processor/handlers/text.ts
@@ -115,6 +115,10 @@ export function handleTextComplete(
       // Overwrite text_delta's Date.now() with main process monotonic timestamp
       // This ensures reload order matches live order
       ...(event.timestamp ? { timestamp: event.timestamp } : {}),
+      ...(event.responseModel ? { responseModel: event.responseModel } : {}),
+      ...(event.responseConnectionName ? { responseConnectionName: event.responseConnectionName } : {}),
+      ...(event.responseConnectionSlug ? { responseConnectionSlug: event.responseConnectionSlug } : {}),
+      ...(event.responseRuntimeChanged !== undefined ? { responseRuntimeChanged: event.responseRuntimeChanged } : {}),
     }, shouldUpdateTimestamp)
     return { session: updatedSession, streaming: null }
   }
@@ -132,6 +136,10 @@ export function handleTextComplete(
     isIntermediate: event.isIntermediate,
     turnId: event.turnId,
     parentToolUseId: event.parentToolUseId,
+    ...(event.responseModel ? { responseModel: event.responseModel } : {}),
+    ...(event.responseConnectionName ? { responseConnectionName: event.responseConnectionName } : {}),
+    ...(event.responseConnectionSlug ? { responseConnectionSlug: event.responseConnectionSlug } : {}),
+    ...(event.responseRuntimeChanged !== undefined ? { responseRuntimeChanged: event.responseRuntimeChanged } : {}),
   }
 
   // Only update lastMessageAt for final (non-intermediate) messages

--- a/apps/electron/src/renderer/event-processor/types.ts
+++ b/apps/electron/src/renderer/event-processor/types.ts
@@ -48,6 +48,14 @@ export interface TextCompleteEvent {
   timestamp?: number
   /** Authoritative message ID from main process for persistence/branching parity */
   messageId?: string
+  /** Model that generated this response (captured at completion time) */
+  responseModel?: string
+  /** Human-readable connection/provider label for the generating backend */
+  responseConnectionName?: string
+  /** Resolved connection slug that produced this response */
+  responseConnectionSlug?: string
+  /** Marks the first assistant response after an explicit runtime switch */
+  responseRuntimeChanged?: boolean
 }
 
 /**

--- a/apps/electron/src/renderer/lib/provider-icons.ts
+++ b/apps/electron/src/renderer/lib/provider-icons.ts
@@ -180,7 +180,9 @@ export function getProviderIcon(
       return providerIcons.copilot
     case 'pi':
     case 'pi_compat': {
-      // Resolve to actual upstream provider icon
+      // Resolve to actual upstream provider icon.
+      // Prefer explicit Pi auth provider, then fall back to baseUrl detection for
+      // custom endpoint / migrated connections where piAuthProvider may be absent.
       if (piAuthProvider) {
         const iconKey = piAuthProviderToIcon(piAuthProvider)
         if (iconKey) return providerIcons[iconKey]
@@ -188,6 +190,12 @@ export function getProviderIcon(
         const domain = PI_AUTH_PROVIDER_DOMAINS[piAuthProvider]
         if (domain) {
           return `https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&size=128&url=https://${domain}`
+        }
+      }
+      if (baseUrl) {
+        const detectedProvider = detectProviderFromUrl(baseUrl)
+        if (detectedProvider) {
+          return providerIcons[detectedProvider]
         }
       }
       return null  // Unknown/custom Pi provider — caller shows brain icon

--- a/apps/electron/src/renderer/pages/ChatPage.tsx
+++ b/apps/electron/src/renderer/pages/ChatPage.tsx
@@ -187,7 +187,7 @@ const ChatPage = React.memo(function ChatPage({ sessionId }: ChatPageProps) {
     }
   }, [sessionId, activeWorkspaceId])
 
-  // Session connection change handler - can only change before first message
+  // Session connection change handler for explicit connection-only actions
   const handleConnectionChange = React.useCallback(async (connectionSlug: string) => {
     try {
       await window.electronAPI.sessionCommand(sessionId, { type: 'setConnection', connectionSlug })

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -322,6 +322,11 @@ export interface Message {
   authError?: string;             // Error message if auth failed
   authEmail?: string;             // Authenticated email (for OAuth)
   authWorkspace?: string;         // Authenticated workspace (for Slack)
+  // Assistant-response metadata (captured at generation time)
+  responseModel?: string;
+  responseConnectionName?: string;
+  responseConnectionSlug?: string;
+  responseRuntimeChanged?: boolean;
 }
 
 /**
@@ -394,6 +399,11 @@ export interface StoredMessage {
   authError?: string;
   authEmail?: string;
   authWorkspace?: string;
+  // Assistant-response metadata (persisted for turn chrome / auditing)
+  responseModel?: string;
+  responseConnectionName?: string;
+  responseConnectionSlug?: string;
+  responseRuntimeChanged?: boolean;
   // Queued: user message that is waiting to be processed (persisted for recovery)
   isQueued?: boolean;
 }

--- a/packages/server-core/src/sessions/SessionManager.ts
+++ b/packages/server-core/src/sessions/SessionManager.ts
@@ -855,6 +855,8 @@ interface ManagedSession {
   authRetryInProgress?: boolean
   // Whether this session is hidden from session list (e.g., mini edit sessions)
   hidden?: boolean
+  // Marks that the next final assistant response should show a runtime-change divider.
+  pendingResponseRuntimeChange?: boolean
   branchFromMessageId?: string
   // Branch context strategy:
   // - sdk-fork: provider-level fork from parent SDK session
@@ -955,6 +957,41 @@ export function createManagedSession(
  * Resolve supportsBranching for a managed session.
  * Prefers the live agent instance; falls back to true for all backends.
  */
+function getSessionSeedAnchorMessageId(messages: Message[]): string | undefined {
+  for (let idx = messages.length - 1; idx >= 0; idx--) {
+    const message = messages[idx]
+    if (!message) continue
+    if ((message.role === 'user' || message.role === 'assistant') && !message.isIntermediate) {
+      return message.id
+    }
+  }
+
+  return messages[messages.length - 1]?.id
+}
+
+function resolveResponseMessageMetadata(managed: ManagedSession): {
+  responseModel?: string
+  responseConnectionName?: string
+  responseConnectionSlug?: string
+} {
+  const wsConfig = loadWorkspaceConfig(managed.workspace.rootPath)
+  const resolvedConnection = resolveSessionConnection(
+    managed.llmConnection,
+    wsConfig?.defaults?.defaultLlmConnection,
+  )
+
+  const responseModel = managed.agent?.getModel()
+    ?? managed.model
+    ?? wsConfig?.defaults?.model
+    ?? resolvedConnection?.defaultModel
+
+  return {
+    responseModel,
+    responseConnectionName: resolvedConnection?.name,
+    responseConnectionSlug: resolvedConnection?.slug,
+  }
+}
+
 function resolveSupportsBranching(managed: ManagedSession): boolean {
   // If agent is live, use its instance property (authoritative)
   if (managed.agent) {
@@ -4160,35 +4197,104 @@ export class SessionManager implements ISessionManager {
   async updateSessionModel(sessionId: string, workspaceId: string, model: string | null, connection?: string): Promise<void> {
     sessionLog.info(`[updateSessionModel] sessionId=${sessionId}, model=${model}, connection=${connection}`)
     const managed = this.sessions.get(sessionId)
-    if (managed) {
-      managed.model = model ?? undefined
-      // Also update connection if provided and not already locked
-      if (connection && !managed.connectionLocked) {
-        managed.llmConnection = connection
+    if (!managed) {
+      return
+    }
+
+    const previousConnectionSlug = managed.llmConnection
+    const previousModel = managed.model
+    const requestedConnection = connection
+
+    let connectionSlug = managed.llmConnection
+    let connectionUpdated = false
+
+    if (requestedConnection) {
+      const existingConnection = getLlmConnection(requestedConnection)
+      if (!existingConnection) {
+        sessionLog.warn(`updateSessionModel: connection "${requestedConnection}" not found for session ${sessionId}`)
+      } else {
+        if (managed.llmConnection !== requestedConnection) {
+          if (managed.isProcessing) {
+            throw new Error('Cannot switch provider while session is processing')
+          }
+          managed.llmConnection = requestedConnection
+          connectionUpdated = true
+        }
+        connectionSlug = requestedConnection
       }
-      // Persist to disk (include connection if it was updated)
+    }
+
+    managed.model = model ?? undefined
+
+    const modelUpdated = previousModel !== managed.model
+    const hasConversationHistory = managed.messages.length > 0
+    if ((connectionUpdated || modelUpdated) && hasConversationHistory) {
+      managed.pendingResponseRuntimeChange = true
+    }
+
+    if (connectionUpdated) {
+      // Switching providers/connections mid-session must resume as a fresh backend
+      // seeded from the persisted conversation, not by trying to reuse the previous
+      // provider's SDK session/fork metadata.
+      if (managed.agent) {
+        sessionLog.info(`[updateSessionModel] Recreating live agent for session ${sessionId} after connection change ${previousConnectionSlug ?? '(default)'} -> ${connectionSlug ?? '(default)'}`)
+        managed.agent.dispose()
+        managed.agent = null
+        managed.agentReady = undefined
+        managed.agentReadyResolve = undefined
+      }
+
+      managed.sdkSessionId = undefined
+      const seedAnchorMessageId = getSessionSeedAnchorMessageId(managed.messages)
+      if (seedAnchorMessageId && !managed.branchFromMessageId) {
+        managed.branchFromMessageId = seedAnchorMessageId
+      }
+      managed.branchContextStrategy = 'seeded-fresh-session'
+      managed.branchSeedApplied = false
+      managed.branchFromSdkSessionId = undefined
+      managed.branchFromSessionPath = undefined
+      managed.branchFromSdkCwd = undefined
+      managed.branchFromSdkTurnId = undefined
+    }
+
+    if (managed.messagesLoaded) {
+      this.persistSession(managed)
+      await this.flushSession(managed.id)
+    } else {
       const updates: { model?: string; llmConnection?: string } = { model: model ?? undefined }
-      if (connection && !managed.connectionLocked) {
-        updates.llmConnection = connection
+      if (connectionUpdated && requestedConnection) {
+        updates.llmConnection = requestedConnection
       }
       await updateSessionMetadata(managed.workspace.rootPath, sessionId, updates)
-      // Update agent model if it already exists (takes effect on next query)
-      if (managed.agent) {
-        // Fallback chain: session model > workspace default > connection default
-        const wsConfig = loadWorkspaceConfig(managed.workspace.rootPath)
-        const sessionConn = resolveSessionConnection(managed.llmConnection, wsConfig?.defaults?.defaultLlmConnection)
-        const effectiveModel = model ?? wsConfig?.defaults?.model ?? sessionConn?.defaultModel!
-        sessionLog.info(`[updateSessionModel] Calling agent.setModel(${effectiveModel}) [agent exists=${!!managed.agent}, connectionLocked=${managed.connectionLocked}]`)
-        managed.agent.setModel(effectiveModel)
-      } else {
-        sessionLog.info(`[updateSessionModel] No agent yet, model will apply on next agent creation`)
-      }
-      // Notify renderer of the model change
-      this.sendEvent({ type: 'session_model_changed', sessionId, model }, managed.workspace.id)
-      sessionLog.info(`Session ${sessionId} model updated to: ${model ?? '(global config)'}`)
     }
-  }
 
+    // Update agent model immediately when the live backend stays on the same connection.
+    if (managed.agent) {
+      // Fallback chain: session model > workspace default > connection default
+      const wsConfig = loadWorkspaceConfig(managed.workspace.rootPath)
+      const sessionConn = resolveSessionConnection(connectionSlug, wsConfig?.defaults?.defaultLlmConnection)
+      const effectiveModel = model ?? wsConfig?.defaults?.model ?? sessionConn?.defaultModel
+      sessionLog.info(`[updateSessionModel] Calling agent.setModel(${effectiveModel}) [agent exists=${!!managed.agent}, connectionLocked=${managed.connectionLocked}]`)
+      if (effectiveModel) {
+        managed.agent.setModel(effectiveModel)
+      }
+    } else {
+      sessionLog.info(`[updateSessionModel] No live agent, updated model/connection will apply on next agent creation`)
+    }
+
+    // Notify renderer of any explicit connection change first, then model change.
+    if (connectionUpdated && requestedConnection) {
+      this.sendEvent({
+        type: 'connection_changed',
+        sessionId,
+        connectionSlug: requestedConnection,
+        supportsBranching: resolveSupportsBranching(managed),
+      }, managed.workspace.id)
+    }
+
+    this.sendEvent({ type: 'session_model_changed', sessionId, model }, managed.workspace.id)
+    sessionLog.info(`Session ${sessionId} model updated to: ${model ?? '(global config)'}`)
+  }
   /**
    * Update the content of a specific message in a session
    * Used by preview window to save edited content back to the original message
@@ -5765,6 +5871,8 @@ export class SessionManager implements ISessionManager {
         // Flush any pending deltas before sending complete (ensures renderer has all content)
         this.flushDelta(sessionId, workspaceId)
 
+        const responseMetadata = resolveResponseMessageMetadata(managed)
+        const responseRuntimeChanged = !event.isIntermediate && !!managed.pendingResponseRuntimeChange
         const assistantMessage: Message = {
           id: generateMessageId(),
           role: 'assistant',
@@ -5773,12 +5881,15 @@ export class SessionManager implements ISessionManager {
           isIntermediate: event.isIntermediate,
           turnId: event.turnId,
           parentToolUseId: event.parentToolUseId,
+          responseRuntimeChanged,
+          ...responseMetadata,
         }
         managed.messages.push(assistantMessage)
         managed.streamingText = ''
 
         // Update lastMessageRole and lastFinalMessageId for badge/unread display (only for final messages)
         if (!event.isIntermediate) {
+          managed.pendingResponseRuntimeChange = false
           managed.lastMessageRole = 'assistant'
           managed.lastFinalMessageId = assistantMessage.id
 
@@ -5805,7 +5916,20 @@ export class SessionManager implements ISessionManager {
           }
         }
 
-        this.sendEvent({ type: 'text_complete', sessionId, text: event.text, isIntermediate: event.isIntermediate, turnId: event.turnId, parentToolUseId: event.parentToolUseId, timestamp: assistantMessage.timestamp, messageId: assistantMessage.id }, workspaceId)
+        this.sendEvent({
+          type: 'text_complete',
+          sessionId,
+          text: event.text,
+          isIntermediate: event.isIntermediate,
+          turnId: event.turnId,
+          parentToolUseId: event.parentToolUseId,
+          timestamp: assistantMessage.timestamp,
+          messageId: assistantMessage.id,
+          responseModel: assistantMessage.responseModel,
+          responseConnectionName: assistantMessage.responseConnectionName,
+          responseConnectionSlug: assistantMessage.responseConnectionSlug,
+          responseRuntimeChanged: assistantMessage.responseRuntimeChanged,
+        }, workspaceId)
 
         // Persist session after complete message to prevent data loss on quit
         this.persistSession(managed)

--- a/packages/server-core/src/sessions/SessionManager.updateSessionModel.test.ts
+++ b/packages/server-core/src/sessions/SessionManager.updateSessionModel.test.ts
@@ -1,0 +1,384 @@
+import { afterAll, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import type { LlmConnection } from '@craft-agent/shared/config/llm-connections'
+
+const tempConfigDir = mkdtempSync(path.join(tmpdir(), 'craft-agent-session-model-'))
+const originalConfigDir = process.env.CRAFT_CONFIG_DIR
+process.env.CRAFT_CONFIG_DIR = tempConfigDir
+
+const sharedConfig = await import('@craft-agent/shared/config')
+const serverCoreSessions = await import('./SessionManager.ts')
+
+const { saveConfig } = sharedConfig
+const { SessionManager, createManagedSession } = serverCoreSessions
+
+const workspace = {
+  id: 'ws-update-model-test',
+  name: 'Test Workspace',
+  rootPath: path.join(tempConfigDir, 'workspace'),
+  createdAt: Date.now(),
+}
+
+const connections: LlmConnection[] = [
+  {
+    slug: 'conn-anthropic',
+    name: 'Anthropic',
+    providerType: 'anthropic',
+    authType: 'environment',
+    models: ['claude-3-opus'],
+    createdAt: Date.now(),
+  },
+  {
+    slug: 'conn-pi-openai',
+    name: 'OpenAI via Pi',
+    providerType: 'pi',
+    authType: 'api_key',
+    piAuthProvider: 'openai',
+    models: ['gpt-4o'],
+    createdAt: Date.now() + 1,
+  },
+]
+
+const sessionId = 'session-update-model-test'
+
+function configureConfig(): void {
+  mkdirSync(workspace.rootPath, { recursive: true })
+  saveConfig({
+    workspaces: [workspace],
+    activeWorkspaceId: workspace.id,
+    activeSessionId: null,
+    llmConnections: [...connections],
+    defaultLlmConnection: connections[0].slug,
+  })
+}
+
+function buildManager() {
+  const manager = new SessionManager()
+  const events: Array<Record<string, any>> = []
+  manager.setEventSink((_channel, _target, event) => {
+    events.push(event as Record<string, any>)
+  })
+
+  const managed = createManagedSession({
+    id: sessionId,
+    llmConnection: connections[0].slug,
+    model: 'claude-3-opus',
+  }, workspace, {
+    messages: [],
+    messagesLoaded: true,
+  })
+
+  const sessions = (manager as unknown as { sessions: Map<string, typeof managed> }).sessions
+  sessions.set(sessionId, managed)
+
+  return { manager, managed, events, sessions }
+}
+
+function buildMockAgent() {
+  const setModelCalls: string[] = []
+  let disposeCalls = 0
+
+  return {
+    setModelCalls,
+    get disposeCalls() {
+      return disposeCalls
+    },
+    agent: {
+      setModel(model: string) {
+        setModelCalls.push(model)
+      },
+      dispose() {
+        disposeCalls += 1
+      },
+      supportsBranching: true,
+    },
+  }
+}
+
+beforeEach(() => {
+  configureConfig()
+})
+
+afterAll(() => {
+  process.env.CRAFT_CONFIG_DIR = originalConfigDir
+  rmSync(tempConfigDir, { recursive: true, force: true })
+})
+
+describe('SessionManager.updateSessionModel', () => {
+  it('updates both connection and model when requested connection is valid and unlocked', async () => {
+    const { manager, managed, events } = buildManager()
+
+    await manager.updateSessionModel(sessionId, workspace.id, 'gpt-4.1', connections[1].slug)
+
+    expect(managed.llmConnection).toBe(connections[1].slug)
+    expect(managed.model).toBe('gpt-4.1')
+    expect(events).toHaveLength(2)
+    expect(events[0]).toMatchObject({
+      type: 'connection_changed',
+      sessionId,
+      connectionSlug: connections[1].slug,
+      supportsBranching: true,
+    })
+    expect(events[1]).toMatchObject({
+      type: 'session_model_changed',
+      sessionId,
+      model: 'gpt-4.1',
+    })
+  })
+
+  it('keeps model update when requested connection is invalid', async () => {
+    const { manager, managed, events } = buildManager()
+
+    await manager.updateSessionModel(sessionId, workspace.id, 'model-fallback', 'missing-connection')
+
+    expect(managed.llmConnection).toBe(connections[0].slug)
+    expect(managed.model).toBe('model-fallback')
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      type: 'session_model_changed',
+      sessionId,
+      model: 'model-fallback',
+    })
+  })
+
+  it('switches connection even when the original session connection is locked', async () => {
+    const { manager, managed, events } = buildManager()
+    managed.connectionLocked = true
+
+    await manager.updateSessionModel(sessionId, workspace.id, 'model-locked', connections[1].slug)
+
+    expect(managed.llmConnection).toBe(connections[1].slug)
+    expect(managed.model).toBe('model-locked')
+    expect(events).toHaveLength(2)
+    expect(events[0]).toMatchObject({
+      type: 'connection_changed',
+      sessionId,
+      connectionSlug: connections[1].slug,
+      supportsBranching: true,
+    })
+    expect(events[1]).toMatchObject({
+      type: 'session_model_changed',
+      sessionId,
+      model: 'model-locked',
+    })
+  })
+
+  it('updates the live agent model in place when the connection does not change', async () => {
+    const { manager, managed, events } = buildManager()
+    const mockAgent = buildMockAgent()
+    managed.agent = mockAgent.agent as any
+    managed.messages = [{
+      id: 'message-1',
+      role: 'user',
+      content: 'hello',
+      timestamp: Date.now(),
+      isQueued: false,
+      isPending: false,
+      attachments: [],
+    }] as unknown as typeof managed.messages
+
+    await manager.updateSessionModel(sessionId, workspace.id, 'claude-3-5-sonnet', connections[0].slug)
+
+    expect(mockAgent.setModelCalls).toEqual(['claude-3-5-sonnet'])
+    expect(mockAgent.disposeCalls).toBe(0)
+    expect(managed.pendingResponseRuntimeChange).toBe(true)
+    expect(managed.agent).toBe(mockAgent.agent as any)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      type: 'session_model_changed',
+      sessionId,
+      model: 'claude-3-5-sonnet',
+    })
+  })
+
+  it('does not mark the first response as a runtime change before any conversation exists', async () => {
+    const { manager, managed, events } = buildManager()
+
+    await manager.updateSessionModel(sessionId, workspace.id, 'gpt-4.1', connections[1].slug)
+
+    expect(managed.llmConnection).toBe(connections[1].slug)
+    expect(managed.model).toBe('gpt-4.1')
+    expect(managed.pendingResponseRuntimeChange).toBeUndefined()
+    expect(events).toHaveLength(2)
+    expect(events[0]).toMatchObject({
+      type: 'connection_changed',
+      sessionId,
+      connectionSlug: connections[1].slug,
+      supportsBranching: true,
+    })
+    expect(events[1]).toMatchObject({
+      type: 'session_model_changed',
+      sessionId,
+      model: 'gpt-4.1',
+    })
+  })
+
+  it('recreates a live session backend when the connection changes', async () => {
+    const { manager, managed, events } = buildManager()
+    const mockAgent = buildMockAgent()
+    managed.agent = mockAgent.agent as any
+    managed.sdkSessionId = 'sdk-session-old'
+    managed.messages = [{
+      id: 'message-1',
+      role: 'user',
+      content: 'hello',
+      timestamp: Date.now(),
+      isQueued: false,
+      isPending: false,
+      attachments: [],
+    }] as unknown as typeof managed.messages
+
+    await manager.updateSessionModel(sessionId, workspace.id, 'gpt-4.1', connections[1].slug)
+
+    expect(mockAgent.disposeCalls).toBe(1)
+    expect(mockAgent.setModelCalls).toEqual([])
+    expect(managed.agent).toBeNull()
+    expect(managed.sdkSessionId).toBeUndefined()
+    expect(managed.llmConnection).toBe(connections[1].slug)
+    expect(managed.model).toBe('gpt-4.1')
+    expect(managed.branchContextStrategy as 'sdk-fork' | 'seeded-fresh-session' | undefined).toBe('seeded-fresh-session')
+    expect(managed.branchSeedApplied).toBe(false)
+    expect(managed.branchFromMessageId).toBe('message-1')
+    expect(managed.pendingResponseRuntimeChange).toBe(true)
+    expect(events).toHaveLength(2)
+    expect(events[0]).toMatchObject({
+      type: 'connection_changed',
+      sessionId,
+      connectionSlug: connections[1].slug,
+      supportsBranching: true,
+    })
+    expect(events[1]).toMatchObject({
+      type: 'session_model_changed',
+      sessionId,
+      model: 'gpt-4.1',
+    })
+  })
+
+  it('resets sdk lineage on connection change even without a live agent', async () => {
+    const { manager, managed, events } = buildManager()
+
+    managed.sdkSessionId = 'sdk-session-old'
+    managed.branchContextStrategy = 'sdk-fork'
+    managed.branchSeedApplied = true
+    managed.branchFromSdkSessionId = 'branch-sdk-old'
+    managed.branchFromSessionPath = '/tmp/source-session'
+    managed.branchFromSdkCwd = '/tmp/source-cwd'
+    managed.branchFromSdkTurnId = 'turn-old'
+    managed.messages = [{
+      id: 'message-1',
+      role: 'user',
+      content: 'hello',
+      timestamp: Date.now(),
+      isQueued: false,
+      isPending: false,
+      attachments: [],
+    }] as unknown as typeof managed.messages
+
+    await manager.updateSessionModel(sessionId, workspace.id, 'gpt-4.1', connections[1].slug)
+
+    expect(managed.agent).toBeNull()
+    expect(managed.sdkSessionId).toBeUndefined()
+    expect(String(managed.branchContextStrategy)).toBe('seeded-fresh-session')
+    expect(managed.branchSeedApplied).toBe(false)
+    expect(managed.branchFromMessageId).toBe('message-1')
+    expect(managed.branchFromSdkSessionId).toBeUndefined()
+    expect(managed.branchFromSessionPath).toBeUndefined()
+    expect(managed.branchFromSdkCwd).toBeUndefined()
+    expect(managed.branchFromSdkTurnId).toBeUndefined()
+    expect(events).toHaveLength(2)
+    expect(events[0]).toMatchObject({
+      type: 'connection_changed',
+      sessionId,
+      connectionSlug: connections[1].slug,
+      supportsBranching: true,
+    })
+    expect(events[1]).toMatchObject({
+      type: 'session_model_changed',
+      sessionId,
+      model: 'gpt-4.1',
+    })
+  })
+
+  it('does not emit a connection change event when connection is unchanged', async () => {
+    const { manager, managed, events } = buildManager()
+
+    await manager.updateSessionModel(sessionId, workspace.id, 'same-conn-model', connections[0].slug)
+
+    expect(managed.llmConnection).toBe(connections[0].slug)
+    expect(managed.model).toBe('same-conn-model')
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      type: 'session_model_changed',
+      sessionId,
+      model: 'same-conn-model',
+    })
+  })
+})
+
+describe('SessionManager.setSessionConnection', () => {
+  it('allows changing connection before first message', async () => {
+    const { manager, managed, events } = buildManager()
+
+    await manager.setSessionConnection(sessionId, connections[1].slug)
+
+    expect(managed.llmConnection).toBe(connections[1].slug)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      type: 'connection_changed',
+      sessionId,
+      connectionSlug: connections[1].slug,
+    })
+  })
+
+  it('allows updateSessionModel to switch connection when connectionLocked is false', async () => {
+    const { manager, managed, events } = buildManager()
+
+    managed.messages = [{
+      id: 'message-1',
+      role: 'user',
+      content: 'hello',
+      timestamp: Date.now(),
+      isQueued: false,
+      isPending: false,
+      attachments: [],
+    }] as unknown as typeof managed.messages
+
+    await manager.updateSessionModel(sessionId, workspace.id, 'model-mid-session', connections[1].slug)
+
+    expect(managed.llmConnection).toBe(connections[1].slug)
+    expect(managed.model).toBe('model-mid-session')
+    expect(events).toHaveLength(2)
+    expect(events[0]).toMatchObject({
+      type: 'connection_changed',
+      sessionId,
+      connectionSlug: connections[1].slug,
+      supportsBranching: true,
+    })
+    expect(events[1]).toMatchObject({
+      type: 'session_model_changed',
+      sessionId,
+      model: 'model-mid-session',
+    })
+  })
+
+  it('rejects connection change after first message is sent', async () => {
+    const { manager, managed, events } = buildManager()
+
+    managed.messages = [{
+      id: 'message-1',
+      role: 'user',
+      content: 'hello',
+      timestamp: Date.now(),
+      isQueued: false,
+      isPending: false,
+      attachments: [],
+    }] as unknown as typeof managed.messages
+
+    await expect(manager.setSessionConnection(sessionId, connections[1].slug)).rejects.toThrow('Cannot change connection after session has started')
+
+    expect(managed.llmConnection).toBe(connections[0].slug)
+    expect(events).toHaveLength(0)
+  })
+})

--- a/packages/shared/src/protocol/dto.ts
+++ b/packages/shared/src/protocol/dto.ts
@@ -146,7 +146,7 @@ export interface PermissionModeState {
 // turnId: Correlation ID from the API's message.id, groups all events in an assistant turn
 export type SessionEvent =
   | { type: 'text_delta'; sessionId: string; delta: string; turnId?: string }
-  | { type: 'text_complete'; sessionId: string; text: string; isIntermediate?: boolean; turnId?: string; parentToolUseId?: string; timestamp?: number; messageId?: string }
+  | { type: 'text_complete'; sessionId: string; text: string; isIntermediate?: boolean; turnId?: string; parentToolUseId?: string; timestamp?: number; messageId?: string; responseModel?: string; responseConnectionName?: string; responseConnectionSlug?: string; responseRuntimeChanged?: boolean }
   | { type: 'tool_start'; sessionId: string; toolName: string; toolUseId: string; toolInput: Record<string, unknown>; toolIntent?: string; toolDisplayName?: string; toolDisplayMeta?: ToolDisplayMeta; turnId?: string; parentToolUseId?: string; timestamp?: number }
   | { type: 'tool_result'; sessionId: string; toolUseId: string; toolName: string; result: string; turnId?: string; parentToolUseId?: string; isError?: boolean; timestamp?: number }
   | { type: 'error'; sessionId: string; error: string; timestamp?: number }

--- a/packages/ui/src/components/chat/TurnCard.tsx
+++ b/packages/ui/src/components/chat/TurnCard.tsx
@@ -244,6 +244,11 @@ export interface ActivityItem {
   messageId?: string
   /** Optional persisted annotations (used by plan activities) */
   annotations?: AnnotationV1[]
+  /** Response model metadata for plan activities */
+  responseModel?: string
+  responseConnectionName?: string
+  responseConnectionSlug?: string
+  responseRuntimeChanged?: boolean
   displayName?: string  // LLM-generated human-friendly tool name (for MCP tools)
   toolDisplayMeta?: ToolDisplayMeta  // Embedded metadata with base64 icon (for viewer compatibility)
   timestamp: number
@@ -270,6 +275,14 @@ export interface ResponseContent {
   messageId?: string
   /** Persisted annotations attached to the response message */
   annotations?: AnnotationV1[]
+  /** Model that generated this response */
+  responseModel?: string
+  /** Human-readable connection/provider label captured at response time */
+  responseConnectionName?: string
+  /** Resolved connection slug captured at response time */
+  responseConnectionSlug?: string
+  /** Marks the first assistant response after an explicit runtime switch */
+  responseRuntimeChanged?: boolean
 }
 
 // ============================================================================
@@ -360,6 +373,8 @@ export interface TurnCardProps {
   openAnnotationRequest?: OpenAnnotationRequest | null
   /** Annotation interaction mode (viewer uses tooltip-only to suppress the island) */
   annotationInteractionMode?: AnnotationInteractionMode
+  /** Optional custom runtime metadata renderer for response footer chrome */
+  renderResponseMeta?: (response: ResponseContent) => React.ReactNode
 }
 
 // ============================================================================
@@ -1391,6 +1406,12 @@ export interface ResponseCardProps {
   messageId?: string
   /** Persisted annotations for this response */
   annotations?: AnnotationV1[]
+  /** Model that generated this response */
+  responseModel?: string
+  /** Human-readable connection/provider label captured at response time */
+  responseConnectionName?: string
+  /** Resolved connection slug captured at response time */
+  responseConnectionSlug?: string
   /** Callback when user accepts the plan (plan variant only) */
   onAccept?: () => void
   /** Callback when user accepts the plan with compaction (compact first, then execute) */
@@ -1419,6 +1440,32 @@ export interface ResponseCardProps {
   openAnnotationRequest?: OpenAnnotationRequest | null
   /** Annotation interaction mode (viewer uses tooltip-only to suppress the island) */
   annotationInteractionMode?: AnnotationInteractionMode
+  /** Optional custom runtime metadata renderer for response footer chrome */
+  renderResponseMeta?: (response: ResponseContent) => React.ReactNode
+}
+
+interface ResponseModelBadgeProps {
+  responseModel: string
+  responseConnectionName?: string
+}
+
+function ResponseModelBadge({ responseModel, responseConnectionName }: ResponseModelBadgeProps) {
+  const label = responseConnectionName
+    ? `${responseConnectionName} · ${responseModel}`
+    : responseModel
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center rounded-full border border-border/50 bg-background/70 px-2 py-1",
+        "text-[11px] leading-none text-muted-foreground"
+      )}
+      title={label}
+      aria-label={`Response model: ${label}`}
+    >
+      <span className="max-w-[240px] truncate">{label}</span>
+    </div>
+  )
 }
 
 interface BranchDropdownProps {
@@ -1644,6 +1691,9 @@ export function ResponseCard({
   sessionId,
   messageId,
   annotations,
+  responseModel,
+  responseConnectionName,
+  responseConnectionSlug,
   onAccept,
   onAcceptWithCompact,
   isLastResponse = true,
@@ -1658,6 +1708,7 @@ export function ResponseCard({
   hasActiveFollowUpAnnotations = false,
   openAnnotationRequest,
   annotationInteractionMode = 'interactive',
+  renderResponseMeta,
 }: ResponseCardProps) {
   // Throttled content for display - updates every CONTENT_THROTTLE_MS during streaming
   const [displayedText, setDisplayedText] = useState(text)
@@ -2528,6 +2579,23 @@ export function ResponseCard({
                     />
                   </div>
                 )}
+                {renderResponseMeta ? renderResponseMeta({
+                  text,
+                  isStreaming,
+                  streamStartTime,
+                  isPlan,
+                  messageId,
+                  annotations,
+                  responseModel,
+                  responseConnectionName,
+                  responseConnectionSlug,
+                  responseRuntimeChanged: false,
+                }) : responseModel && (
+                  <ResponseModelBadge
+                    responseModel={responseModel}
+                    responseConnectionName={responseConnectionName}
+                  />
+                )}
                 {onBranch && <BranchDropdown onBranch={onBranch} />}
               </div>
             </div>
@@ -2732,6 +2800,7 @@ export const TurnCard = React.memo(function TurnCard({
   hasActiveFollowUpAnnotations = false,
   openAnnotationRequest,
   annotationInteractionMode = 'interactive',
+  renderResponseMeta,
 }: TurnCardProps) {
   // Derive the turn phase from props using the state machine.
   // This provides a single source of truth for lifecycle state,
@@ -3081,6 +3150,8 @@ export const TurnCard = React.memo(function TurnCard({
             variant="plan"
             messageId={planActivity.messageId}
             annotations={planActivity.annotations}
+            responseModel={planActivity.responseModel}
+            responseConnectionName={planActivity.responseConnectionName}
             onAddAnnotation={onAddAnnotation}
             onRemoveAnnotation={onRemoveAnnotation}
             onUpdateAnnotation={onUpdateAnnotation}
@@ -3090,6 +3161,7 @@ export const TurnCard = React.memo(function TurnCard({
             isLastResponse={isLastResponse && index === planActivities.length - 1}
             compactMode={compactMode}
             onBranch={onBranch ? (options?: { newPanel?: boolean }) => onBranch(planActivity.messageId ?? planActivity.id, options) : undefined}
+            renderResponseMeta={renderResponseMeta}
             sendMessageKey={sendMessageKey}
             hasActiveFollowUpAnnotations={hasActiveFollowUpAnnotations}
             openAnnotationRequest={openAnnotationRequest}
@@ -3120,6 +3192,8 @@ export const TurnCard = React.memo(function TurnCard({
                 variant={response.isPlan ? 'plan' : 'response'}
                 messageId={response.messageId}
                 annotations={response.annotations}
+                responseModel={response.responseModel}
+                responseConnectionName={response.responseConnectionName}
                 onAddAnnotation={onAddAnnotation}
                 onRemoveAnnotation={onRemoveAnnotation}
                 onUpdateAnnotation={onUpdateAnnotation}
@@ -3129,6 +3203,7 @@ export const TurnCard = React.memo(function TurnCard({
                 isLastResponse={isLastResponse}
                 compactMode={compactMode}
                 onBranch={onBranch && response.messageId ? (options?: { newPanel?: boolean }) => onBranch(response.messageId!, options) : undefined}
+                renderResponseMeta={renderResponseMeta}
                 sendMessageKey={sendMessageKey}
                 hasActiveFollowUpAnnotations={hasActiveFollowUpAnnotations}
                 openAnnotationRequest={openAnnotationRequest}
@@ -3152,6 +3227,9 @@ export const TurnCard = React.memo(function TurnCard({
             variant={response.isPlan ? 'plan' : 'response'}
             messageId={response.messageId}
             annotations={response.annotations}
+            responseModel={response.responseModel}
+            responseConnectionName={response.responseConnectionName}
+            responseConnectionSlug={response.responseConnectionSlug}
             onAddAnnotation={onAddAnnotation}
             onRemoveAnnotation={onRemoveAnnotation}
             onUpdateAnnotation={onUpdateAnnotation}
@@ -3161,6 +3239,7 @@ export const TurnCard = React.memo(function TurnCard({
             isLastResponse={isLastResponse}
             compactMode={compactMode}
             onBranch={onBranch && response.messageId ? (options?: { newPanel?: boolean }) => onBranch(response.messageId!, options) : undefined}
+            renderResponseMeta={renderResponseMeta}
             sendMessageKey={sendMessageKey}
             hasActiveFollowUpAnnotations={hasActiveFollowUpAnnotations}
             openAnnotationRequest={openAnnotationRequest}

--- a/packages/ui/src/components/chat/__tests__/turn-utils-response-model.test.ts
+++ b/packages/ui/src/components/chat/__tests__/turn-utils-response-model.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test'
+import { groupMessagesByTurn } from '../turn-utils'
+import type { Message } from '@craft-agent/core'
+
+describe('groupMessagesByTurn response metadata', () => {
+  it('carries response model metadata onto assistant turns', () => {
+    const turns = groupMessagesByTurn([
+      {
+        id: 'user-1',
+        role: 'user',
+        content: 'hi',
+        timestamp: 1,
+      },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'hello',
+        timestamp: 2,
+        responseModel: 'pi/openai/gpt-5',
+        responseConnectionName: 'OpenAI',
+      },
+    ] as Message[])
+
+    const assistantTurn = turns.find((turn) => turn.type === 'assistant')
+    expect(assistantTurn?.type).toBe('assistant')
+    if (assistantTurn?.type !== 'assistant') throw new Error('assistant turn missing')
+    expect(assistantTurn.response?.responseModel).toBe('pi/openai/gpt-5')
+    expect(assistantTurn.response?.responseConnectionName).toBe('OpenAI')
+  })
+})

--- a/packages/ui/src/components/chat/turn-utils.ts
+++ b/packages/ui/src/components/chat/turn-utils.ts
@@ -519,6 +519,10 @@ export function groupMessagesByTurn(messages: Message[]): Turn[] {
         content: message.content,
         messageId: message.id,
         annotations: message.annotations,
+        responseModel: message.responseModel,
+        responseConnectionName: message.responseConnectionName,
+        responseConnectionSlug: message.responseConnectionSlug,
+        responseRuntimeChanged: message.responseRuntimeChanged,
         displayName: 'Plan',
         timestamp: message.timestamp,
       })
@@ -621,6 +625,10 @@ export function groupMessagesByTurn(messages: Message[]): Turn[] {
         streamStartTime: message.isStreaming ? message.timestamp : undefined,
         messageId: message.id,
         annotations: message.annotations,
+        responseModel: message.responseModel,
+        responseConnectionName: message.responseConnectionName,
+        responseConnectionSlug: message.responseConnectionSlug,
+        responseRuntimeChanged: message.responseRuntimeChanged,
       }
       currentTurn.isStreaming = !!message.isStreaming
       currentTurn.isComplete = !message.isStreaming


### PR DESCRIPTION
## Summary
Support mid-session provider/model changes and surface the runtime used for each response in chat.

## Changes
- allow provider/model switches mid-session through the model selector flow
- recreate the live backend when the connection changes so the next turn uses the selected provider
- reset SDK lineage on connection changes even when the session has no live agent loaded
- surface response runtime provenance in chat UI, including the normal non-animated response path
- add regression coverage for session model updates and runtime metadata propagation

## Testing
- `~/.bun/bin/bun test packages/server-core/src/sessions/SessionManager.updateSessionModel.test.ts`
- `cd packages/server-core && ~/.bun/bin/bun run tsc --noEmit`
- `cd packages/ui && ~/.bun/bin/bun run tsc --noEmit`

## Screenshots (if applicable)
- Not included

PS. Code mostly generated via GPT-5.4 with Codex, reviewed and tested by myself.
