### PR TITLE
fix: preserve localhost custom endpoint auth

### DIFF
--- a/packages/server-core/src/domain/connection-setup-logic.test.ts
+++ b/packages/server-core/src/domain/connection-setup-logic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import {
   validateSetupTestInput,
   isLoopbackBaseUrl,
+  resolveCompatPiAuthProvider,
   setupTestRequiresApiKey,
 } from './connection-setup-logic'
 
@@ -43,5 +44,28 @@ describe('setup test API key requirements', () => {
   it('allows keyless setup tests for loopback endpoints', () => {
     expect(setupTestRequiresApiKey('http://localhost:11434/v1')).toBe(false)
     expect(setupTestRequiresApiKey('http://127.0.0.1:11434/v1')).toBe(false)
+  })
+})
+
+describe('resolveCompatPiAuthProvider', () => {
+  it('keeps provider hint for authenticated local OpenAI-compatible endpoints', () => {
+    expect(resolveCompatPiAuthProvider({
+      authType: 'api_key_with_endpoint',
+      customEndpointApi: 'openai-completions',
+    })).toBe('openai')
+  })
+
+  it('keeps provider hint for authenticated local Anthropic-compatible endpoints', () => {
+    expect(resolveCompatPiAuthProvider({
+      authType: 'api_key_with_endpoint',
+      customEndpointApi: 'anthropic-messages',
+    })).toBe('anthropic')
+  })
+
+  it('leaves keyless local endpoints generic', () => {
+    expect(resolveCompatPiAuthProvider({
+      authType: 'none',
+      customEndpointApi: 'openai-completions',
+    })).toBeUndefined()
   })
 })

--- a/packages/server-core/src/domain/connection-setup-logic.ts
+++ b/packages/server-core/src/domain/connection-setup-logic.ts
@@ -91,6 +91,24 @@ export function setupTestRequiresApiKey(baseUrl?: string): boolean {
   return !isLoopbackBaseUrl(baseUrl)
 }
 
+/**
+ * Infer the Pi provider hint for custom endpoint connections.
+ *
+ * Keyless loopback endpoints (Ollama, LM Studio) intentionally stay generic,
+ * but authenticated custom endpoints still need a provider hint so Craft can
+ * reload the stored credential at runtime.
+ */
+export function resolveCompatPiAuthProvider(params: {
+  authType: LlmConnection['authType']
+  customEndpointApi: 'openai-completions' | 'anthropic-messages'
+}): LlmConnection['piAuthProvider'] | undefined {
+  if (params.authType === 'none') {
+    return undefined
+  }
+
+  return params.customEndpointApi === 'anthropic-messages' ? 'anthropic' : 'openai'
+}
+
 // ============================================================
 // Built-in Connection Templates
 // ============================================================

--- a/packages/server-core/src/handlers/rpc/llm-connections.ts
+++ b/packages/server-core/src/handlers/rpc/llm-connections.ts
@@ -8,7 +8,7 @@ import {
   validateStoredBackendConnection,
 } from '@craft-agent/shared/agent/backend'
 import { getModelRefreshService } from '@craft-agent/server-core/model-fetchers'
-import { parseTestConnectionError, createBuiltInConnection, validateModelList, piAuthProviderDisplayName, validateSetupTestInput, setupTestRequiresApiKey, isLoopbackBaseUrl } from '@craft-agent/server-core/domain'
+import { parseTestConnectionError, createBuiltInConnection, validateModelList, piAuthProviderDisplayName, validateSetupTestInput, setupTestRequiresApiKey, isLoopbackBaseUrl, resolveCompatPiAuthProvider } from '@craft-agent/server-core/domain'
 import { getWorkspaceOrThrow, buildBackendHostRuntimeContext } from '@craft-agent/server-core/handlers'
 import { pushTyped, type RpcServer } from '@craft-agent/server-core/transport'
 import type { HandlerDeps } from '../handler-deps'
