### PR TITLE
feat: Debugging configurations for VSCode based IDEs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach Electron Main",
+      "type": "node",
+      "request": "attach",
+      "port": 43229,
+      "restart": true,
+      "timeout": 30000,
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/apps/electron/dist/**/*.cjs"
+      ],
+      "preLaunchTask": "craft: electron dev (debug)"
+    },
+    {
+      "name": "Attach Electron Renderer",
+      "type": "chrome",
+      "request": "attach",
+      "port": 43222,
+      "webRoot": "${workspaceFolder}/apps/electron/src/renderer",
+      "timeout": 30000
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Electron Main + Renderer",
+      "configurations": [
+        "Attach Electron Main",
+        "Attach Electron Renderer"
+      ],
+      "stopAll": true
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,52 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "craft: electron dev (debug)",
+      "type": "shell",
+      "command": "bun",
+      "args": [
+        "run",
+        "electron:dev"
+      ],
+      "options": {
+        "env": {
+          "CRAFT_ELECTRON_INSPECT_PORT": "43229",
+          "CRAFT_ELECTRON_REMOTE_DEBUG_PORT": "43222"
+        }
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "custom",
+        "pattern": {
+          "regexp": "^(.*)$",
+          "message": 1
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "^.*$",
+          "endsPattern": "Debugger listening on ws://.*:43229/"
+        }
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "clear": false
+      }
+    },
+    {
+      "label": "validate electron dev debug",
+      "type": "shell",
+      "command": "bun",
+      "args": [
+        "run",
+        "electron:dev"
+      ],
+      "isBackground": true,
+      "problemMatcher": [
+        "$tsc"
+      ],
+      "group": "test"
+    }
+  ]
+}

--- a/scripts/electron-dev.ts
+++ b/scripts/electron-dev.ts
@@ -26,6 +26,23 @@ const BIN_EXT = IS_WINDOWS ? ".exe" : "";
 const VITE_BIN = join(ROOT_DIR, `node_modules/.bin/vite${BIN_EXT}`);
 const ELECTRON_BIN = join(ROOT_DIR, `node_modules/.bin/electron${BIN_EXT}`);
 
+function getElectronDebugArgs(): string[] {
+  const args: string[] = []
+  const inspectPort = process.env.CRAFT_ELECTRON_INSPECT_PORT?.trim()
+  const remoteDebuggingPort =
+    process.env.CRAFT_ELECTRON_REMOTE_DEBUG_PORT?.trim()
+
+  if (inspectPort) {
+    args.push(`--inspect=${inspectPort}`)
+  }
+
+  if (remoteDebuggingPort) {
+    args.push(`--remote-debugging-port=${remoteDebuggingPort}`)
+  }
+
+  return args
+}
+
 function resolveBuildPlatform(): Platform {
   if (process.platform === "darwin") return "darwin";
   if (process.platform === "win32") return "win32";
@@ -275,6 +292,7 @@ async function runEsbuild(
       bundle: true,
       platform: "node",
       format: "cjs",
+      sourcemap: 'linked',
       outfile: join(ROOT_DIR, outfile),
       external: ["electron"],
       ...(options.packagesExternal ? { packages: "external" as const } : {}),
@@ -381,6 +399,11 @@ async function main(): Promise<void> {
 
   const vitePort = process.env.CRAFT_VITE_PORT || "5173";
   const oauthDefines = getOAuthDefines();
+  const electronDebugArgs = getElectronDebugArgs()
+
+  if (electronDebugArgs.length > 0) {
+    console.log(`🐞 Electron debug flags: ${electronDebugArgs.join(' ')}`)
+  }
 
   // Kill any existing process on the Vite port
   await killProcessOnPort(vitePort);
@@ -494,6 +517,7 @@ async function main(): Promise<void> {
     bundle: true,
     platform: "node",
     format: "cjs",
+    sourcemap: 'linked',
     outfile: join(ROOT_DIR, "apps/electron/dist/main.cjs"),
     external: ["electron"],
     define: oauthDefines,
@@ -509,6 +533,7 @@ async function main(): Promise<void> {
     bundle: true,
     platform: "node",
     format: "cjs",
+    sourcemap: 'linked',
     outfile: join(ROOT_DIR, "apps/electron/dist/bootstrap-preload.cjs"),
     external: ["electron"],
     logLevel: "info",
@@ -523,6 +548,7 @@ async function main(): Promise<void> {
     bundle: true,
     platform: "node",
     format: "cjs",
+    sourcemap: 'linked',
     outfile: join(ROOT_DIR, "apps/electron/dist/browser-toolbar-preload.cjs"),
     external: ["electron"],
     logLevel: "info",
@@ -535,7 +561,7 @@ async function main(): Promise<void> {
   console.log("🚀 Starting Electron...\n");
 
   const electronProc = spawn({
-    cmd: [ELECTRON_BIN, "apps/electron"],
+    cmd: [ELECTRON_BIN, ...electronDebugArgs, "apps/electron"],
     cwd: ROOT_DIR,
     stdin: "ignore",
     stdout: "inherit",


### PR DESCRIPTION
## Summary
Add VSCode debugging configurations for Electron app.

## Changes
- Add `.vscode/launch.json` with debugger configurations for Electron Main (Node.js on port 43229) and Renderer (Chrome on port 43222), plus a compound configuration "Electron Main + Renderer" for simultaneous debugging
- Add `.vscode/tasks.json` with the "craft: electron dev (debug)" task that sets debug environment variables and handles the debugger startup
- Update `scripts/electron-dev.ts`:
  - Add `getElectronDebugArgs()` function to read debug ports from environment variables and generate corresponding Electron CLI flags
  - Enable source maps ('linked') for all esbuild configurations (main, bootstrap-preload, browser-toolbar-preload)
  - Pass debug arguments to Electron process spawn command
  - Add console feedback showing active debug flags

## Testing
1. Select "Electron Main + Renderer" from the debug configuration dropdown
2. Press F5 (or Run > Start Debugging)
3. Both debugger sessions attach automatically - breakpoints work in both main and renderer processes
4. Application runs with debug ports 43229 (main) and 43222 (renderer) active

## Screenshots
<img width="735" height="357" alt="craft-agents-oss" src="https://github.com/user-attachments/assets/b1a4e38d-5721-49f6-9ee2-13b798357f1d" />
