### PR TITLE
fix(electron): stop overriding dock icon in packaged app

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -397,7 +397,7 @@ app.whenReady().then(async () => {
   // Application menu is created after windowManager initialization (see below)
 
   // Set dock icon on macOS (required for dev mode, bundled apps use Info.plist)
-  if (process.platform === 'darwin' && app.dock) {
+  if (process.platform === 'darwin' && app.dock && !app.isPackaged) {
     // In packaged app, resources are at dist/resources/ (same level as __dirname)
     // In dev, resources are at ../resources/ (sibling of dist/)
     const dockIconPath = [

--- a/apps/electron/src/main/notifications.ts
+++ b/apps/electron/src/main/notifications.ts
@@ -178,7 +178,7 @@ function updateBadgeCountMacOS(count: number): void {
       }
     } else {
       // Reset to original icon (no badge)
-      if (baseIconPath) {
+      if (baseIconPath && !app.isPackaged) {
         const originalIcon = nativeImage.createFromPath(baseIconPath)
         app.dock?.setIcon(originalIcon)
       }


### PR DESCRIPTION
## Summary

- Guard `app.dock.setIcon()` calls with `!app.isPackaged` so macOS Tahoe can apply Liquid Glass icon tinting to the dock icon
- Fixes startup override in `index.ts` and badge-reset override in `notifications.ts`

Fixes #551

## Test plan

- [ ] Launch packaged app on macOS Tahoe with any icon appearance style (dark, tinted, automatic)
- [ ] Verify dock icon respects the system's chosen tinting
- [ ] Verify dock icon still works correctly in dev mode (`app.isPackaged === false`)
- [ ] Verify badge overlay still functions in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)