@@ -109,17 +109,20 @@ export function registerLlmConnectionsHandlers(server: RpcServer, deps: HandlerD
         updates.customEndpoint = customEndpoint
         // Route custom OpenAI/Anthropic-compatible endpoints through PiAgent.
         updates.providerType = 'pi_compat'
-        // Local loopback endpoints (Ollama, LM Studio) don't need API keys.
-        updates.authType = (isLoopbackBaseUrl(setup.baseUrl ?? undefined) && !setup.credential)
+        const authType = (isLoopbackBaseUrl(setup.baseUrl ?? undefined) && !setup.credential)
           ? 'none'
           : 'api_key_with_endpoint'
+        // Local loopback endpoints (Ollama, LM Studio) don't need API keys.
+        updates.authType = authType
+        updates.piAuthProvider = resolveCompatPiAuthProvider({
+          authType,
+          customEndpointApi: customEndpoint.api,
+        })
         if (isLoopbackBaseUrl(setup.baseUrl ?? undefined)) {
           // Local models use the OpenAI protocol but aren't "OpenAI".
-          // Leave piAuthProvider unset → generic icon in the selector.
+          // Keyless local models keep a generic icon; authenticated local proxies
+          // still retain the provider hint so runtime auth can reload their key.
           updates.name = 'Local Model'
-        } else {
-          // Remote custom endpoints: keep provider hint for correct icon.
-          updates.piAuthProvider = customEndpoint.api === 'anthropic-messages' ? 'anthropic' : 'openai'
         }
       } else if (setup.baseUrl !== undefined) {
         // Base URL was explicitly updated without custom protocol config.

--- a/packages/shared/src/agent/__tests__/pi-agent-auth.test.ts
+++ b/packages/shared/src/agent/__tests__/pi-agent-auth.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, mock } from 'bun:test'
+import { resolvePiAuthForConnection, resolvePiAuthProviderFromRuntime } from '../pi-agent.ts'
+
+describe('resolvePiAuthProviderFromRuntime', () => {
+  it('infers OpenAI provider for authenticated custom OpenAI endpoints', () => {
+    expect(resolvePiAuthProviderFromRuntime({
+      customEndpoint: { api: 'openai-completions' },
+    }, 'api_key_with_endpoint')).toBe('openai')
+  })
+
+  it('does not infer provider for keyless custom endpoints', () => {
+    expect(resolvePiAuthProviderFromRuntime({
+      customEndpoint: { api: 'openai-completions' },
+    }, 'none')).toBeNull()
+  })
+})
+
+describe('resolvePiAuthForConnection', () => {
+  it('reuses stored API key for legacy localhost custom endpoint configs missing piAuthProvider', async () => {
+    const getLlmApiKey = mock(async (slug: string) => slug === 'pi-api-key' ? 'sk-888' : null)
+    const getLlmOAuth = mock(async () => null)
+    const getLlmIamCredentials = mock(async () => null)
+
+    const auth = await resolvePiAuthForConnection({
+      authType: 'api_key_with_endpoint',
+      connectionSlug: 'pi-api-key',
+      credentialManager: {
+        getLlmApiKey,
+        getLlmOAuth,
+        getLlmIamCredentials,
+      },
+      runtime: {
+        customEndpoint: { api: 'openai-completions' },
+      },
+    })
+
+    expect(auth).toEqual({
+      provider: 'openai',
+      credential: { type: 'api_key', key: 'sk-888' },
+    })
+    expect(getLlmApiKey).toHaveBeenCalledWith('pi-api-key')
+    expect(getLlmOAuth).not.toHaveBeenCalled()
+    expect(getLlmIamCredentials).not.toHaveBeenCalled()
+  })
+
+  it('keeps keyless localhost custom endpoints unauthenticated', async () => {
+    const getLlmApiKey = mock(async () => 'should-not-be-read')
+    const getLlmOAuth = mock(async () => null)
+    const getLlmIamCredentials = mock(async () => null)
+
+    const auth = await resolvePiAuthForConnection({
+      authType: 'none',
+      connectionSlug: 'local-model',
+      credentialManager: {
+        getLlmApiKey,
+        getLlmOAuth,
+        getLlmIamCredentials,
+      },
+      runtime: {
+        customEndpoint: { api: 'openai-completions' },
+      },
+    })
+
+    expect(auth).toBeNull()
+    expect(getLlmApiKey).not.toHaveBeenCalled()
+  })
+})

--- a/packages/shared/src/agent/pi-agent.ts
+++ b/packages/shared/src/agent/pi-agent.ts
@@ -45,7 +45,7 @@ import { EventQueue } from './backend/event-queue.ts';
 import { getSystemPrompt } from '../prompts/system.ts';
 
 // Credential manager for token storage
-import { getCredentialManager } from '../credentials/manager.ts';
+import { getCredentialManager, type CredentialManager } from '../credentials/manager.ts';
 
 // ChatGPT OAuth token refresh (shared with CodexAgent)
 import { refreshChatGptTokens } from '../auth/chatgpt-oauth.ts';
