### PR TITLE
fix(electron): left-align wrapped sidebar label text

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -486,7 +486,7 @@ const SidebarButton = React.forwardRef<HTMLButtonElement, SidebarButtonProps & R
         onClick={isOverlay ? undefined : link.onClick}
         data-tutorial={link.dataTutorial}
         className={cn(
-          "group flex w-full items-center gap-2 rounded-[6px] text-[13px] select-none outline-none",
+          "group flex w-full items-center gap-2 rounded-[6px] text-[13px] text-left select-none outline-none",
           "focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
           // Compact mode: 4px less total height (py-[3px] vs py-[5px])
           link.compact ? "py-[3px]" : "py-[5px]",


### PR DESCRIPTION
## Summary

- Add `text-left` to `SidebarButton` to fix centered text when labels wrap in a narrow sidebar
- HTML `<button>` elements default to `text-align: center`, so long labels that wrap to multiple lines appear centered instead of left-aligned

## Test plan

- [ ] Narrow the sidebar until a long label wraps to multiple lines
- [ ] Verify the wrapped text is left-aligned, not centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)