### PR TITLE
Fix Claude SDK support for Anthropic-compatible custom models

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
+++ b/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
@@ -56,7 +56,7 @@ import { isMac, PATH_SEP, getPathBasename } from '@/lib/platform'
 import { applySmartTypography } from '@/lib/smart-typography'
 import { AttachmentPreview } from '../AttachmentPreview'
 import { ANTHROPIC_MODELS, getModelShortName, getModelDisplayName, getModelContextWindow, type ModelDefinition } from '@config/models'
-import { resolveEffectiveConnectionSlug, isCompatProvider } from '@config/llm-connections'
+import { resolveEffectiveConnectionSlug, isCompatProvider, getConnectionModelContextWindow } from '@config/llm-connections'
 import { useOptionalAppShellContext } from '@/context/AppShellContext'
 import { EditPopover, getEditConfig } from '@/components/ui/EditPopover'
 import { SourceAvatar } from '@/components/ui/source-avatar'
@@ -1975,7 +1975,9 @@ Model
             // not the full context window - this gives users meaningful warnings before compaction kicks in.
             // SDK triggers compaction at ~155k tokens for a 200k context window.
             // Falls back to known per-model context window when SDK hasn't reported usage yet.
-            const effectiveContextWindow = contextStatus?.contextWindow || getModelContextWindow(currentModel)
+            const effectiveContextWindow = contextStatus?.contextWindow
+              || getConnectionModelContextWindow(effectiveConnectionDetails, currentModel)
+              || getModelContextWindow(currentModel)
             const compactionThreshold = effectiveContextWindow
               ? Math.round(effectiveContextWindow * 0.775)
               : null

--- a/packages/shared/src/agent/__tests__/claude-thinking-config.test.ts
+++ b/packages/shared/src/agent/__tests__/claude-thinking-config.test.ts
@@ -30,6 +30,20 @@ describe('resolveClaudeThinkingOptions', () => {
     })
   })
 