@@ -108,6 +108,95 @@ export const PI_BACKEND_SESSION_TOOL_NAMES = new Set<string>([
   'spawn_session',
   'browser_tool',
 ]);
+
+type PiAuthCredential =
+  | { type: 'api_key'; key: string }
+  | { type: 'oauth'; access: string; refresh: string; expires: number }
+  | { type: 'iam'; accessKeyId: string; secretAccessKey: string; region?: string; sessionToken?: string }
+
+export interface ResolvedPiAuth {
+  provider: string
+  credential: PiAuthCredential
+}
+
+export function resolvePiAuthProviderFromRuntime(
+  runtime: Pick<ReturnType<typeof getBackendRuntime>, 'customEndpoint' | 'piAuthProvider'>,
+  authType?: BackendConfig['authType'],
+): string | null {
+  if (runtime.piAuthProvider) {
+    return runtime.piAuthProvider
+  }
+
+  if (!runtime.customEndpoint || authType === 'none') {
+    return null
+  }
+
+  return runtime.customEndpoint.api === 'anthropic-messages' ? 'anthropic' : 'openai'
+}
+
+export async function resolvePiAuthForConnection(params: {
+  authType?: BackendConfig['authType']
+  connectionSlug?: string
+  credentialManager: Pick<CredentialManager, 'getLlmApiKey' | 'getLlmOAuth' | 'getLlmIamCredentials'>
+  runtime: Pick<ReturnType<typeof getBackendRuntime>, 'customEndpoint' | 'piAuthProvider'>
+  debug?: (message: string) => void
+}): Promise<ResolvedPiAuth | null> {
+  const piAuthProvider = resolvePiAuthProviderFromRuntime(params.runtime, params.authType)
+  if (!piAuthProvider) return null
+
+  const debug = params.debug ?? (() => {})
+  const slug = params.connectionSlug || 'pi'
+
+  if (params.authType === 'oauth') {
+    const oauth = await params.credentialManager.getLlmOAuth(slug)
+    if (oauth?.accessToken) {
+      if (piAuthProvider === 'github-copilot' && oauth.refreshToken) {
+        debug(`Retrieved Copilot OAuth credential for Pi provider: ${piAuthProvider}`)
+        return {
+          provider: piAuthProvider,
+          credential: {
+            type: 'oauth',
+            access: oauth.accessToken,
+            refresh: oauth.refreshToken,
+            expires: oauth.expiresAt ?? 0,
+          },
+        }
+      }
+      debug(`Retrieved OAuth access token for Pi provider: ${piAuthProvider}`)
+      return {
+        provider: piAuthProvider,
+        credential: { type: 'api_key', key: oauth.accessToken },
+      }
+    }
+  } else if (params.authType === 'iam_credentials') {
+    const iam = await params.credentialManager.getLlmIamCredentials(slug)
+    if (iam) {
+      debug(`Retrieved IAM credentials for Pi provider: ${piAuthProvider}`)
+      return {
+        provider: piAuthProvider,
+        credential: {
+          type: 'iam',
+          accessKeyId: iam.accessKeyId,
+          secretAccessKey: iam.secretAccessKey,
+          region: iam.region,
+          sessionToken: iam.sessionToken,
+        },
+      }
+    }
+  } else {
+    const apiKey = await params.credentialManager.getLlmApiKey(slug)
+    if (apiKey) {
+      debug(`Retrieved API key credential for Pi provider: ${piAuthProvider}`)
+      return {
+        provider: piAuthProvider,
+        credential: { type: 'api_key', key: apiKey },
+      }
+    }
+  }
+
+  debug(`No credentials found for Pi provider: ${piAuthProvider}`)
+  return null
+}
 
 /**
  * Backend implementation using the Pi coding agent SDK via subprocess.
@@ -497,81 +586,15 @@ export class PiAgent extends BaseAgent {
    * modules use directly. The OAuth exchange happens on the Craft side; by the time
    * it reaches Pi, it's just an access token.
    */
