### PR TITLE
feat: support URL icons in tool-icons.json

### DIFF
--- a/apps/electron/src/renderer/lib/icon-cache.ts
+++ b/apps/electron/src/renderer/lib/icon-cache.ts
@@ -598,7 +598,7 @@ export function useEntityIcon(opts: UseEntityIconOptions): ResolvedEntityIcon {
     let cancelled = false
 
     async function loadIcon() {
-      let result: { dataUrl: string; colorable: boolean; rawSvg?: string } | null = null
+      let result: ResolvedEntityIcon | null = null
 
       if (iconPath) {
         // Known path - extract relative portion and load directly
@@ -703,12 +703,17 @@ function sanitizeSvgForInline(svg: string): string {
  * Determines colorability, sanitizes for inline rendering, and returns a ready-to-render icon.
  */
 export function resolveRawSvgIcon(rawSvg: string, dataUrl: string): ResolvedEntityIcon {
-  const colorable = rawSvg.includes('currentColor')
+  // Normalize to currentColor for theme-aware inline rendering:
+  // strip <style> blocks and replace all hardcoded fill colors with currentColor
+  let svg = rawSvg.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+  svg = svg.replace(/\bfill="(?!none|currentColor)[^"]*"/gi, 'fill="currentColor"')
+
+  const colorable = svg.includes('currentColor')
   return {
     kind: 'file',
     value: dataUrl,
     colorable,
-    rawSvg: colorable ? sanitizeSvgForInline(rawSvg) : undefined,
+    rawSvg: colorable ? sanitizeSvgForInline(svg) : undefined,
   }
 }
 

--- a/apps/electron/src/renderer/lib/icon-cache.ts
+++ b/apps/electron/src/renderer/lib/icon-cache.ts
@@ -618,19 +618,14 @@ export function useEntityIcon(opts: UseEntityIconOptions): ResolvedEntityIcon {
 
       if (result) {
         // Cache the loaded icon and its colorability/rawSvg
-        iconCache.set(cacheKey, result.dataUrl)
+        iconCache.set(cacheKey, result.value!)
         if (result.colorable) {
           colorableCache.add(cacheKey)
         }
         if (result.rawSvg) {
           rawSvgCache.set(cacheKey, result.rawSvg)
         }
-        setResolved({
-          kind: 'file',
-          value: result.dataUrl,
-          colorable: result.colorable,
-          rawSvg: result.rawSvg,
-        })
+        setResolved(result)
       } else {
         setResolved({ kind: 'fallback', colorable: false })
       }
@@ -670,31 +665,18 @@ const rawSvgCache = new Map<string, string>()
 async function loadIconFile(
   workspaceId: string,
   relativePath: string
-): Promise<{ dataUrl: string; colorable: boolean; rawSvg?: string } | null> {
+): Promise<ResolvedEntityIcon | null> {
   try {
     const content = await window.electronAPI.readWorkspaceImage(workspaceId, relativePath)
     // IPC returns null for missing files (silent fallback)
-    if (!content) {
-      return null
-    }
+    if (!content) return null
 
     if (relativePath.endsWith('.svg')) {
-      // Detect if SVG uses currentColor (colorable)
-      const colorable = content.includes('currentColor')
-      // Theme SVG: inject foreground color for data URL usage
-      const dataUrl = svgToThemedDataUrl(content)
-
-      if (colorable) {
-        // Sanitize SVG for inline rendering (XSS prevention)
-        const rawSvg = sanitizeSvgForInline(content)
-        return { dataUrl, colorable, rawSvg }
-      }
-
-      return { dataUrl, colorable }
+      return resolveRawSvgIcon(content, svgToThemedDataUrl(content))
     }
 
     // Raster image (PNG, JPG) - not colorable
-    return { dataUrl: content, colorable: false }
+    return { kind: 'file', value: content, colorable: false }
   } catch {
     // File doesn't exist or failed to load
     return null
@@ -717,6 +699,20 @@ function sanitizeSvgForInline(svg: string): string {
 }
 
 /**
+ * Resolve raw SVG content into a ResolvedEntityIcon.
+ * Determines colorability, sanitizes for inline rendering, and returns a ready-to-render icon.
+ */
+export function resolveRawSvgIcon(rawSvg: string, dataUrl: string): ResolvedEntityIcon {
+  const colorable = rawSvg.includes('currentColor')
+  return {
+    kind: 'file',
+    value: dataUrl,
+    colorable,
+    rawSvg: colorable ? sanitizeSvgForInline(rawSvg) : undefined,
+  }
+}
+
+/**
  * Auto-discover an icon file in a workspace directory.
  * Probes all extensions (.svg, .png, .jpg, .jpeg) in parallel via IPC,
  * then returns the first successful result by priority order.
@@ -727,7 +723,7 @@ async function discoverIconFile(
   workspaceId: string,
   iconDir: string,
   fileName?: string
-): Promise<{ dataUrl: string; colorable: boolean; rawSvg?: string } | null> {
+): Promise<ResolvedEntityIcon | null> {
   const name = fileName ?? 'icon'
 
   // Probe all extensions in parallel — reduces round-trips from N to 1

--- a/apps/electron/src/renderer/pages/settings/AppearanceSettingsPage.tsx
+++ b/apps/electron/src/renderer/pages/settings/AppearanceSettingsPage.tsx
@@ -16,9 +16,12 @@ import { EditPopover, EditButton, getEditConfig } from '@/components/ui/EditPopo
 import { useTheme } from '@/context/ThemeContext'
 import { useAppShellContext } from '@/context/AppShellContext'
 import { routes } from '@/lib/navigate'
-import { Monitor, Sun, Moon } from 'lucide-react'
+import { Monitor, Sun, Moon, Terminal } from 'lucide-react'
 import type { DetailsPageMeta } from '@/lib/navigation-registry'
 import type { ToolIconMapping } from '../../../shared/types'
+import { EntityIcon } from '@/components/ui/entity-icon'
+import { resolveRawSvgIcon } from '@/lib/icon-cache'
+import type { ResolvedEntityIcon } from '@craft-agent/shared/icons'
 
 import {
   SettingsSection,
@@ -51,15 +54,17 @@ const getToolIconColumns = (t: (key: string) => string): ColumnDef<ToolIconMappi
   {
     accessorKey: 'iconDataUrl',
     header: () => <span className="p-1.5 pl-2.5">{t("settings.appearance.iconHeader")}</span>,
-    cell: ({ row }) => (
-      <div className="p-1.5 pl-2.5">
-        <img
-          src={row.original.iconDataUrl}
-          alt={row.original.displayName}
-          className="w-5 h-5 object-contain"
-        />
-      </div>
-    ),
+    cell: ({ row }) => {
+      const { rawSvg, iconDataUrl } = row.original
+      const icon: ResolvedEntityIcon = rawSvg
+        ? resolveRawSvgIcon(rawSvg, iconDataUrl)
+        : { kind: 'file', value: iconDataUrl, colorable: false }
+      return (
+        <div className="p-1.5 pl-2.5">
+          <EntityIcon icon={icon} size="md" fallbackIcon={Terminal} />
+        </div>
+      )
+    },
     size: 60,
     enableSorting: false,
   },

--- a/apps/electron/src/shared/types.ts
+++ b/apps/electron/src/shared/types.ts
@@ -98,6 +98,8 @@ export interface ToolIconMapping {
   displayName: string
   /** Data URL of the icon (e.g., data:image/png;base64,...) */
   iconDataUrl: string
+  /** Sanitized raw SVG for inline rendering (SVG icons only) */
+  rawSvg?: string
   commands: string[]
 }
 

--- a/packages/server-core/src/handlers/rpc/workspace.ts
+++ b/packages/server-core/src/handlers/rpc/workspace.ts
@@ -378,7 +378,8 @@ export function registerWorkspaceCoreHandlers(server: RpcServer, deps: HandlerDe
     const { loadToolIconConfig, findToolIconFile } = await import('@craft-agent/shared/utils/cli-icon-resolver')
     const { encodeIconToDataUrl } = await import('@craft-agent/shared/utils/icon-encoder')
     const { isIconUrl } = await import('@craft-agent/shared/utils/icon-constants')
-    const { join } = await import('path')
+    const { join, extname } = await import('path')
+    const { readFileSync } = await import('fs')
 
     const toolIconsDir = getToolIconsDir()
     const config = loadToolIconConfig(toolIconsDir)
@@ -392,10 +393,18 @@ export function registerWorkspaceCoreHandlers(server: RpcServer, deps: HandlerDe
           : join(toolIconsDir, tool.icon)
         const iconDataUrl = encodeIconToDataUrl(iconPath)
         if (!iconDataUrl) return null
+
+        // For SVGs, include raw content — renderer sanitizes for inline rendering
+        let rawSvg: string | undefined
+        if (iconPath && extname(iconPath).toLowerCase() === '.svg') {
+          try { rawSvg = readFileSync(iconPath, 'utf-8') } catch {}
+        }
+
         return {
           id: tool.id,
           displayName: tool.displayName,
           iconDataUrl,
+          rawSvg,
           commands: tool.commands,
         }
       })

--- a/packages/server-core/src/handlers/rpc/workspace.ts
+++ b/packages/server-core/src/handlers/rpc/workspace.ts
@@ -375,8 +375,9 @@ export function registerWorkspaceCoreHandlers(server: RpcServer, deps: HandlerDe
   // for display in the Appearance settings page
   server.handle(RPC_CHANNELS.toolIcons.GET_MAPPINGS, async () => {
     const { getToolIconsDir } = await import('@craft-agent/shared/config/storage')
-    const { loadToolIconConfig } = await import('@craft-agent/shared/utils/cli-icon-resolver')
+    const { loadToolIconConfig, findToolIconFile } = await import('@craft-agent/shared/utils/cli-icon-resolver')
     const { encodeIconToDataUrl } = await import('@craft-agent/shared/utils/icon-encoder')
+    const { isIconUrl } = await import('@craft-agent/shared/utils/icon-constants')
     const { join } = await import('path')
 
     const toolIconsDir = getToolIconsDir()
@@ -385,7 +386,10 @@ export function registerWorkspaceCoreHandlers(server: RpcServer, deps: HandlerDe
 
     return config.tools
       .map(tool => {
-        const iconPath = join(toolIconsDir, tool.icon)
+        // URL icons are cached locally by ensureToolIcons/ConfigWatcher
+        const iconPath = isIconUrl(tool.icon)
+          ? findToolIconFile(toolIconsDir, tool.id)
+          : join(toolIconsDir, tool.icon)
         const iconDataUrl = encodeIconToDataUrl(iconPath)
         if (!iconDataUrl) return null
         return {

--- a/packages/shared/src/config/storage.ts
+++ b/packages/shared/src/config/storage.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync, statSync } from 'fs';
-import { join, dirname, basename } from 'path';
+import { join, dirname, basename, extname } from 'path';
 import { getCredentialManager } from '../credentials/index.ts';
 import { getOrCreateLatestSession, type SessionConfig } from '../sessions/index.ts';
 import {
@@ -2793,10 +2793,14 @@ export function ensureToolIcons(): void {
     const referencedFiles = new Set(['tool-icons.json']);
     for (const tool of config.tools) {
       if (isIconUrl(tool.icon)) {
-        // Download URL icons if not already cached locally
-        const cached = findToolIconFile(toolIconsDir, tool.id);
-        if (cached) {
-          referencedFiles.add(basename(cached));
+        // Check for the specific file downloadIcon would produce ({toolId}.{ext}).
+        // Uses URL extension or defaults to .svg (CDN icons are typically SVG).
+        // This avoids matching stale bundled files with different extensions (e.g. git.ico).
+        let urlExt: string | null = null;
+        try { urlExt = extname(new URL(tool.icon).pathname).toLowerCase() || null; } catch {}
+        const expectedFile = `${tool.id}${urlExt || '.svg'}`;
+        if (existsSync(join(toolIconsDir, expectedFile))) {
+          referencedFiles.add(expectedFile);
         } else {
           downloadIcon(toolIconsDir, tool.icon, 'ToolIcons', tool.id);
         }

--- a/packages/shared/src/config/storage.ts
+++ b/packages/shared/src/config/storage.ts
@@ -9,7 +9,8 @@ import {
   createWorkspaceAtPath,
   isValidWorkspace,
 } from '../workspaces/storage.ts';
-import { findIconFile } from '../utils/icon.ts';
+import { findIconFile, isIconUrl, downloadIcon } from '../utils/icon.ts';
+import { loadToolIconConfig, findToolIconFile } from '../utils/cli-icon-resolver.ts';
 import { extractWorkspaceSlugFromPath } from '../utils/workspace-slug.ts';
 import { initializeDocs } from '../docs/index.ts';
 import { expandPath, toPortablePath, getBundledAssetsDir } from '../utils/paths.ts';
@@ -2776,15 +2777,44 @@ export function ensureToolIcons(): void {
     return;
   }
 
-  // Copy each bundled file if it doesn't exist in the target dir
-  // This includes tool-icons.json and all icon files (png, ico, svg, jpg)
+  // Seed config and icon files. Only copy bundled icons referenced as local filenames.
+  // URL icons are downloaded and cached locally (same approach as source/skill icons).
   try {
-    const bundledFiles = readdirSync(bundledToolIconsDir);
-    for (const file of bundledFiles) {
-      const destPath = join(toolIconsDir, file);
-      if (!existsSync(destPath)) {
-        const srcPath = join(bundledToolIconsDir, file);
-        copyFileSync(srcPath, destPath);
+    // Seed the config first so we can read it
+    const configDest = join(toolIconsDir, 'tool-icons.json');
+    if (!existsSync(configDest)) {
+      copyFileSync(join(bundledToolIconsDir, 'tool-icons.json'), configDest);
+    }
+
+    const config = loadToolIconConfig(toolIconsDir);
+    if (!config) return;
+
+    // Seed/download icons and track which files are referenced
+    const referencedFiles = new Set(['tool-icons.json']);
+    for (const tool of config.tools) {
+      if (isIconUrl(tool.icon)) {
+        // Download URL icons if not already cached locally
+        const cached = findToolIconFile(toolIconsDir, tool.id);
+        if (cached) {
+          referencedFiles.add(basename(cached));
+        } else {
+          downloadIcon(toolIconsDir, tool.icon, 'ToolIcons', tool.id);
+        }
+      } else {
+        referencedFiles.add(tool.icon);
+        // Copy bundled local icon files if missing
+        const destPath = join(toolIconsDir, tool.icon);
+        if (!existsSync(destPath)) {
+          const srcPath = join(bundledToolIconsDir, tool.icon);
+          if (existsSync(srcPath)) copyFileSync(srcPath, destPath);
+        }
+      }
+    }
+
+    // Remove orphaned icon files no longer referenced by the config
+    for (const file of readdirSync(toolIconsDir)) {
+      if (!referencedFiles.has(file)) {
+        try { rmSync(join(toolIconsDir, file)); } catch { /* ignore */ }
       }
     }
   } catch {

--- a/packages/shared/src/config/watcher.ts
+++ b/packages/shared/src/config/watcher.ts
@@ -16,7 +16,7 @@
  *   - permissions.json
  */
 
-import { watch, existsSync, readdirSync, statSync, readFileSync, mkdirSync } from 'fs';
+import { watch, existsSync, readdirSync, statSync, readFileSync, mkdirSync, rmSync } from 'fs';
 import { join, dirname, basename, relative } from 'path';
 import { platform } from 'os';
 import type { FSWatcher } from 'fs';
@@ -52,7 +52,9 @@ import {
 import { readSessionHeader } from '../sessions/jsonl.ts';
 import type { SessionHeader } from '../sessions/types.ts';
 import { AUTOMATIONS_CONFIG_FILE } from '../automations/constants.ts';
-import { loadAppTheme, loadPresetThemes, loadPresetTheme, getAppThemesDir } from './storage.ts';
+import { loadAppTheme, loadPresetThemes, loadPresetTheme, getAppThemesDir, getToolIconsDir } from './storage.ts';
+import { loadToolIconConfig, findToolIconFile } from '../utils/cli-icon-resolver.ts';
+import { isIconUrl, downloadIcon } from '../utils/icon.ts';
 import type { ThemeOverrides, PresetTheme } from './theme.ts';
 
 // ============================================================
@@ -155,6 +157,10 @@ export interface ConfigWatcherCallbacks {
   // Session callbacks
   /** Called when a session's JSONL header is modified externally (labels, name, flags, etc.) */
   onSessionMetadataChange?: (sessionId: string, header: SessionHeader) => void;
+
+  // Tool icon callbacks
+  /** Called when tool-icons.json changes */
+  onToolIconsChange?: () => void;
 
   // Theme callbacks (app-level only)
   /** Called when app-level theme.json changes */
@@ -285,6 +291,10 @@ export class ConfigWatcher {
     // Watch app-level permissions directory
     this.watchAppPermissionsDir();
     span.mark('watchAppPermissionsDir');
+
+    // Watch tool-icons directory
+    this.watchToolIconsDir();
+    span.mark('watchToolIconsDir');
 
     // Initial scan to populate known sources, skills, and themes
     this.scanSources();
@@ -1036,6 +1046,73 @@ export class ConfigWatcher {
     } catch (error) {
       debug('[ConfigWatcher] Error watching app permissions directory:', error);
     }
+  }
+
+  /**
+   * Watch tool-icons directory (~/.craft-agent/tool-icons/)
+   * Downloads URL icons when tool-icons.json changes.
+   */
+  private watchToolIconsDir(): void {
+    const toolIconsDir = getToolIconsDir();
+
+    if (!existsSync(toolIconsDir)) {
+      mkdirSync(toolIconsDir, { recursive: true });
+    }
+
+    try {
+      const watcher = watch(toolIconsDir, (eventType, filename) => {
+        if (!filename || filename !== 'tool-icons.json') return;
+        this.debounce('tool-icons', () => this.handleToolIconsChange());
+      });
+
+      this.watchers.push(watcher);
+      debug('[ConfigWatcher] Watching tool-icons directory:', toolIconsDir);
+    } catch (error) {
+      debug('[ConfigWatcher] Error watching tool-icons directory:', error);
+    }
+  }
+
+  /**
+   * Handle tool-icons.json change — download URL icons that aren't cached locally
+   */
+  private handleToolIconsChange(): void {
+    const toolIconsDir = getToolIconsDir();
+    const config = loadToolIconConfig(toolIconsDir);
+    if (!config) return;
+
+    // Download URL icons not yet cached locally
+    const referencedFiles = new Set(['tool-icons.json']);
+    for (const tool of config.tools) {
+      if (isIconUrl(tool.icon)) {
+        const cached = findToolIconFile(toolIconsDir, tool.id);
+        if (cached) {
+          referencedFiles.add(basename(cached));
+        } else {
+          debug('[ConfigWatcher] Downloading tool icon:', tool.id);
+          downloadIcon(toolIconsDir, tool.icon, 'ToolIcons', tool.id)
+            .then((iconPath) => {
+              if (iconPath) {
+                debug('[ConfigWatcher] Tool icon downloaded:', tool.id, iconPath);
+              }
+            })
+            .catch((err) => {
+              debug('[ConfigWatcher] Tool icon download failed:', tool.id, err);
+            });
+        }
+      } else {
+        referencedFiles.add(tool.icon);
+      }
+    }
+
+    // Remove orphaned icon files no longer referenced by the config
+    for (const file of readdirSync(toolIconsDir)) {
+      if (!referencedFiles.has(file)) {
+        debug('[ConfigWatcher] Removing orphaned tool icon:', file);
+        try { rmSync(join(toolIconsDir, file)); } catch { /* ignore */ }
+      }
+    }
+
+    this.callbacks.onToolIconsChange?.();
   }
 
   /**

--- a/packages/shared/src/utils/cli-icon-resolver.ts
+++ b/packages/shared/src/utils/cli-icon-resolver.ts
@@ -22,6 +22,7 @@ import { join, basename } from 'path';
 import { parse as shellParse } from 'shell-quote';
 import { encodeIconToDataUrl } from './icon-encoder.ts';
 import { readJsonFileSync } from './files.ts';
+import { isIconUrl, ICON_EXTENSIONS } from './icon-constants.ts';
 
 // ============================================
 // Types
@@ -297,6 +298,20 @@ export function loadToolIconConfig(toolIconsDir: string): ToolIconConfig | null 
 // ============================================
 
 /**
+ * Find a cached icon file for a tool (downloaded from a URL).
+ * Checks for {toolId}.{ext} in the tool-icons directory.
+ */
+export function findToolIconFile(toolIconsDir: string, toolId: string): string | undefined {
+  for (const ext of ICON_EXTENSIONS) {
+    const iconPath = join(toolIconsDir, `${toolId}${ext}`);
+    if (existsSync(iconPath)) {
+      return iconPath;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Builds a lookup map from command name → tool entry for fast resolution.
  * Called once per config load, not per command.
  */
@@ -340,8 +355,10 @@ export function resolveToolIcon(
     const tool = commandMap.get(cmdName);
     if (!tool) continue;
 
-    // Resolve icon file path (icon filename is relative to toolIconsDir)
-    const iconPath = join(toolIconsDir, tool.icon);
+    // URL icons are cached locally by ensureToolIcons/ConfigWatcher
+    const iconPath = isIconUrl(tool.icon)
+      ? findToolIconFile(toolIconsDir, tool.id)
+      : join(toolIconsDir, tool.icon);
     const iconDataUrl = encodeIconToDataUrl(iconPath);
 
     if (iconDataUrl) {


### PR DESCRIPTION
## Summary

Tool icons in `tool-icons.json` currently only support local filenames (e.g. `"icon": "git.ico"`). This adds support for URL values (e.g. `"icon": "https://cdn.simpleicons.org/git/000/fff"`), bringing tool icons in line with how source and skill icons already handle remote assets.

When a tool's icon is a URL, it is downloaded and cached as a local file in the `tool-icons/` directory, keyed by tool ID (e.g. `git.svg`). This means icons are fetched once and served locally from that point on — no repeated network requests during rendering.

The download happens both at startup (via `ensureToolIcons`) and live while the app is running (via a new `ConfigWatcher` handler for `tool-icons.json`). When a tool is removed from the config, its cached icon file is cleaned up automatically.

As part of this change, the startup seeding logic was tightened so that only bundled icon files actually referenced by the config are copied — previously all bundled files were copied unconditionally.

## Changes

- **`cli-icon-resolver.ts`**: Added `findToolIconFile` to locate cached icon files by tool ID. Updated `resolveToolIcon` to check for cached local copies when the icon is a URL.
- **`workspace.ts`**: Same resolution logic applied to the Settings > Appearance > Tool Icons handler so the UI correctly displays URL-based icons.
- **`storage.ts`**: Reworked `ensureToolIcons` to download URL icons on first run, seed only referenced bundled icons, and clean up orphaned files.
- **`watcher.ts`**: Added a file watcher for `tool-icons.json` that downloads new URL icons and removes orphaned files when the config changes at runtime.

## Test plan

Note: `tool-icons.json` is typically edited by the agent on the user's behalf, not manually.

- [ ] Ask the agent to set a tool icon to a URL
- [ ] Verify the icon renders in Settings > Appearance > Tool Icons
- [ ] Verify the icon renders on CLI tool turn cards in chat
- [ ] Confirm the icon file has been downloaded to `~/.craft-agent/tool-icons/`
- [ ] Ask the agent to remove a tool — verify its cached icon file is cleaned up
- [ ] Verify icon changes take effect immediately without restarting the app
- [ ] Verify existing local filename icons continue to work