+  it('uses token budgets for non-Claude anthropic_compat models when the connection marks them as thinking-capable', () => {
+    const result = resolveClaudeThinkingOptions({
+      thinkingLevel: 'high',
+      model: 'glm-5.1',
+      providerType: 'anthropic_compat',
+      minimizeThinking: false,
+      supportsThinking: true,
+    })
+
+    expect(result).toEqual({
+      maxThinkingTokens: getThinkingTokens('high', 'glm-5.1'),
+    })
+  })
+
   it('uses token budgets for Haiku on true Anthropic backends', () => {
     const result = resolveClaudeThinkingOptions({
       thinkingLevel: 'high',
@@ -62,6 +76,20 @@ describe('resolveClaudeThinkingOptions', () => {
       model: 'claude-haiku-4-5-20251001',
       providerType: 'anthropic',
       minimizeThinking: false,
+    })
+
+    expect(result).toEqual({
+      maxThinkingTokens: 0,
+    })
+  })
+
+  it('respects explicit supportsThinking=false for anthropic_compat models', () => {
+    const result = resolveClaudeThinkingOptions({
+      thinkingLevel: 'high',
+      model: 'glm-5v-turbo',
+      providerType: 'anthropic_compat',
+      minimizeThinking: false,
+      supportsThinking: false,
     })
 
     expect(result).toEqual({

--- a/packages/shared/src/agent/backend/claude/event-adapter.ts
+++ b/packages/shared/src/agent/backend/claude/event-adapter.ts
@@ -224,6 +224,15 @@ export class ClaudeEventAdapter extends BaseEventAdapter {
     this.callbacks.sessionDir = sessionDir;
   }
 
+  /**
+   * Seed the adapter with a known context window before provider usage arrives.
+   * This is required for custom Anthropic-compatible models, which may not report
+   * modelUsage.contextWindow back through the Claude SDK result payload.
+   */
+  setContextWindow(contextWindow: number): void {
+    this.cachedContextWindow = contextWindow;
+  }
+
   // ============================================================
   // Per-message-type Handlers
   // ============================================================

--- a/packages/shared/src/agent/claude-agent.ts
+++ b/packages/shared/src/agent/claude-agent.ts
@@ -18,6 +18,8 @@ import { loadStoredConfig, loadConfigDefaults, type Workspace, type AuthType, ge
 import { getValidClaudeOAuthToken } from '../auth/state.ts';
 import {
   clearClaudeBedrockRoutingEnvVars,
+  getConnectionModelContextWindow,
+  getConnectionModelSupportsThinking,
   resolveAuthEnvVars,
 } from '../config/llm-connections.ts';
 import type { McpClientPool } from '../mcp/mcp-pool.ts';
@@ -130,14 +132,18 @@ export function resolveClaudeThinkingOptions(args: {
   model: string;
   providerType?: BackendConfig['providerType'];
   minimizeThinking: boolean;
+  supportsThinking?: boolean;
 }): Partial<Options> {
-  const { thinkingLevel, model, providerType, minimizeThinking } = args;
+  const { thinkingLevel, model, providerType, minimizeThinking, supportsThinking } = args;
   const isClaude = isClaudeModel(model);
   const effort = THINKING_TO_EFFORT[thinkingLevel];
   const isHaiku = model.toLowerCase().includes('haiku');
   const supportsAdaptiveThinking = isClaude && !isHaiku && providerType !== 'anthropic_compat';
+  const supportsTokenBudgetThinking = providerType === 'anthropic_compat'
+    ? supportsThinking !== false
+    : isClaude;
 
-  if (minimizeThinking || !isClaude || !effort) {
+  if (minimizeThinking || !supportsTokenBudgetThinking || !effort) {
     return supportsAdaptiveThinking
       ? { thinking: { type: 'disabled' as const } }
       : { maxThinkingTokens: 0 };
@@ -469,6 +475,8 @@ export class ClaudeAgent extends BaseAgent {
   private preferencesDriftNotified: boolean = false;
   // Captured stderr from SDK subprocess (for error diagnostics when process exits with code 1)
   private lastStderrOutput: string[] = [];
+  /** Resolved thinking capability for the selected model on this connection. */
+  private modelSupportsThinking: boolean | undefined;
   /** Pending steer message — injected via additionalContext on next PreToolUse */
   private pendingSteerMessage: string | null = null;
 
@@ -533,10 +541,13 @@ export class ClaudeAgent extends BaseAgent {
   constructor(config: ClaudeAgentConfig) {
     // Resolve model: prioritize session model > config model (caller must provide via connection)
     const model = config.session?.model ?? config.model!;
+    const connection = config.connectionSlug ? getLlmConnection(config.connectionSlug) : null;
 
     // Build BackendConfig for BaseAgent
-    // Context window from registry (1M for Opus/Sonnet 4.6, 200K for others)
-    const CLAUDE_CONTEXT_WINDOW = getModelContextWindow(model) ?? 200_000;
+    // Prefer connection-scoped metadata for custom Anthropic-compatible models,
+    // then fall back to the built-in Claude registry.
+    const CLAUDE_CONTEXT_WINDOW = getConnectionModelContextWindow(connection, model) ?? 200_000;
+    const supportsThinking = getConnectionModelSupportsThinking(connection, model);
     const backendConfig: BackendConfig = {
       provider: 'anthropic',
       workspace: config.workspace,
@@ -566,6 +577,7 @@ export class ClaudeAgent extends BaseAgent {
     // The inherited this.config is set by super() and compatible with ClaudeAgentConfig
     super(backendConfig, DEFAULT_MODEL, CLAUDE_CONTEXT_WINDOW);
 
+    this.modelSupportsThinking = supportsThinking;
     this.isHeadless = config.isHeadless ?? false;
     this.automationSystem = config.automationSystem;
 
@@ -574,6 +586,7 @@ export class ClaudeAgent extends BaseAgent {
       onDebug: (msg) => this.onDebug?.(msg),
       mapSDKError: (errorCode) => this.mapSDKErrorToTypedError(errorCode),
     });
+    this.eventAdapter.setContextWindow(CLAUDE_CONTEXT_WINDOW);
 
     // Log which model is being used (helpful for debugging custom models)
     this.debug(`Using model: ${model}`);
@@ -873,6 +886,7 @@ export class ClaudeAgent extends BaseAgent {
         model,
         providerType: this.config.providerType,
         minimizeThinking: miniConfig.minimizeThinking,
+        supportsThinking: this.modelSupportsThinking,
       });
       if ('effort' in thinkingOptions && thinkingOptions.effort) {
         debug(`[chat] Thinking: level=${this._thinkingLevel}, effort=${thinkingOptions.effort}`);
@@ -928,9 +942,9 @@ export class ClaudeAgent extends BaseAgent {
           }
         },
         // Thinking config is provider-aware:
-        // - true Anthropic backends use adaptive thinking + effort
+        // - true Anthropic Claude backends use adaptive thinking + effort
         // - anthropic_compat/custom endpoints fall back to token budgets
-        // - non-Claude models disable thinking entirely
+        // - custom compat models can opt out with supportsThinking: false
         ...thinkingOptions,
         // System prompt configuration:
         // - Mini agents: Use custom (lean) system prompt without Claude Code preset

--- a/packages/shared/src/config/__tests__/llm-connections.test.ts
+++ b/packages/shared/src/config/__tests__/llm-connections.test.ts
@@ -9,6 +9,9 @@ import {
   toBedrockNativeId,
   fromBedrockNativeId,
   normalizeBedrockModelId,
+  getModelDefinitionForConnection,
+  getConnectionModelContextWindow,
+  getConnectionModelSupportsThinking,
 } from '../llm-connections'
 import { ANTHROPIC_MODELS, getModelDisplayName, getModelContextWindow, getModelShortName, isClaudeModel } from '../models'
 
@@ -151,6 +154,43 @@ describe('isPiProvider', () => {
 
   it('returns false for anthropic', () => {
     expect(isPiProvider('anthropic')).toBe(false)
+  })
+})
+
+describe('connection-scoped model metadata', () => {
+  const compatConnection = {
+    models: [
+      {
+        id: 'glm-5.1',
+        name: 'GLM-5.1',
+        shortName: 'GLM-5.1',
+        description: 'Z.AI flagship coding model',
+        provider: 'anthropic' as const,
+        contextWindow: 204_800,
+        supportsThinking: true,
+      },
+    ],
+  }
+
+  it('prefers connection model definitions for custom compat models', () => {
+    expect(getModelDefinitionForConnection(compatConnection, 'glm-5.1')).toMatchObject({
+      id: 'glm-5.1',
+      contextWindow: 204_800,
+      supportsThinking: true,
+    })
+  })
+
+  it('resolves context window from connection models when registry has no entry', () => {
+    expect(getConnectionModelContextWindow(compatConnection, 'glm-5.1')).toBe(204_800)
+  })
+
+  it('resolves supportsThinking from connection models when registry has no entry', () => {
+    expect(getConnectionModelSupportsThinking(compatConnection, 'glm-5.1')).toBe(true)
+  })
+
+  it('falls back to registry metadata for built-in Claude models', () => {
+    expect(getConnectionModelContextWindow({ models: [] }, 'claude-opus-4-6')).toBe(1_000_000)
+    expect(getConnectionModelSupportsThinking({ models: [] }, 'claude-opus-4-6')).toBeUndefined()
   })
 })
 

--- a/packages/shared/src/config/llm-connections.ts
+++ b/packages/shared/src/config/llm-connections.ts
@@ -14,6 +14,7 @@
 import {
   type ModelDefinition,
   ANTHROPIC_MODELS,
+  getModelById,
 } from './models';
 import type { CredentialManager } from '../credentials/manager.ts';
 
@@ -498,6 +499,60 @@ export function getDefaultModelForConnection(providerType: LlmProviderType, piAu
   const first = models[0];
   if (!first) return '';  // Dynamic provider — no default
   return typeof first === 'string' ? first : first.id;
+}
+
+/**
+ * Resolve full model metadata for a model ID within the context of a connection.
+ *
+ * Why this exists:
+ * - Built-in Claude models live in MODEL_REGISTRY
+ * - Compat/custom endpoint models often exist only in connection.models
+ * - UI and backend logic (context window, thinking support) need a single lookup path
+ *   that prefers connection-specific metadata but still falls back to known registry data.
+ */
+export function getModelDefinitionForConnection(
+  connection: Pick<LlmConnection, 'models'> | null | undefined,
+  modelId: string,
+): ModelDefinition | undefined {
+  const connectionModel = connection?.models?.find(m => (typeof m === 'string' ? m : m.id) === modelId)
+
+  if (connectionModel && typeof connectionModel !== 'string') {
+    const registryModel = getModelById(modelId)
+    return {
+      ...(registryModel ?? {
+        id: connectionModel.id,
+        name: connectionModel.name || connectionModel.id,
+        shortName: connectionModel.shortName || connectionModel.name || connectionModel.id,
+        description: connectionModel.description || '',
+        provider: connectionModel.provider || 'anthropic',
+        contextWindow: connectionModel.contextWindow,
+      }),
+      ...connectionModel,
+    }
+  }
+
+  return getModelById(modelId)
+}
+
+/**
+ * Resolve context window using connection-specific metadata first, then global registry fallback.
+ */
+export function getConnectionModelContextWindow(
+  connection: Pick<LlmConnection, 'models'> | null | undefined,
+  modelId: string,
+): number | undefined {
+  return getModelDefinitionForConnection(connection, modelId)?.contextWindow
+}
+
+/**
+ * Resolve whether a model supports thinking/reasoning.
+ * Returns undefined when no explicit metadata is available.
+ */
+export function getConnectionModelSupportsThinking(
+  connection: Pick<LlmConnection, 'models'> | null | undefined,
+  modelId: string,
+): boolean | undefined {
+  return getModelDefinitionForConnection(connection, modelId)?.supportsThinking
 }
 
 /**


### PR DESCRIPTION
## Summary

Fix Claude SDK handling for Anthropic-compatible custom models that are not in the hardcoded Claude registry.

This makes custom Anthropic-compatible endpoints work much better for models like `glm-5.1`:
- seed context window from `connection.models[]` metadata instead of only the global Claude registry
- preserve a context window denominator even when the provider does not return `modelUsage.contextWindow`
- allow Anthropic-compatible non-Claude model IDs to use token-budget thinking on the Claude SDK path
- keep the renderer context warning badge aligned with connection-scoped model metadata

## Problem

The app already routes `anthropic_compat` connections through `ClaudeAgent`, but a few pieces were still implicitly Claude-registry-only:

1. `ClaudeAgent` initialized its context window with `getModelContextWindow(model)`.
   - This works for built-in Claude IDs.
   - It fails for custom Anthropic-compatible IDs that only exist in `connection.models[]`.

2. `ClaudeEventAdapter` only learned `contextWindow` later from `result.modelUsage.contextWindow`.
   - Some Anthropic-compatible providers do not report that field.
   - Result: session token usage had no stable context-window denominator.

3. `resolveClaudeThinkingOptions()` disabled thinking for non-Claude IDs because it gated on `isClaudeModel(model)`.
   - That prevented compatible custom models from receiving token-budget thinking on the Claude SDK path.

## What changed

- Added connection-aware model metadata helpers in `llm-connections.ts`:
  - `getModelDefinitionForConnection()`
  - `getConnectionModelContextWindow()`
  - `getConnectionModelSupportsThinking()`
- Updated `ClaudeAgent` to prefer connection-scoped metadata for custom compat models.
- Seeded `ClaudeEventAdapter` with the resolved context window immediately.
- Updated Claude thinking resolution to allow Anthropic-compatible custom models to use token budgets unless explicitly marked `supportsThinking: false`.
- Updated the renderer context warning badge to use connection-scoped context windows before falling back to the global registry.
- Added regression tests for context window + thinking behavior.

## Validation

- `bun run test:shared:config`
- `cd packages/shared && bun test src/agent/__tests__/claude-thinking-config.test.ts`
- `bun run typecheck:shared`
- `bun run typecheck:electron`
