### PR TITLE
fix(electron): persist macOS zoom and window bounds across reopen

### DIFF
--- a/apps/electron/src/main/handlers/system.ts
+++ b/apps/electron/src/main/handlers/system.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { homedir } from 'os'
 import { execSync } from 'child_process'
 import { RPC_CHANNELS } from '@craft-agent/shared/protocol'
-import { getGitBashPath, setGitBashPath, clearGitBashPath } from '@craft-agent/shared/config'
+import { getGitBashPath, setGitBashPath, clearGitBashPath, setWindowZoomFactor } from '@craft-agent/shared/config'
 import { isUsableGitBashPath, validateGitBashPath } from '@craft-agent/server-core/services'
 import { validateFilePath } from '@craft-agent/server-core/handlers'
 import type { RpcServer } from '@craft-agent/server-core/transport'
@@ -326,7 +326,9 @@ export function registerSystemGuiHandlers(server: RpcServer, deps: HandlerDeps):
     const win = windowManager.getWindowByWebContentsId(ctx.webContentsId!)
     if (win) {
       const currentZoom = win.webContents.getZoomFactor()
-      win.webContents.setZoomFactor(Math.min(currentZoom + 0.1, 3.0))
+      const nextZoom = Math.min(currentZoom + 0.1, 3.0)
+      win.webContents.setZoomFactor(nextZoom)
+      setWindowZoomFactor(nextZoom)
     }
   })
 
@@ -335,7 +337,9 @@ export function registerSystemGuiHandlers(server: RpcServer, deps: HandlerDeps):
     const win = windowManager.getWindowByWebContentsId(ctx.webContentsId!)
     if (win) {
       const currentZoom = win.webContents.getZoomFactor()
-      win.webContents.setZoomFactor(Math.max(currentZoom - 0.1, 0.5))
+      const nextZoom = Math.max(currentZoom - 0.1, 0.5)
+      win.webContents.setZoomFactor(nextZoom)
+      setWindowZoomFactor(nextZoom)
     }
   })
 
@@ -343,6 +347,7 @@ export function registerSystemGuiHandlers(server: RpcServer, deps: HandlerDeps):
     if (!windowManager) return
     const win = windowManager.getWindowByWebContentsId(ctx.webContentsId!)
     win?.webContents.setZoomFactor(1.0)