-  private async getPiAuth(): Promise<{
-    provider: string;
-    credential:
-      | { type: 'api_key'; key: string }
-      | { type: 'oauth'; access: string; refresh: string; expires: number }
-      | { type: 'iam'; accessKeyId: string; secretAccessKey: string; region?: string; sessionToken?: string }
-  } | null> {
-    const piAuthProvider = getBackendRuntime(this.config).piAuthProvider;
-    if (!piAuthProvider) return null;
-
+  private async getPiAuth(): Promise<ResolvedPiAuth | null> {
     try {
-      const credentialManager = getCredentialManager();
-      const slug = this.config.connectionSlug || 'pi';
-
-      if (this.config.authType === 'oauth') {
-        const oauth = await credentialManager.getLlmOAuth(slug);
-        if (oauth?.accessToken) {
-          // Copilot: pass full OAuth credential so the Pi SDK can derive the
-          // correct API endpoint from the Copilot token's proxy-ep field.
-          // The refresh token is the GitHub access token used to obtain fresh
-          // Copilot tokens when they expire (~1 hour).
-          if (piAuthProvider === 'github-copilot' && oauth.refreshToken) {
-            this.debug(`Retrieved Copilot OAuth credential for Pi provider: ${piAuthProvider}`);
-            return {
-              provider: piAuthProvider,
-              credential: {
-                type: 'oauth',
-                access: oauth.accessToken,
-                refresh: oauth.refreshToken,
-                expires: oauth.expiresAt ?? 0,
-              },
-            };
-          }
-          // Other OAuth providers: pass as api_key (bearer token)
-          this.debug(`Retrieved OAuth access token for Pi provider: ${piAuthProvider}`);
-          return {
-            provider: piAuthProvider,
-            credential: { type: 'api_key', key: oauth.accessToken },
-          };
-        }
-      } else if (this.config.authType === 'iam_credentials') {
-        // AWS IAM credentials — pass structured fields so the subprocess can
-        // identify the credential type. Actual AWS env var injection happens
-        // at spawn time (see spawnSubprocess) for proper process isolation.
-        const iam = await credentialManager.getLlmIamCredentials(slug);
-        if (iam) {
-          this.debug(`Retrieved IAM credentials for Pi provider: ${piAuthProvider}`);
-          return {
-            provider: piAuthProvider,
-            credential: {
-              type: 'iam',
-              accessKeyId: iam.accessKeyId,
-              secretAccessKey: iam.secretAccessKey,
-              region: iam.region,
-              sessionToken: iam.sessionToken,
-            },
-          };
-        }
-      } else {
-        // API key-based connections.
-        // NOTE: authType === 'environment' (e.g. Bedrock with ~/.aws/credentials)
-        // intentionally falls through here, finds no API key, and returns null.
-        // The subprocess inherits process.env which contains the AWS credential chain.
-        const apiKey = await credentialManager.getLlmApiKey(slug);
-        if (apiKey) {
-          this.debug(`Retrieved API key credential for Pi provider: ${piAuthProvider}`);
-          return {
-            provider: piAuthProvider,
-            credential: { type: 'api_key', key: apiKey },
-          };
-        }
-      }
-
-      this.debug(`No credentials found for Pi provider: ${piAuthProvider}`);
-      return null;
+      return await resolvePiAuthForConnection({
+        authType: this.config.authType,
+        connectionSlug: this.config.connectionSlug,
+        credentialManager: getCredentialManager(),
+        runtime: getBackendRuntime(this.config),
+        debug: (message) => this.debug(message),
+      })
     } catch (error) {
       this.debug(`Failed to retrieve Pi auth: ${error}`);
       return null;


### PR DESCRIPTION
## Summary
- preserve `piAuthProvider` for authenticated localhost custom endpoints instead of only remote compat endpoints
- infer provider hints at runtime for legacy custom-endpoint configs so saved API keys are still loaded
- add regression coverage for authenticated vs keyless localhost custom endpoint behavior

## Root cause
Saving a localhost custom endpoint with a credential set `authType=api_key_with_endpoint` but left `piAuthProvider` empty. Pi runtime only loaded provider credentials when that hint was already present, so existing saved keys were skipped and localhost requests fell back to `not-needed`.

## Testing
- bun test packages/server-core/src/domain/connection-setup-logic.test.ts
- bun test packages/shared/src/agent/__tests__/pi-agent-auth.test.ts packages/shared/src/agent/__tests__/pi-agent-bedrock-env.test.ts
- bun test apps/electron/src/main/__tests__/connection-setup-logic.test.ts packages/shared/src/agent/backend/__tests__/factory.test.ts
- cd packages/shared && bun run tsc --noEmit
- cd packages/server-core && bun run tsc --noEmit
