### PR TITLE
fix: prevent processLines from calling resolve() after promise settles in server-spawner

### DIFF
--- a/apps/cli/src/server-spawner.ts
+++ b/apps/cli/src/server-spawner.ts
@@ -97,6 +97,7 @@ export async function spawnServer(opts?: SpawnServerOptions): Promise<SpawnedSer
     }, startupTimeout)
 
     let url = ''
+    let resolved = false
     let buffer = ''
 
     const processLines = () => {
@@ -110,8 +111,9 @@ export async function spawnServer(opts?: SpawnServerOptions): Promise<SpawnedSer
           // Server echoes the token — we already have it but this confirms ready
         }
         // Once we have the URL, the server is ready
-        if (url) {
+        if (url && !resolved) {
           clearTimeout(timer)
+          resolved = true
           resolve({
             url,
             token,


### PR DESCRIPTION
## Summary

Fixes a bug in `apps/cli/src/server-spawner.ts` where the stdout stream loop continues processing lines after the `spawnServer` promise has already resolved, potentially calling `resolve()` redundantly.

## Change

Added a `resolved` boolean flag:
- `processLines` checks `!resolved` before calling `resolve()`
- Sets `resolved = true` when URL is found, preventing duplicate calls

```ts
let resolved = false
// ...
if (url && !resolved) {
  resolved = true
  clearTimeout(timer)
  resolve({ url, token, stop: ... })
  return
}
```

Closes #561

Signed-off-by: cocoon <54054995+kuishou68@users.noreply.github.com>