### PR TITLE
fix: Amazon Bedrock Authentication and Model Issues

### DIFF
--- a/packages/server-core/src/handlers/rpc/llm-connections.ts
+++ b/packages/server-core/src/handlers/rpc/llm-connections.ts
@@ -1,5 +1,5 @@
 import { RPC_CHANNELS, type LlmConnectionSetup } from '@craft-agent/shared/protocol'
-import { getLlmConnections, getLlmConnection, addLlmConnection, updateLlmConnection, deleteLlmConnection, getDefaultLlmConnection, setDefaultLlmConnection, touchLlmConnection, isCompatProvider, isAnthropicProvider, getDefaultModelsForConnection, getDefaultModelForConnection, type LlmConnection, type LlmConnectionWithStatus } from '@craft-agent/shared/config'
+import { getLlmConnections, getLlmConnection, addLlmConnection, updateLlmConnection, deleteLlmConnection, getDefaultLlmConnection, setDefaultLlmConnection, touchLlmConnection, isCompatProvider, isAnthropicProvider, getDefaultModelsForConnection, getDefaultModelForConnection, type LlmConnection, type LlmConnectionWithStatus, normalizeBedrockModelId } from '@craft-agent/shared/config'
 import { getCredentialManager } from '@craft-agent/shared/credentials'
 import { setSetupDeferred } from '@craft-agent/shared/config/storage'
 import {
@@ -151,6 +151,15 @@ export function registerLlmConnectionsHandlers(server: RpcServer, deps: HandlerD
         }
         if (updates.defaultModel) {
           updates.defaultModel = toPiModelId(updates.defaultModel)
+        }
+      } else if (effectiveProviderType === 'bedrock') {
+        if (updates.models) {
+          updates.models = updates.models.map(m => typeof m === 'string'
+            ? normalizeBedrockModelId(m)
+            : { ...m, id: normalizeBedrockModelId(m.id) })
+        }
+        if (updates.defaultModel) {
+          updates.defaultModel = normalizeBedrockModelId(updates.defaultModel)
         }
       }
 

--- a/packages/server-core/src/sessions/SessionManager.ts
+++ b/packages/server-core/src/sessions/SessionManager.ts
@@ -18,7 +18,7 @@ import {
   type BackendHostRuntimeContext,
   type PostInitResult,
 } from '@craft-agent/shared/agent/backend'
-import { getLlmConnection, getDefaultLlmConnection, getDefaultThinkingLevel } from '@craft-agent/shared/config'
+import { getLlmConnection, getDefaultLlmConnection, getDefaultThinkingLevel, resetManagedAnthropicAuthEnvVars } from '@craft-agent/shared/config'
 import { PrivilegedExecutionBroker } from '@craft-agent/server-core/services'
 import { isValidWorkingDirectory } from '../utils/path-validation'
 import { InitGate } from '@craft-agent/server-core/domain'
@@ -1498,10 +1498,8 @@ export class SessionManager implements ISessionManager {
       }
       const connection = slug ? getLlmConnection(slug) : null
 
