### PR TITLE
fix: BrowserView layout on Linux + custom font config

### DIFF
--- a/apps/electron/src/main/browser-pane-manager.ts
+++ b/apps/electron/src/main/browser-pane-manager.ts
@@ -3124,6 +3124,20 @@ export class BrowserPaneManager implements IBrowserPaneManager {
     instance.window.on('show', () => {
       instance.isVisible = true
       this.emitStateChange(instance)
+      // Workaround for Electron on Linux/Wayland: BrowserViews may retain their
+      // initial surface size after the first show. Re-attaching them forces the
+      // compositor to recreate surfaces at the current window size.
+      if (process.platform === 'linux') {
+        const win = instance.window
+        win.removeBrowserView(instance.pageView)
+        win.removeBrowserView(instance.nativeOverlayView)
+        win.removeBrowserView(instance.toolbarView)
+        win.addBrowserView(instance.pageView)
+        win.addBrowserView(instance.nativeOverlayView)
+        win.addBrowserView(instance.toolbarView)
+        win.setTopBrowserView(instance.toolbarView)
+        this.layoutAllViews(instance)
+      }
       this.reapplyAgentControlVisual(instance)
       this.pushToolbarState(instance)
       this.updateNativeOverlayState(instance)

--- a/apps/electron/src/renderer/context/ThemeContext.tsx
+++ b/apps/electron/src/renderer/context/ThemeContext.tsx
@@ -12,18 +12,25 @@ import {
 } from '@config/theme'
 
 export type ThemeMode = 'light' | 'dark' | 'system'
-export type FontFamily = 'inter' | 'system'
+export type FontPreset = 'inter' | 'system' | 'custom'
+
+const FONT_PRESET_MAP: Record<Exclude<FontPreset, 'custom'>, string> = {
+  inter: '"Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+  system: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+}
 
 interface ThemeContextType {
   // Preferences (persisted at app level)
   mode: ThemeMode
   /** App-level default color theme (used when workspace has no override) */
   colorTheme: string
-  font: FontFamily
+  font: string
+  fontPreset: FontPreset
   setMode: (mode: ThemeMode) => void
   /** Set app-level default color theme */
   setColorTheme: (theme: string) => void
-  setFont: (font: FontFamily) => void
+  setFont: (font: string) => void
+  setFontPreset: (preset: FontPreset) => void
 
   // Workspace-level theme override
   /** Active workspace ID (null if no workspace context) */
@@ -67,7 +74,8 @@ interface ThemeContextType {
 interface StoredTheme {
   mode: ThemeMode
   colorTheme: string
-  font?: FontFamily
+  font?: string
+  fontPreset?: FontPreset
   /** True when user explicitly changed theme in UI (not auto-saved on startup) */
   isUserOverride?: boolean
 }
@@ -91,7 +99,8 @@ interface ThemeProviderProps {
   children: ReactNode
   defaultMode?: ThemeMode
   defaultColorTheme?: string
-  defaultFont?: FontFamily
+  defaultFont?: string
+  defaultFontPreset?: FontPreset
   /** Active workspace ID for workspace-level theme overrides */
   activeWorkspaceId?: string | null
 }
@@ -112,11 +121,18 @@ function saveTheme(theme: StoredTheme): void {
   storage.set(storage.KEYS.theme, theme)
 }
 
+function inferFontPreset(font: string): FontPreset {
+  if (font === FONT_PRESET_MAP.inter) return 'inter'
+  if (font === FONT_PRESET_MAP.system) return 'system'
+  return 'custom'
+}
+
 export function ThemeProvider({
   children,
   defaultMode = 'system',
   defaultColorTheme = 'default',
-  defaultFont = 'system',
+  defaultFont = FONT_PRESET_MAP.system,
+  defaultFontPreset = 'system',
   activeWorkspaceId = null
 }: ThemeProviderProps) {
   const stored = loadStoredTheme()
@@ -130,7 +146,10 @@ export function ThemeProvider({
     }
     return defaultColorTheme // Will be updated by config.json effect
   })
-  const [font, setFontState] = useState<FontFamily>(stored?.font ?? defaultFont)
+  const initialFont = stored?.font ?? defaultFont
+  const initialFontPreset = stored?.fontPreset ?? inferFontPreset(initialFont)
+  const [font, setFontState] = useState<string>(initialFont)
+  const [fontPreset, setFontPresetState] = useState<FontPreset>(initialFontPreset)
   const [systemPreference, setSystemPreference] = useState<'light' | 'dark'>(getSystemPreference)
   const [previewColorTheme, setPreviewColorTheme] = useState<string | null>(null)
 
@@ -139,6 +158,7 @@ export function ThemeProvider({
 
   // Track if we're receiving an external update to prevent echo broadcasts
   const isExternalUpdate = useRef(false)
+  const externalUpdateTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Load app-level colorTheme from config.json on mount (only if user hasn't overridden)
   useEffect(() => {
@@ -287,8 +307,14 @@ export function ThemeProvider({
   useEffect(() => {
     const root = document.documentElement
 
-    // Apply font
-    if (font === 'inter') {
+    // Apply font via CSS variable (presets or custom string)
+    const effectiveFont = fontPreset === 'custom'
+      ? (font || FONT_PRESET_MAP.system)
+      : (FONT_PRESET_MAP[fontPreset] ?? FONT_PRESET_MAP.system)
+    root.style.setProperty('--font-default', effectiveFont)
+
+    // Keep data-font attribute so CSS can apply Inter-specific features
+    if (fontPreset === 'inter') {
       root.dataset.font = 'inter'
     } else {
       delete root.dataset.font
@@ -303,7 +329,7 @@ export function ThemeProvider({
 
     // Always set theme override for semi-transparent background (vibrancy effect)
     root.dataset.themeOverride = 'true'
-  }, [effectiveColorTheme, font])
+  }, [effectiveColorTheme, font, fontPreset])
 
   // Apply dark/light class and theme-specific DOM attributes
   // This runs when preset loads or mode changes
@@ -415,53 +441,84 @@ export function ThemeProvider({
 
     const cleanup = window.electronAPI.onThemePreferencesChange((preferences) => {
       isExternalUpdate.current = true
+      const syncedPreset = preferences.fontPreset
+        ? (preferences.fontPreset as FontPreset)
+        : inferFontPreset(preferences.font)
       setModeState(preferences.mode as ThemeMode)
       setColorThemeState(preferences.colorTheme)
-      setFontState(preferences.font as FontFamily)
+      setFontState(preferences.font)
+      setFontPresetState(syncedPreset)
       // When syncing from another window, mark as user override since user explicitly changed theme
       saveTheme({
         mode: preferences.mode as ThemeMode,
         colorTheme: preferences.colorTheme,
-        font: preferences.font as FontFamily,
+        font: preferences.font,
+        fontPreset: syncedPreset,
         isUserOverride: true
       })
-      setTimeout(() => {
+      externalUpdateTimeout.current = setTimeout(() => {
         isExternalUpdate.current = false
       }, 0)
     })
 
-    return cleanup
+    return () => {
+      if (externalUpdateTimeout.current) {
+        clearTimeout(externalUpdateTimeout.current)
+        externalUpdateTimeout.current = null
+      }
+      cleanup()
+    }
   }, [])
 
   // === Setters with persistence and broadcast ===
+  const persistAndBroadcast = useCallback((updates: Partial<StoredTheme>) => {
+    const existing = loadStoredTheme()
+    const next: StoredTheme = {
+      mode,
+      colorTheme,
+      font,
+      fontPreset,
+      isUserOverride: existing?.isUserOverride,
+      ...updates,
+    }
+    saveTheme(next)
+    if (!isExternalUpdate.current && window.electronAPI?.broadcastThemePreferences) {
+      window.electronAPI.broadcastThemePreferences({
+        mode: next.mode,
+        colorTheme: next.colorTheme,
+        font: next.font ?? font,
+        fontPreset: next.fontPreset ?? fontPreset,
+      })
+    }
+  }, [mode, colorTheme, font, fontPreset])
+
   const setMode = useCallback((newMode: ThemeMode) => {
     setModeState(newMode)
-    // Preserve existing isUserOverride flag
-    const existing = loadStoredTheme()
-    saveTheme({ mode: newMode, colorTheme, font, isUserOverride: existing?.isUserOverride })
-    if (!isExternalUpdate.current && window.electronAPI?.broadcastThemePreferences) {
-      window.electronAPI.broadcastThemePreferences({ mode: newMode, colorTheme, font })
-    }
-  }, [colorTheme, font])
+    persistAndBroadcast({ mode: newMode })
+  }, [persistAndBroadcast])
 
   const setColorTheme = useCallback((newTheme: string) => {
     setColorThemeState(newTheme)
-    // Mark as user override - user explicitly changed theme via UI
-    saveTheme({ mode, colorTheme: newTheme, font, isUserOverride: true })
-    if (!isExternalUpdate.current && window.electronAPI?.broadcastThemePreferences) {
-      window.electronAPI.broadcastThemePreferences({ mode, colorTheme: newTheme, font })
-    }
-  }, [mode, font])
+    persistAndBroadcast({ colorTheme: newTheme, isUserOverride: true })
+  }, [persistAndBroadcast])
 
-  const setFont = useCallback((newFont: FontFamily) => {
+  const setFont = useCallback((newFont: string) => {
     setFontState(newFont)
-    // Preserve existing isUserOverride flag
-    const existing = loadStoredTheme()
-    saveTheme({ mode, colorTheme, font: newFont, isUserOverride: existing?.isUserOverride })
-    if (!isExternalUpdate.current && window.electronAPI?.broadcastThemePreferences) {
-      window.electronAPI.broadcastThemePreferences({ mode, colorTheme, font: newFont })
+    persistAndBroadcast({ font: newFont })
+  }, [persistAndBroadcast])
+
+  const setFontPreset = useCallback((newPreset: FontPreset) => {
+    setFontPresetState(newPreset)
+    let newFont = font
+    if (newPreset === 'custom') {
+      const isPresetValue = Object.values(FONT_PRESET_MAP).includes(font)
+      newFont = isPresetValue ? '' : font
+    } else {
+      newFont = FONT_PRESET_MAP[newPreset] ?? font
     }
-  }, [mode, colorTheme])
+    setFontState(newFont)
+    persistAndBroadcast({ font: newFont, fontPreset: newPreset })
+  }, [font, persistAndBroadcast])
 
   // Set workspace-specific color theme override
   const setWorkspaceColorTheme = useCallback((newTheme: string | null) => {
@@ -493,9 +550,11 @@ export function ThemeProvider({
         mode,
         colorTheme,
         font,
+        fontPreset,
         setMode,
         setColorTheme,
         setFont,
+        setFontPreset,
 
         // Workspace-level theme override
         activeWorkspaceId,

--- a/apps/electron/src/renderer/index.css
+++ b/apps/electron/src/renderer/index.css
@@ -370,15 +370,6 @@ html[data-scenic] {
   --background: oklch(0.2 0.005 270 / 0.55);
 }
 
-/* Inter Font - Opt-in via data-font="inter" attribute
-   Loaded from Google Fonts in index.html with optical sizing (opsz) axis */
-html[data-font="inter"] {
-  --font-sans: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  --font-default: var(--font-sans);
-  font-optical-sizing: auto;
-  font-feature-settings: "cv01", "cv02", "cv03", "cv04", "case";
-}
-
 /* Theme integration for Tailwind v4 */
 @theme inline {
   /* === 6 BASE COLORS === */
@@ -489,6 +480,11 @@ html[data-font="inter"] {
     color: var(--foreground);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+  }
+
+  html[data-font="inter"] body {
+    font-optical-sizing: auto;
+    font-feature-settings: "cv01", "cv02", "cv03", "cv04", "case";
   }
 
   /* Scrollbar styling */

--- a/apps/electron/src/renderer/pages/settings/AppearanceSettingsPage.tsx
+++ b/apps/electron/src/renderer/pages/settings/AppearanceSettingsPage.tsx
@@ -5,7 +5,7 @@
  * workspace-specific theme overrides, and CLI tool icon mappings.
  */
 
-import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LANGUAGES, type LanguageCode } from '@craft-agent/shared/i18n'
 import type { ColumnDef } from '@tanstack/react-table'
@@ -16,7 +16,7 @@ import { EditPopover, EditButton, getEditConfig } from '@/components/ui/EditPopo
 import { useTheme } from '@/context/ThemeContext'
 import { useAppShellContext } from '@/context/AppShellContext'
 import { routes } from '@/lib/navigate'
-import { Monitor, Sun, Moon } from 'lucide-react'
+import { Monitor, Sun, Moon, ChevronDown } from 'lucide-react'
 import type { DetailsPageMeta } from '@/lib/navigation-registry'
 import type { ToolIconMapping } from '../../../shared/types'
 
@@ -28,11 +28,29 @@ import {
   SettingsMenuSelect,
   SettingsToggle,
 } from '@/components/settings'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from '@/components/ui/command'
 import * as storage from '@/lib/local-storage'
 import { useWorkspaceIcons } from '@/hooks/useWorkspaceIcon'
 import { Info_DataTable, SortableHeader } from '@/components/info/Info_DataTable'
 import { Info_Badge } from '@/components/info/Info_Badge'
 import type { PresetTheme } from '@config/theme'
+import type { FontPreset } from '@/context/ThemeContext'
+
+interface QueryLocalFontsAPI {
+  queryLocalFonts(): Promise<Array<{ family: string }>>
+}
 
 export const meta: DetailsPageMeta = {
   navigator: 'settings',
@@ -105,6 +123,8 @@ export default function AppearanceSettingsPage() {
     setColorTheme,
     font,
     setFont,
+    fontPreset,
+    setFontPreset,
     activeWorkspaceId,
     setWorkspaceColorTheme,
     themeLoadError,
@@ -135,6 +155,44 @@ export default function AppearanceSettingsPage() {
     setShowConnectionIcons(checked)
     storage.set(storage.KEYS.showConnectionIcons, checked)
   }, [])
+
+  // System font picker state
+  const [systemFonts, setSystemFonts] = useState<string[]>([])
+  const [fontQuery, setFontQuery] = useState('')
+  const [fontOpen, setFontOpen] = useState(false)
+  const hasQueriedFonts = useRef(false)
+
+  useEffect(() => {
+    if (fontPreset !== 'custom') return
+    if (hasQueriedFonts.current) return
+    const win = window as unknown as Window & QueryLocalFontsAPI
+    if (!('queryLocalFonts' in win)) return
+    win.queryLocalFonts()
+      .then((fonts) => {
+        const families = Array.from(new Set(fonts.map((f) => f.family))).sort()
+        hasQueriedFonts.current = true
+        setSystemFonts(families)
+      })
+      .catch(() => {
+        // Permission denied or API unavailable — leave list empty
+      })
+  }, [fontPreset])
+
+  const filteredFonts = useMemo(() => {
+    if (!fontQuery.trim()) return systemFonts.slice(0, 50)
+    const q = fontQuery.toLowerCase()
+    return systemFonts.filter(f => f.toLowerCase().includes(q)).slice(0, 50)
+  }, [systemFonts, fontQuery])
+
+  const passThroughFilter = useCallback(() => 1, [])
+
+  const handleFontSearchEnter = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && fontQuery.trim()) {
+      setFont(fontQuery.trim())
+      setFontOpen(false)
+      setFontQuery('')
+    }
+  }, [fontQuery, setFont])
 
   // Rich tool descriptions toggle (persisted in config.json, read by SDK subprocess)
   const [richToolDescriptions, setRichToolDescriptions] = useState(true)
@@ -271,14 +329,61 @@ export default function AppearanceSettingsPage() {
                     />
                   </SettingsRow>
                   <SettingsRow label={t("settings.appearance.font")}>
-                    <SettingsSegmentedControl
-                      value={font}
-                      onValueChange={setFont}
-                      options={[
-                        { value: 'inter', label: t("settings.appearance.fontInter") },
-                        { value: 'system', label: t("settings.appearance.fontSystem") },
-                      ]}
-                    />
+                    <div className="flex flex-col gap-2">
+                      <SettingsSegmentedControl
+                        value={fontPreset}
+                        onValueChange={setFontPreset}
+                        options={[
+                          { value: 'inter' as const, label: t("settings.appearance.fontInter") },
+                          { value: 'system' as const, label: t("settings.appearance.fontSystem") },
+                          { value: 'custom' as const, label: t("settings.appearance.fontCustom") }
+                        ]}
+                      />
+                      {fontPreset === 'custom' && (
+                        <Popover open={fontOpen} onOpenChange={setFontOpen}>
+                          <PopoverTrigger asChild>
+                            <button
+                              type="button"
+                              className="flex items-center justify-between gap-2 px-2.5 py-1.5 text-sm rounded-md border border-border bg-background text-foreground hover:bg-muted/50 focus:outline-none focus:ring-1 focus:ring-ring w-full max-w-[240px]"
+                            >
+                              <span className="truncate">{font || 'Select font...'}</span>
+                              <ChevronDown className="w-4 h-4 shrink-0 text-muted-foreground" />
+                            </button>
+                          </PopoverTrigger>
+                          <PopoverContent className="p-0 w-[260px]" align="start">
+                            <Command filter={passThroughFilter}>
+                              <CommandInput
+                                placeholder="Search fonts..."
+                                value={fontQuery}
+                                onValueChange={setFontQuery}
+                                onKeyDown={handleFontSearchEnter}
+                              />
+                              <CommandList>
+                                <CommandEmpty className="py-2 text-xs text-center text-muted-foreground">
+                                  Press Enter to use “{fontQuery.trim()}”
+                                </CommandEmpty>
+                                <CommandGroup>
+                                  {filteredFonts.map((name) => (
+                                    <CommandItem
+                                      key={name}
+                                      value={name}
+                                      onSelect={() => {
+                                        setFont(name)
+                                        setFontOpen(false)
+                                        setFontQuery('')
+                                      }}
+                                      className="cursor-pointer"
+                                    >
+                                      <span style={{ fontFamily: name }}>{name}</span>
+                                    </CommandItem>
+                                  ))}
+                                </CommandGroup>
+                              </CommandList>
+                            </Command>
+                          </PopoverContent>
+                        </Popover>
+                      )}
+                    </div>
                   </SettingsRow>
                   <SettingsRow label={t("settings.appearance.language")}>
                     <SettingsMenuSelect

--- a/apps/electron/src/shared/types.ts
+++ b/apps/electron/src/shared/types.ts
@@ -562,8 +562,8 @@ export interface ElectronAPI {
   onNotificationNavigate(callback: (data: { workspaceId: string; sessionId: string }) => void): () => void
 
   // Theme preferences sync across windows
-  broadcastThemePreferences(preferences: { mode: string; colorTheme: string; font: string }): Promise<void>
-  onThemePreferencesChange(callback: (preferences: { mode: string; colorTheme: string; font: string }) => void): () => void
+  broadcastThemePreferences(preferences: { mode: string; colorTheme: string; font: string; fontPreset?: string }): Promise<void>
+  onThemePreferencesChange(callback: (preferences: { mode: string; colorTheme: string; font: string; fontPreset?: string }) => void): () => void
 
   // Workspace theme sync across windows
   broadcastWorkspaceThemeChange(workspaceId: string, themeId: string | null): Promise<void>

--- a/apps/electron/vite.config.ts
+++ b/apps/electron/vite.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
   build: {
     outDir: resolve(__dirname, 'dist/renderer'),
     emptyDirBeforeWrite: true,
+    emptyOutDir: true,
     sourcemap: true,  // Source maps generated for debugging. Not uploaded to Sentry (see CLAUDE.md).
     rollupOptions: {
       input: {

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -609,6 +609,7 @@
   "settings.appearance.font": "Font",
   "settings.appearance.fontInter": "Inter",
   "settings.appearance.fontSystem": "System",
+  "settings.appearance.fontCustom": "Custom",
   "settings.appearance.iconHeader": "Icon",
   "settings.appearance.interface": "Interface",
   "settings.appearance.language": "Language",

--- a/packages/shared/src/i18n/locales/es.json
+++ b/packages/shared/src/i18n/locales/es.json
@@ -609,6 +609,7 @@
   "settings.appearance.font": "Fuente",
   "settings.appearance.fontInter": "Inter",
   "settings.appearance.fontSystem": "Sistema",
+  "settings.appearance.fontCustom": "Personalizada",
   "settings.appearance.iconHeader": "Icono",
   "settings.appearance.interface": "Interfaz",
   "settings.appearance.language": "Idioma",

--- a/packages/shared/src/i18n/locales/ja.json
+++ b/packages/shared/src/i18n/locales/ja.json
@@ -609,6 +609,7 @@
   "settings.appearance.font": "フォント",
   "settings.appearance.fontInter": "Inter",
   "settings.appearance.fontSystem": "システム",
+  "settings.appearance.fontCustom": "カスタム",
   "settings.appearance.iconHeader": "アイコン",
   "settings.appearance.interface": "インターフェース",
   "settings.appearance.language": "言語",

--- a/packages/shared/src/i18n/locales/zh-Hans.json
+++ b/packages/shared/src/i18n/locales/zh-Hans.json
@@ -609,6 +609,7 @@
   "settings.appearance.font": "字体",
   "settings.appearance.fontInter": "Inter",
   "settings.appearance.fontSystem": "系统",
+  "settings.appearance.fontCustom": "自定义",
   "settings.appearance.iconHeader": "图标",
   "settings.appearance.interface": "界面",
   "settings.appearance.language": "语言",


### PR DESCRIPTION
## Summary

This PR contains two main improvements:

1. **BrowserView layout fix on Linux**
   - Fixes an issue where BrowserView renders only half the window on first show under Linux/Wayland by forcing a compositor surface refresh via `removeBrowserView` / `addBrowserView`.

2. **Custom font configuration**
   - Extends font settings from a hardcoded `inter | system` choice to support arbitrary custom fonts.
   - Adds a `fontPreset` field (`inter` / `system` / `custom`) with a searchable system-font picker in Appearance settings.
   - Dynamically injects the chosen font stack via `--font-default` CSS variable.

3. **Build warning cleanup**
   - Adds `emptyOutDir: true` to `vite.config.ts` to eliminate the Vite "outDir not inside project root" warning.