### PR TITLE
feat: adds support for named AWS profiles

### DIFF
--- a/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
+++ b/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
@@ -54,6 +54,8 @@ export interface ApiKeySubmitData {
   awsRegion?: string
   /** Bedrock authentication method — determines auth type for Pi+Bedrock connections */
   bedrockAuthMethod?: 'iam_credentials' | 'environment'
+  /** AWS named profile for Bedrock environment auth (maps to AWS_PROFILE) */
+  awsProfile?: string
 }
 
 export interface ApiKeyInputProps {
@@ -78,6 +80,8 @@ export interface ApiKeyInputProps {
     models?: string[]
     /** Pre-fill the protocol toggle for custom endpoints */
     customApi?: CustomEndpointApi
+    /** Pre-fill AWS profile for Bedrock environment auth */
+    awsProfile?: string
   }
 }
 
@@ -198,6 +202,7 @@ export function ApiKeyInput({
   const [awsSecretAccessKey, setAwsSecretAccessKey] = useState('')
   const [awsSessionToken, setAwsSessionToken] = useState('')
   const [awsRegion, setAwsRegion] = useState('us-east-1')
+  const [awsProfile, setAwsProfile] = useState(initialValues?.awsProfile ?? 'default')
 
   // Pi model tier state (for providers with many models like OpenRouter, Vercel)
   const [piModels, setPiModels] = useState<PiModelInfo[]>([])
@@ -364,6 +369,7 @@ export function ApiKeyInput({
             ...(awsSessionToken.trim() ? { sessionToken: awsSessionToken.trim() } : {}),
           },
         } : {}),
+        ...(bedrockAuthMethod === 'environment' && awsProfile.trim() ? { awsProfile: awsProfile.trim() } : {}),
         connectionDefaultModel: parsedModels[0],
         models: parsedModels.length > 0 ? parsedModels : undefined,
       })
@@ -623,11 +629,25 @@ export function ApiKeyInput({
             </div>
           )}
 
-          {/* Environment info */}
+          {/* AWS Profile (environment auth) */}
           {bedrockAuthMethod === 'environment' && (
-            <div className="rounded-md bg-foreground-2 p-3">
-              <p className="text-xs text-foreground/50">
-                Uses your existing AWS credential chain — <code className="text-foreground/70">~/.aws/credentials</code>, <code className="text-foreground/70">AWS_PROFILE</code>, IAM roles, SSO sessions, and environment variables.
+            <div className="space-y-1.5">
+              <Label htmlFor="aws-profile" className="text-muted-foreground font-normal text-xs">
+                AWS Profile
+              </Label>
+              <div className={cn("rounded-md shadow-minimal transition-colors", "bg-foreground-2 focus-within:bg-background")}>
+                <Input
+                  id="aws-profile"
+                  type="text"
+                  value={awsProfile}
+                  onChange={(e) => setAwsProfile(e.target.value)}
+                  placeholder="default"
+                  className="border-0 bg-transparent shadow-none"
+                  disabled={isDisabled}
+                />
+              </div>
+              <p className="text-xs text-foreground/40">
+                Named profile from ~/.aws/config. Supports SSO sessions, IAM roles, and static credentials.
               </p>
             </div>
           )}

--- a/apps/electron/src/renderer/hooks/useOnboarding.ts
+++ b/apps/electron/src/renderer/hooks/useOnboarding.ts
@@ -147,6 +147,7 @@ export function apiSetupMethodToConnectionSetup(
     iamCredentials?: { accessKeyId: string; secretAccessKey: string; sessionToken?: string }
     awsRegion?: string
     bedrockAuthMethod?: 'iam_credentials' | 'environment'
+    awsProfile?: string
   },
   editingSlug: string | null,
   existingSlugs: Set<string>,
@@ -187,6 +188,7 @@ export function apiSetupMethodToConnectionSetup(
         iamCredentials: options.iamCredentials,
         awsRegion: options.awsRegion,
         bedrockAuthMethod: options.bedrockAuthMethod,
+        awsProfile: options.awsProfile,
       }
   }
 }