-      // Clear all auth env vars first to ensure clean state
-      delete process.env.ANTHROPIC_API_KEY
-      delete process.env.CLAUDE_CODE_OAUTH_TOKEN
-      delete process.env.ANTHROPIC_BASE_URL
+      // Restore managed auth env vars to their baseline before applying this connection.
+      resetManagedAnthropicAuthEnvVars()
 
       if (!connection) {
         sessionLog.error(`No LLM connection found for slug: ${slug}`)

--- a/packages/shared/src/agent/backend/internal/drivers/anthropic.ts
+++ b/packages/shared/src/agent/backend/internal/drivers/anthropic.ts
@@ -105,6 +105,38 @@ export const anthropicDriver: ProviderDriver = {
     const isAnthropicProvider =
       connection.providerType === 'anthropic' || connection.providerType === 'anthropic_compat';
 
+    if (connection.providerType === 'bedrock') {
+      if (connection.authType === 'iam_credentials') {
+        return { success: true };
+      }
+
+      if (connection.authType === 'bearer_token') {
+        const bearerToken = await credentialManager.getLlmApiKey(slug);
+        if (!bearerToken) {
+          return {
+            success: false,
+            error: 'Could not retrieve Bedrock bearer token',
+          };
+        }
+        return { success: true };
+      }
+
+      if (connection.authType === 'environment') {
+        const hasRegion =
+          !!connection.awsRegion ||
+          !!process.env.AWS_REGION ||
+          !!process.env.AWS_DEFAULT_REGION;
+        if (!hasRegion) {
+          return {
+            success: false,
+            error: 'AWS region is required for Bedrock environment auth.',
+          };
+        }
+
+        return { success: true };
+      }
+    }
+
     if (isAnthropicProvider && connection.authType === 'oauth') {
       const { getValidClaudeOAuthToken } = await import('../../../../auth/state.ts');
       const tokenResult = await getValidClaudeOAuthToken(slug);

--- a/packages/shared/src/agent/claude-agent.ts
+++ b/packages/shared/src/agent/claude-agent.ts
@@ -16,7 +16,7 @@ import { mapClaudeSdkAssistantError, type ClaudeSdkApiError } from './claude-sdk
 import { runErrorDiagnostics } from './diagnostics.ts';
 import { loadStoredConfig, loadConfigDefaults, type Workspace, type AuthType, getDefaultLlmConnection, getLlmConnection } from '../config/storage.ts';
 import { getValidClaudeOAuthToken } from '../auth/state.ts';
-import { resolveAuthEnvVars } from '../config/llm-connections.ts';
+import { resetManagedAnthropicAuthEnvVars, resolveAuthEnvVars } from '../config/llm-connections.ts';
 import type { McpClientPool } from '../mcp/mcp-pool.ts';
 import { loadPlanFromPath, type SessionConfig as Session } from '../sessions/storage.ts';
 import { DEFAULT_MODEL, isClaudeModel, getDefaultSummarizationModel, getModelContextWindow } from '../config/models.ts';
@@ -622,10 +622,8 @@ export class ClaudeAgent extends BaseAgent {
       return { authInjected: false, authWarning: `Connection not found: ${slug}`, authWarningLevel: 'error' };
     }
 
-    // Clear all auth env vars first for clean state
-    delete process.env.ANTHROPIC_API_KEY;
-    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
-    delete process.env.ANTHROPIC_BASE_URL;
+    // Restore process auth env vars to their pre-Craft baseline before applying this connection.
+    resetManagedAnthropicAuthEnvVars();
 
     // Resolve auth env vars via shared utility
     const manager = getCredentialManager();
@@ -833,7 +831,7 @@ export class ClaudeAgent extends BaseAgent {
       const mcpServers: Options['mcpServers'] = miniConfig.enabled
         ? this.filterMcpServersForMiniAgent(fullMcpServers, miniConfig.mcpServerKeys)
         : fullMcpServers;
-      
+
       // Configure SDK options
       // Model is always set by caller via connection config
       const model = this._model;

--- a/packages/shared/src/auth/state.ts
+++ b/packages/shared/src/auth/state.ts
@@ -23,6 +23,23 @@ import {
 import { refreshClaudeToken, isTokenExpired } from './claude-token.ts';
 import { debug } from '../utils/debug.ts';
 
+function toLegacyBillingType(
+  authType: NonNullable<ReturnType<typeof getLlmConnection>>['authType'],
+): AuthType {
+  switch (authType) {
+    case 'oauth':
+      return 'oauth_token'
+    case 'api_key':
+    case 'api_key_with_endpoint':
+    case 'bearer_token':
+    case 'iam_credentials':
+    case 'service_account_file':
+    case 'environment':
+    case 'none':
+      return 'api_key'
+  }
+}
+
 // ============================================
 // Types
 // ============================================
@@ -257,15 +274,9 @@ export async function getAuthState(): Promise<AuthState> {
   // Determine auth type from connection (no legacy fallback - migration ensures all users have connections)
   let effectiveAuthType: AuthType | null = null;
   if (connection) {
-    // Map connection authType to legacy AuthType format for backwards compatibility
-    // New auth types (api_key, api_key_with_endpoint, bearer_token) map to 'api_key'
-    // OAuth maps to 'oauth_token'
-    if (connection.authType === 'api_key' || connection.authType === 'api_key_with_endpoint' || connection.authType === 'bearer_token') {
-      effectiveAuthType = 'api_key';
-    } else if (connection.authType === 'oauth') {
-      effectiveAuthType = 'oauth_token';
-    }
-    // Other auth types (iam_credentials, service_account_file, environment, none) don't map to legacy types
+    // Onboarding still consumes a legacy billing bucket. Any configured default
+    // connection counts as billing-configured, including environment/IAM auth.
+    effectiveAuthType = toLegacyBillingType(connection.authType)
   }
   // No fallback to legacy config.authType - if no connection, return unauthenticated state
 

--- a/packages/shared/src/config/llm-connections.ts
+++ b/packages/shared/src/config/llm-connections.ts
@@ -261,7 +261,11 @@ function findSmallModel(connection: Pick<LlmConnection, 'models' | 'providerType
   const keywords: string[] = [];
 
   if (isAnthropicProvider(connection.providerType)) {
-    keywords.push('haiku');
+    if (connection.providerType === 'bedrock') {
+      keywords.push('global.anthropic.claude-haiku');
+    } else {
+      keywords.push('haiku');
+    }
   } else if (isPiProvider(connection.providerType)) {
     keywords.push('mini', 'flash');
   } else {
@@ -572,6 +576,18 @@ export function isValidProviderAuthCombination(
   return validCombinations[providerType]?.includes(authType) ?? false;
 }
 
+export function normalizeBedrockModelId(
+  modelId: string | undefined,
+): string {
+  if (!modelId) return '';
+
+  if (modelId.startsWith('pi/')) {
+    return modelId.slice(3)
+  }
+
+  return modelId
+}
+
 // ============================================================
 // Migration Helpers
 // ============================================================
@@ -633,6 +649,49 @@ export interface ResolvedAuthEnvVars {
   warning?: string;
 }
 
+const MANAGED_ANTHROPIC_AUTH_ENV_KEYS = [
+  'ANTHROPIC_API_KEY',
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'ANTHROPIC_BASE_URL',
+  'CLAUDE_CODE_USE_BEDROCK',
+  'AWS_BEARER_TOKEN_BEDROCK',
+  'ANTHROPIC_BEDROCK_BASE_URL',
+  'AWS_REGION',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+] as const
+
+function getRuntimeEnvValue(key: string): string | undefined {
+  if (typeof process === 'undefined' || !process?.env) {
+    return undefined
+  }
+  return process.env[key]
+}
+
+const MANAGED_ANTHROPIC_AUTH_ENV_BASELINE: Record<string, string | undefined> =
+  Object.fromEntries(
+    MANAGED_ANTHROPIC_AUTH_ENV_KEYS.map((key) => [
+      key,
+      getRuntimeEnvValue(key),
+    ]),
+  )
+
+export function resetManagedAnthropicAuthEnvVars(): void {
+  if (typeof process === 'undefined' || !process?.env) {
+    return
+  }
+
+  for (const key of MANAGED_ANTHROPIC_AUTH_ENV_KEYS) {
+    const originalValue = MANAGED_ANTHROPIC_AUTH_ENV_BASELINE[key]
+    if (originalValue === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = originalValue
+    }
+  }
+}
+
 /**
  * Resolve authentication environment variables for an LLM connection.
  *
@@ -662,6 +721,73 @@ export async function resolveAuthEnvVars(
   // OpenAI (Codex), Copilot, and Pi handle auth internally in their postInit()
   if (!isAnthropicProvider(connection.providerType)) {
     return { envVars, success: true };
+  }
+
+  if (connection.providerType === 'bedrock') {
+    envVars.CLAUDE_CODE_USE_BEDROCK = '1'
+
+    if (connection.baseUrl) {
+      envVars.ANTHROPIC_BEDROCK_BASE_URL = connection.baseUrl
+    }
+
+    const configuredRegion =
+      connection.awsRegion ||
+      getRuntimeEnvValue('AWS_REGION') ||
+      getRuntimeEnvValue('AWS_DEFAULT_REGION')
+    if (!configuredRegion) {
+      return {
+        envVars,
+        success: false,
+        warning: `No AWS region found for Bedrock connection: ${connectionSlug}`,
+      }
+    }
+
+    envVars.AWS_REGION = configuredRegion
+
+    if (connection.authType === 'bearer_token') {
+      const bearerToken = await credentialManager.getLlmApiKey(connectionSlug)
+      if (!bearerToken) {
+        return {
+          envVars,
+          success: false,
+          warning: `No Bedrock bearer token found for: ${connectionSlug}`,
+        }
+      }
+
+      envVars.AWS_BEARER_TOKEN_BEDROCK = bearerToken
+      return { envVars, success: true }
+    }
+
+    if (connection.authType === 'iam_credentials') {
+      const iamCredentials =
+        await credentialManager.getLlmIamCredentials(connectionSlug)
+      if (!iamCredentials?.accessKeyId || !iamCredentials.secretAccessKey) {
+        return {
+          envVars,
+          success: false,
+          warning: `No IAM credentials found for: ${connectionSlug}`,
+        }
+      }
+
+      envVars.AWS_ACCESS_KEY_ID = iamCredentials.accessKeyId
+      envVars.AWS_SECRET_ACCESS_KEY = iamCredentials.secretAccessKey
+      if (iamCredentials.sessionToken) {
+        envVars.AWS_SESSION_TOKEN = iamCredentials.sessionToken
+      }
+      envVars.AWS_REGION = iamCredentials.region || configuredRegion
+
+      return { envVars, success: true }
+    }
+
+    if (connection.authType === 'environment') {
+      return { envVars, success: true }
+    }
+
+    return {
+      envVars,
+      success: false,
+      warning: `Unsupported Bedrock auth type: ${connection.authType}`,
+    }
   }
 
   // Set base URL if configured

--- a/packages/shared/src/config/storage.ts
+++ b/packages/shared/src/config/storage.ts
@@ -40,7 +40,7 @@ import type { Workspace, AuthType } from '@craft-agent/core/types';
 
 // Import LLM connection types and constants
 import type { LlmConnection } from './llm-connections.ts';
-import { isValidProviderAuthCombination, getDefaultModelsForConnection, getDefaultModelForConnection, isPiProvider } from './llm-connections.ts';
+import { isValidProviderAuthCombination, getDefaultModelsForConnection, getDefaultModelForConnection, isPiProvider, normalizeBedrockModelId } from './llm-connections.ts';
 import {
   getModelProvider,
 } from './models.ts';
@@ -1402,6 +1402,28 @@ function backfillAllConnectionModels(config: StoredConfig): boolean {
     const defaultModels = getDefaultModelsForConnection(connection.providerType, connection.piAuthProvider);
     const defaultModel = getDefaultModelForConnection(connection.providerType, connection.piAuthProvider);
     const providerDefaultModelIds = normalizeModelIds(defaultModels as Array<{ id: string } | string>);
+
+    if (connection.providerType === 'bedrock') {
+      const currentIds = normalizeModelIds(connection.models)
+      const normalizedIds = currentIds.map((id) =>
+        normalizeBedrockModelId(id),
+      )
+
+      if (!modelSetEquals(currentIds, normalizedIds)) {
+        connection.models = [...new Set(normalizedIds)]
+        changed = true
+      }
+
+      if (connection.defaultModel) {
+        const normalizedDefaultModel = normalizeBedrockModelId(
+          connection.defaultModel,
+        )
+        if (normalizedDefaultModel !== connection.defaultModel) {
+          connection.defaultModel = normalizedDefaultModel
+          changed = true
+        }
+      }
+    }
 
     if (isPiProvider(connection.providerType) && connection.piAuthProvider) {
       // Copilot models are always server-managed (GitHub policy controls which


### PR DESCRIPTION
## Summary

This PR addresses critical authentication and model ID normalization issues for Amazon Bedrock LLM connections. The changes ensure proper credential handling across different auth types and consistent model ID formatting throughout the system.

## Changes

### Authentication Improvements
- Added comprehensive Bedrock authentication validation in the provider driver supporting three auth methods:
  - IAM credentials (access key + secret key)
  - Bearer token authentication
  - Environment variable-based authentication
- Implemented `resetManagedAnthropicAuthEnvVars()` utility to properly manage auth environment variables instead of directly deleting them, preserving pre-Craft baseline values
- Added Bedrock-specific environment variable resolution in `resolveAuthEnvVars()` with proper region and credential configuration

### Bedrock Model ID Normalization
- Created `normalizeBedrockModelId()` function to handle inconsistent Bedrock model IDs (e.g., stripping `pi/` prefixes)
- Applied model ID normalization across:
  - RPC handlers for connection updates
  - Connection storage during backfill/migration
  - Small model selection logic (e.g., `global.anthropic.claude-haiku` for Bedrock)

### Auth State Mapping
- Added `toLegacyBillingType()` helper to map new connection auth types to legacy billing categories
- Updated auth state determination to properly recognize all configured auth types (including IAM and environment auth) as billing-configured
- Fixed application startup hang during loading by ensuring auth state is correctly resolved for all connection types, preventing indefinite loading states when Bedrock connections are present

## Testing
- Verify Bedrock connections work with IAM credentials
- Verify Bedrock connections work with bearer token auth
- Verify Bedrock connections work with environment variables (AWS CLI)
- Confirm model IDs are properly normalized on connection setup and update
- Verify auth environment variables are restored to baseline values correctly
- Verify application loads successfully with Bedrock connections configured


## Related Issues
- #451
- #400 
