### PR TITLE
fix(electron): enable macOS window tiling menu

### DIFF
--- a/apps/electron/src/main/menu.ts
+++ b/apps/electron/src/main/menu.ts
@@ -179,6 +179,7 @@ export async function rebuildMenu(): Promise<void> {
 
     // Window menu (from shared schema + macOS-specific items)
     {
+      role: 'windowMenu' as const,
       label: i18n.t(WINDOW_MENU.labelKey),
       submenu: [
         ...WINDOW_MENU.items.map(toElectronMenuItem),


### PR DESCRIPTION
## Summary

- Add `role: 'windowMenu'` to the Window menu so macOS recognises it as the system Window menu
- Without this, macOS doesn't inject its native tiling options (Move & Resize), making window tiling unavailable through the standard menu

One-line change. See [Electron MenuItem docs](https://www.electronjs.org/docs/latest/api/menu-item) on the `windowMenu` role.

## Test plan

- [ ] Open the app on macOS Sequoia or Tahoe
- [ ] Check Window menu — should now include Move & Resize / tiling options
- [ ] Verify tiling works as expected (e.g. tile left/right, fill screen)