@@ -252,6 +254,7 @@ export function useOnboarding({
       iamCredentials?: { accessKeyId: string; secretAccessKey: string; sessionToken?: string }
       awsRegion?: string
       bedrockAuthMethod?: 'iam_credentials' | 'environment'
+      awsProfile?: string
     },
     methodOverride?: ApiSetupMethod,
     connectionSlugOverride?: string,
@@ -277,6 +280,7 @@ export function useOnboarding({
         iamCredentials: options?.iamCredentials,
         awsRegion: options?.awsRegion,
         bedrockAuthMethod: options?.bedrockAuthMethod,
+        awsProfile: options?.awsProfile,
       }, connectionSlugOverride ?? editingSlug, existingSlugs)
       // Use new unified API
       const result = await window.electronAPI.setupLlmConnection(
@@ -394,6 +398,7 @@ export function useOnboarding({
           iamCredentials: data.iamCredentials,
           awsRegion: data.awsRegion,
           bedrockAuthMethod: data.bedrockAuthMethod,
+          awsProfile: data.awsProfile,
         })
         if (saved) {
           setState(s => ({ ...s, credentialStatus: 'success', step: 'complete' }))

--- a/apps/electron/src/renderer/pages/settings/AiSettingsPage.tsx
+++ b/apps/electron/src/renderer/pages/settings/AiSettingsPage.tsx
@@ -563,6 +563,7 @@ export default function AiSettingsPage() {
     activePreset?: string
     models?: string[]
     customApi?: CustomEndpointApi
+    awsProfile?: string
   } | undefined>(undefined)
   const setFullscreenOverlayOpen = useSetAtom(fullscreenOverlayOpenAtom)
 
@@ -758,6 +759,7 @@ export default function AiSettingsPage() {
       activePreset: isCustomEndpointConnection ? 'custom' : (connection.piAuthProvider || undefined),
       models: modelIds,
       customApi: connection.customEndpoint?.api,
+      awsProfile: connection.awsProfile,
     })
 
     // Open overlay and jump directly to credentials step (no reset — jumpToCredentials sets state)

--- a/packages/server-core/src/handlers/rpc/llm-connections.ts
+++ b/packages/server-core/src/handlers/rpc/llm-connections.ts
@@ -143,6 +143,12 @@ export function registerLlmConnectionsHandlers(server: RpcServer, deps: HandlerD
       // providerType stays 'pi' (Bedrock routes through Pi SDK).
       if (setup.bedrockAuthMethod) {
         updates.authType = setup.bedrockAuthMethod
+        if (setup.awsRegion) updates.awsRegion = setup.awsRegion
+        if (setup.awsProfile !== undefined) updates.awsProfile = setup.awsProfile || undefined
+        // Update display name to include profile when set and not 'default'
+        if (setup.awsProfile && setup.awsProfile !== 'default') {
+          updates.name = `Amazon Bedrock \u2014 ${setup.awsProfile} Profile`
+        }
       }
 
       const effectiveProviderType = updates.providerType ?? connection.providerType

--- a/packages/server-core/src/sessions/SessionManager.ts
+++ b/packages/server-core/src/sessions/SessionManager.ts
@@ -2624,6 +2624,16 @@ export class SessionManager implements ISessionManager {
         // use the correct model for summarization (instead of hardcoded Haiku)
         ...(miniModel ? { ANTHROPIC_DEFAULT_HAIKU_MODEL: miniModel } : {}),
       }
+
+      // Resolve per-connection auth env vars (e.g. AWS_PROFILE for Bedrock environment auth)
+      const authEnvResult = connection
+        ? await resolveAuthEnvVars(connection, connection.slug, getCredentialManager(), getValidClaudeOAuthToken)
+        : { envVars: {}, success: true }
+      if (!authEnvResult.success) {
+        sessionLog.warn(`Auth env resolution failed for ${connection?.slug}: ${authEnvResult.warning}`)
+      }
+      Object.assign(envOverrides, authEnvResult.envVars)
+
       managed.envOverrides = envOverrides
 
       // ============================================================

--- a/packages/shared/src/agent/pi-agent.ts
+++ b/packages/shared/src/agent/pi-agent.ts
@@ -35,7 +35,7 @@ import { getModelById } from '../config/models.ts';
 
 // BaseAgent provides common functionality
 import { BaseAgent } from './base-agent.ts';
-import type { Workspace } from '../config/storage.ts';
+import { getLlmConnection, type Workspace } from '../config/storage.ts';
 
 // Event adapter
 import { PiEventAdapter } from './backend/pi/event-adapter.ts';
@@ -510,6 +510,9 @@ export class PiAgent extends BaseAgent {
       const credentialManager = getCredentialManager();
       const slug = this.config.connectionSlug || 'pi';
 
+      // DEBUG: Log auth resolution path
+      this.debug(`[getPiAuth] authType=${this.config.authType}, piAuthProvider=${piAuthProvider}, slug=${slug}`);
+
       if (this.config.authType === 'oauth') {
         const oauth = await credentialManager.getLlmOAuth(slug);
         if (oauth?.accessToken) {
@@ -555,17 +558,77 @@ export class PiAgent extends BaseAgent {
           };
         }
       } else {
-        // API key-based connections.
-        // NOTE: authType === 'environment' (e.g. Bedrock with ~/.aws/credentials)
-        // intentionally falls through here, finds no API key, and returns null.
-        // The subprocess inherits process.env which contains the AWS credential chain.
-        const apiKey = await credentialManager.getLlmApiKey(slug);
-        if (apiKey) {
-          this.debug(`Retrieved API key credential for Pi provider: ${piAuthProvider}`);
-          return {
-            provider: piAuthProvider,
-            credential: { type: 'api_key', key: apiKey },
-          };
+        // Check if the stored connection uses 'environment' auth for Bedrock.
+        // this.config.authType is unreliable here — the factory maps 'environment' → undefined
+        // → falls back to 'api_key' for Pi provider. We check the connection directly.
+        const storedConnection = getLlmConnection(slug);
+
+        if (storedConnection?.authType === 'environment' && piAuthProvider === 'amazon-bedrock') {
+          // Bedrock environment auth — resolve credentials from the AWS credential chain
+          // (SSO, named profiles, ~/.aws/credentials, IAM roles, etc.) in the main Node
+          // process, then pass as IAM credentials to the Pi subprocess.
+          // The subprocess runs in Bun which has issues with AWS credential chain resolution.
+          try {
+            const profile = storedConnection.awsProfile;
+            const region = storedConnection.awsRegion;
+
+            // Use the AWS CLI to resolve credentials — avoids bundling @aws-sdk/credential-providers
+            // (which causes esbuild issues) and the Bun credential chain hang.
+            const { execFileSync } = await import('node:child_process');
+            const { existsSync } = await import('node:fs');
+
+            // Electron apps don't inherit shell PATH — find the aws CLI explicitly
+            const awsPaths = [
+              '/usr/local/bin/aws',
+              '/opt/homebrew/bin/aws',
+              `${process.env.HOME}/.local/bin/aws`,
+              '/usr/bin/aws',
+            ];
+            const awsBin = awsPaths.find(p => existsSync(p)) || 'aws';
+            this.debug(`[getPiAuth] Resolving Bedrock env credentials via ${awsBin} (profile=${profile || 'default'})`);
+
+            const env = { ...process.env };
+            if (profile) env.AWS_PROFILE = profile;
+
+            const output = execFileSync(awsBin, ['configure', 'export-credentials', '--format', 'process'], {
+              timeout: 10000,
+              encoding: 'utf-8',
+              env,
+            });
+            const creds = JSON.parse(output) as {
+              Version: number;
+              AccessKeyId: string;
+              SecretAccessKey: string;
+              SessionToken?: string;
+            };
+
+            this.debug(`[getPiAuth] Resolved AWS credentials for Bedrock (profile=${profile || 'default'})`);
+            return {
+              provider: piAuthProvider,
+              credential: {
+                type: 'iam',
+                accessKeyId: creds.AccessKeyId,
+                secretAccessKey: creds.SecretAccessKey,
+                region: region || process.env.AWS_REGION || 'us-east-1',
+                sessionToken: creds.SessionToken,
+              },
+            };
+          } catch (awsError) {
+            const errMsg = awsError instanceof Error ? awsError.message : String(awsError);
+            this.debug(`[getPiAuth] AWS credential resolution failed: ${errMsg}`);
+            console.error(`[getPiAuth] AWS credential resolution failed: ${errMsg}`);
+            // Fall through to return null
+          }
+        } else {
+          // API key-based connections (default).
+          const apiKey = await credentialManager.getLlmApiKey(slug);
+          if (apiKey) {
+            this.debug(`Retrieved API key credential for Pi provider: ${piAuthProvider}`);
+            return {
+              provider: piAuthProvider,
+              credential: { type: 'api_key', key: apiKey },
+            };
+          }
         }
       }
 

--- a/packages/shared/src/config/__tests__/resolve-auth-env-vars.test.ts
+++ b/packages/shared/src/config/__tests__/resolve-auth-env-vars.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'bun:test'
+import { resolveAuthEnvVars, type LlmConnection } from '../llm-connections'
+import type { CredentialManager } from '../../credentials/manager'
+
+function makeConnection(overrides: Partial<LlmConnection>): LlmConnection {
+  return {
+    slug: 'test-conn',
+    name: 'Test Connection',
+    providerType: 'anthropic',
+    authType: 'api_key',
+    createdAt: Date.now(),
+    ...overrides,
+  }
+}
+
+function makeMockCredentialManager(overrides: Partial<CredentialManager> = {}): CredentialManager {
+  return {
+    getLlmApiKey: async () => null,
+    getLlmOAuth: async () => null,
+    getLlmIamCredentials: async () => null,
+    ...overrides,
+  } as unknown as CredentialManager
+}
+
+const noopGetValidOAuthToken = async () => ({ accessToken: null })
+
+describe('resolveAuthEnvVars — Bedrock awsProfile', () => {
+  it('sets AWS_PROFILE when awsProfile is configured', async () => {
+    const connection = makeConnection({
+      providerType: 'bedrock',
+      authType: 'environment',
+      awsRegion: 'us-east-1',
+      awsProfile: 'my-sso-profile',
+    })
+    const result = await resolveAuthEnvVars(
+      connection, 'bedrock-profile', makeMockCredentialManager(), noopGetValidOAuthToken,
+    )
+    expect(result.success).toBe(true)
+    expect(result.envVars.AWS_PROFILE).toBe('my-sso-profile')
+    expect(result.envVars.AWS_REGION).toBe('us-east-1')
+  })
+
+  it('does not set AWS_PROFILE when awsProfile is not configured', async () => {
+    const connection = makeConnection({
+      providerType: 'bedrock',
+      authType: 'environment',
+      awsRegion: 'us-east-1',
+    })
+    const result = await resolveAuthEnvVars(
+      connection, 'bedrock-no-profile', makeMockCredentialManager(), noopGetValidOAuthToken,
+    )
+    expect(result.success).toBe(true)
+    expect(result.envVars.AWS_PROFILE).toBeUndefined()
+  })
+})

--- a/packages/shared/src/config/llm-connections.ts
+++ b/packages/shared/src/config/llm-connections.ts
@@ -162,6 +162,14 @@ export interface LlmConnection {
    */
   customEndpoint?: CustomEndpointConfig;
 
+  // --- Cloud provider specific fields ---
+
+  /** AWS region (for 'bedrock' provider) */
+  awsRegion?: string;
+
+  /** AWS named profile (for 'bedrock' provider with environment auth). Maps to AWS_PROFILE env var. */
+  awsProfile?: string;
+
   // --- Timestamps ---
 
   /** Timestamp when connection was created */

--- a/packages/shared/src/config/storage.ts
+++ b/packages/shared/src/config/storage.ts
@@ -2400,6 +2400,9 @@ export function updateLlmConnection(slug: string, updates: Partial<Omit<LlmConne
     models: updates.models !== undefined ? updates.models : existing.models,
     defaultModel: updates.defaultModel !== undefined ? updates.defaultModel : existing.defaultModel,
     modelSelectionMode: updates.modelSelectionMode !== undefined ? updates.modelSelectionMode : existing.modelSelectionMode,
+    // Cloud provider fields
+    awsRegion: updates.awsRegion !== undefined ? updates.awsRegion : existing.awsRegion,
+    awsProfile: updates.awsProfile !== undefined ? updates.awsProfile : existing.awsProfile,
     // Pi auth provider
     piAuthProvider: updates.piAuthProvider !== undefined ? updates.piAuthProvider : existing.piAuthProvider,
     // Custom endpoint protocol (Anthropic/OpenAI compatible)

--- a/packages/shared/src/protocol/dto.ts
+++ b/packages/shared/src/protocol/dto.ts
@@ -354,6 +354,8 @@ export interface LlmConnectionSetup {
   }
   /** AWS region for Pi+Bedrock connections */
   awsRegion?: string
+  /** AWS named profile for Bedrock environment auth. Maps to AWS_PROFILE env var. */
+  awsProfile?: string
   /** Bedrock authentication method — determines auth type for Pi+Bedrock connections */
   bedrockAuthMethod?: 'iam_credentials' | 'environment'
 }


### PR DESCRIPTION
## Summary
This PR adds support for named AWS profiles (`aws sso login --profile my-profile`).   For those of us who work with multiple clients and AWS profiles, named profiles are a great tool to keep things clear.  This PR adds support for these named profiles within Craft Agents, so all bedrock calls are routed through the right account.

## Changes
- Adds an 'AWS Profile' field in the config, defaults to `default`, the value for anyone who hasn't changed or set up custom ones.
- Adds handling to `llm-connections.ts` and the pipeline. 
- Note: It does bring back the `awsRegion` field throughout, because it's needed for this implementation, but this feels like the right way to specify it. Not sure if that conflicts with the recent changes - open to feedback!
- Disclosure: mostly written in Craft Agents by Claude Opus 4.6.

## Testing
- Added new automated tests
- Tested by hand with my profiles, worked well.

## Screenshots
![CleanShot 2026-04-08 at 17 20 44](https://github.com/user-attachments/assets/fccac8d4-da3f-4277-8a7d-eddec3d26b26)