+    setWindowZoomFactor(1.0)
   })
 
   server.handle(RPC_CHANNELS.menu.TOGGLE_DEV_TOOLS, async (ctx) => {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1001,17 +1001,40 @@ app.whenReady().then(async () => {
   // macOS: Re-create window when dock icon is clicked
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0 && windowManager) {
-      // Open first workspace or last focused
+      // Open using last closed/saved state first, then fall back to workspace default.
       const workspaces = getWorkspaces()
       if (workspaces.length > 0) {
         const savedState = loadWindowState()
-        const wsId = savedState?.lastFocusedWorkspaceId || workspaces[0].id
-        // Verify workspace still exists
-        if (workspaces.some(ws => ws.id === wsId)) {
-          windowManager.createWindow({ workspaceId: wsId })
-        } else {
-          windowManager.createWindow({ workspaceId: workspaces[0].id })
+        const validWorkspaceIds = new Set(workspaces.map(ws => ws.id))
+        const lastClosed = windowManager.getLastClosedWindowState()
+
+        const preferredSavedWindow = (() => {
+          if (lastClosed && validWorkspaceIds.has(lastClosed.workspaceId)) {
+            return lastClosed
+          }
+          if (!savedState?.windows.length) return null
+          const preferredWorkspaceId = savedState.lastFocusedWorkspaceId
+          const byFocus = preferredWorkspaceId
+            ? savedState.windows.find(w => w.workspaceId === preferredWorkspaceId && validWorkspaceIds.has(w.workspaceId))
+            : undefined
+          if (byFocus) return byFocus
+          return savedState.windows.find(w => validWorkspaceIds.has(w.workspaceId)) ?? null
+        })()
+
+        if (preferredSavedWindow) {
+          const win = windowManager.createWindow({
+            workspaceId: preferredSavedWindow.workspaceId,
+            focused: preferredSavedWindow.focused,
+            restoreUrl: preferredSavedWindow.url,
+          })
+          win.setBounds(preferredSavedWindow.bounds)
+          return
         }
+
+        const wsId = savedState?.lastFocusedWorkspaceId || workspaces[0].id
+        windowManager.createWindow({
+          workspaceId: validWorkspaceIds.has(wsId) ? wsId : workspaces[0].id,
+        })
       }
     }
   })
@@ -1038,20 +1061,29 @@ app.on('before-quit', async (event) => {
   windowManager?.setAppQuitting(true)
 
   if (windowManager) {
-    // Get full window states (includes bounds, type, and query)
+    // Get full window states (includes bounds, type, and query).
+    // On macOS users may quit while no windows are open; in that case preserve the
+    // last closed window snapshot so next launch can restore size/position correctly.
     const windows = windowManager.getWindowStates()
+    const lastClosedWindow = windowManager.getLastClosedWindowState()
+    const windowsToSave = windows.length > 0
+      ? windows
+      : (lastClosedWindow ? [lastClosedWindow] : [])
+
     // Get the focused window's workspace as last focused
     const focusedWindow = BrowserWindow.getFocusedWindow()
     let lastFocusedWorkspaceId: string | undefined
     if (focusedWindow) {
       lastFocusedWorkspaceId = windowManager.getWorkspaceForWindow(focusedWindow.webContents.id) ?? undefined
+    } else if (windowsToSave[0]) {
+      lastFocusedWorkspaceId = windowsToSave[0].workspaceId
     }
 
     saveWindowState({
-      windows,
+      windows: windowsToSave,
       lastFocusedWorkspaceId,
     })
-    mainLog.info('Saved window state:', windows.length, 'windows')
+    mainLog.info('Saved window state:', windowsToSave.length, 'windows')
   }
 
   // Flush all pending session writes before quitting

--- a/apps/electron/src/main/window-manager.ts
+++ b/apps/electron/src/main/window-manager.ts
@@ -3,6 +3,7 @@ import { windowLog } from './logger'
 import { join } from 'path'
 import { existsSync } from 'fs'
 import { release } from 'os'
+import { getWindowZoomFactor, setWindowZoomFactor } from '@craft-agent/shared/config'
 import { RPC_CHANNELS, type WindowCloseRequestSource } from '../shared/types'
 import type { SavedWindow } from './window-state'
 
@@ -169,6 +170,19 @@ export class WindowManager {
         sandbox: false,
         webviewTag: false // Browser integration uses WebContentsView, not <webview>
       }
+    })
+
+    const initialZoomFactor = getWindowZoomFactor()
+    window.webContents.setZoomFactor(initialZoomFactor)
+    window.webContents.once('did-finish-load', () => {
+      if (window.isDestroyed() || window.webContents.isDestroyed()) return
+      window.webContents.setZoomFactor(getWindowZoomFactor())
+    })
+    window.webContents.on('zoom-changed', () => {
+      setTimeout(() => {
+        if (window.isDestroyed() || window.webContents.isDestroyed()) return
+        setWindowZoomFactor(window.webContents.getZoomFactor())
+      }, 0)
     })
 
     // Show window when first paint is ready (faster perceived startup)
@@ -343,6 +357,10 @@ export class WindowManager {
     // Handle window close request (traffic-light button, menu close, Cmd/Ctrl+W)
     // and send source metadata so renderer can decide layered dismiss vs direct close.
     window.on('close', (event) => {
+      if (!window.isDestroyed() && !window.webContents.isDestroyed()) {
+        setWindowZoomFactor(window.webContents.getZoomFactor())
+      }
+
       // During app quit, bypass layered close behavior and allow native close flow.
       // This preserves expected Cmd+Q semantics (quit app instead of closing overlays/panels first).
       if (this.isAppQuitting) {

--- a/apps/electron/src/main/window-manager.ts
+++ b/apps/electron/src/main/window-manager.ts
@@ -54,6 +54,7 @@ export interface CreateWindowOptions {
 export class WindowManager {
   private windows: Map<number, ManagedWindow> = new Map()  // webContents.id → ManagedWindow
   private focusedModeWindows: Set<number> = new Set()  // webContents.id of windows in focused mode
+  private lastClosedWindowState: SavedWindow | null = null
   private pendingCloseTimeouts: Map<number, NodeJS.Timeout> = new Map()  // Fallback timeouts for window close
   private eventSink: ((channel: string, target: import('@craft-agent/shared/protocol').PushTarget, ...args: any[]) => void) | null = null
   private clientResolver: ((wcId: number) => string | undefined) | null = null
@@ -95,6 +96,22 @@ export class WindowManager {
     // Fallback: direct webContents.send (used before WS handshake completes)
     if (!window.isDestroyed() && !window.webContents.isDestroyed() && window.webContents.mainFrame) {
       window.webContents.send(channel, ...args)
+    }
+  }
+
+  private buildSavedWindowState(window: BrowserWindow, workspaceId: string): SavedWindow {
+    const webContentsId = window.webContents.id
+    const isFocused = this.focusedModeWindows.has(webContentsId)
+    let url = ''
+    if (!window.webContents.isDestroyed()) {
+      url = window.webContents.getURL()
+    }
+    return {
+      type: 'main',
+      workspaceId,
+      bounds: window.getBounds(),
+      ...(isFocused && { focused: true }),
+      ...(url && { url }),
     }
   }
 
@@ -357,6 +374,10 @@ export class WindowManager {
     // Handle window close request (traffic-light button, menu close, Cmd/Ctrl+W)
     // and send source metadata so renderer can decide layered dismiss vs direct close.
     window.on('close', (event) => {
+      // Keep last known state so macOS can restore size/position when reopening from Dock
+      // without a full app quit (window-all-closed keeps app alive on macOS).
+      this.lastClosedWindowState = this.buildSavedWindowState(window, workspaceId)
+
       if (!window.isDestroyed() && !window.webContents.isDestroyed()) {
         setWindowZoomFactor(window.webContents.getZoomFactor())
       }
@@ -504,6 +525,7 @@ export class WindowManager {
 
     const managed = this.windows.get(webContentsId)
     if (managed && !managed.window.isDestroyed()) {
+      this.lastClosedWindowState = this.buildSavedWindowState(managed.window, managed.workspaceId)
       // Remove close listener temporarily to avoid infinite loop,
       // then destroy the window directly
       managed.window.destroy()
@@ -591,17 +613,20 @@ export class WindowManager {
    */
   getWindowStates(): SavedWindow[] {
     return this.getAllWindows().map(managed => {
-      const webContentsId = managed.window.webContents.id
-      const isFocused = this.focusedModeWindows.has(webContentsId)
-      const url = managed.window.webContents.getURL()
-      return {
-        type: 'main' as const,
-        workspaceId: managed.workspaceId,
-        bounds: managed.window.getBounds(),
-        ...(isFocused && { focused: true }),
-        ...(url && { url }),
-      }
+      return this.buildSavedWindowState(managed.window, managed.workspaceId)
     })
+  }
+
+  /**
+   * Last window state captured during close flow.
+   * Used to restore macOS windows when the app remains alive with no windows.
+   */
+  getLastClosedWindowState(): SavedWindow | null {
+    if (!this.lastClosedWindowState) return null
+    return {
+      ...this.lastClosedWindowState,
+      bounds: { ...this.lastClosedWindowState.bounds },
+    }
   }
 
   /**

--- a/packages/shared/src/config/storage.ts
+++ b/packages/shared/src/config/storage.ts
@@ -69,6 +69,8 @@ export interface StoredConfig {
   spellCheck?: boolean;  // Enable spell check in input (default: false)
   // Power settings
   keepAwakeWhileRunning?: boolean;  // Prevent screen sleep while sessions are running (default: false)
+  // Window zoom
+  windowZoomFactor?: number;  // Global window zoom factor (default: 1.0, range: 0.5-3.0)
   // Tool metadata
   richToolDescriptions?: boolean;  // Add intent/action metadata to all tool calls (default: true)
   // Tools
@@ -88,6 +90,10 @@ export interface StoredConfig {
 
 const CONFIG_FILE = join(CONFIG_DIR, 'config.json');
 const CONFIG_DEFAULTS_FILE = join(CONFIG_DIR, 'config-defaults.json');
+const MIN_WINDOW_ZOOM_FACTOR = 0.5;
+const MAX_WINDOW_ZOOM_FACTOR = 3.0;
+const DEFAULT_WINDOW_ZOOM_FACTOR = 1.0;
+const WINDOW_ZOOM_PRECISION = 100;
 
 // Track if config-defaults have been synced this session (prevents re-sync on hot reload)
 let configDefaultsSynced = false;
@@ -397,6 +403,34 @@ export function setKeepAwakeWhileRunning(enabled: boolean): void {
   const config = loadStoredConfig();
   if (!config) return;
   config.keepAwakeWhileRunning = enabled;
+  saveConfig(config);
+}
+
+function normalizeWindowZoomFactor(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_WINDOW_ZOOM_FACTOR;
+  const clamped = Math.min(Math.max(value, MIN_WINDOW_ZOOM_FACTOR), MAX_WINDOW_ZOOM_FACTOR);
+  // Keep two decimal places to avoid noisy floating-point persistence updates.
+  return Math.round(clamped * WINDOW_ZOOM_PRECISION) / WINDOW_ZOOM_PRECISION;
+}
+
+/**
+ * Get global window zoom factor.
+ * Defaults to 1.0 when unset.
+ */
+export function getWindowZoomFactor(): number {
+  const config = loadStoredConfig();
+  return normalizeWindowZoomFactor(config?.windowZoomFactor ?? DEFAULT_WINDOW_ZOOM_FACTOR);
+}
+
+/**
+ * Persist global window zoom factor.
+ */
+export function setWindowZoomFactor(zoomFactor: number): void {
+  const config = loadStoredConfig();
+  if (!config) return;
+  const normalized = normalizeWindowZoomFactor(zoomFactor);
+  if (config.windowZoomFactor === normalized) return;
+  config.windowZoomFactor = normalized;
   saveConfig(config);
 }
 


### PR DESCRIPTION
## Summary
Fixes macOS window state persistence issues when reopening the app window without fully quitting.

This PR now covers:
- zoom persistence across close/reopen
- window bounds (size and position) persistence across close/reopen

Fixes #529

## Changes
- Persist window zoom factor in app config (`windowZoomFactor`)
- Apply persisted zoom on window creation and after initial renderer load
- Persist zoom on `webContents` zoom change events
- Add close-time fallback persistence for zoom on window close
- Capture last-closed window snapshot in `WindowManager` (workspace, bounds, focused, url)
- On macOS `app.activate` (Dock reopen with no windows), restore from last-closed/saved window state instead of default window size
- During `before-quit`, avoid saving an empty window list when all windows were already closed by reusing last-closed window state

## Testing
- Manual (macOS):
  1. Open app
  2. Change zoom (`Cmd +` / `Cmd -`)
  3. Resize and move window
  4. Close window (`Cmd + W` / traffic-light close), do not quit app
  5. Reopen from Dock
  6. Verify both zoom and window bounds are preserved
- Verification:
  - `bun run typecheck:shared`
  - `bun run typecheck:electron`
