### PR TITLE
fix(server-core): resolve symlinks in workspace allowed dirs

### DIFF
--- a/packages/server-core/src/handlers/utils.ts
+++ b/packages/server-core/src/handlers/utils.ts
@@ -1,6 +1,7 @@
 import { normalize, isAbsolute, sep } from 'path'
 import { homedir, tmpdir } from 'os'
 import { realpath } from 'fs/promises'
+import { realpathSync } from 'fs'
 import { getWorkspaceByNameOrId, type Workspace } from '@craft-agent/shared/config'
 import { loadWorkspaceConfig } from '@craft-agent/shared/workspaces'
 import type { PlatformServices } from '../runtime/platform'
@@ -58,9 +59,20 @@ export function getWorkspaceAllowedDirs(workspaceId?: string | null): string[] {
   if (!workspace) return []
 
   const dirs: string[] = [workspace.rootPath]
+  // Resolve symlinks so setups that mount workspaces via symlink (e.g. NFS-backed
+  // Syncthing mirrors) don't fail path validation when realpath() on a session file
+  // resolves outside the symlink path.
+  try {
+    const real = realpathSync(workspace.rootPath)
+    if (real !== workspace.rootPath) dirs.push(real)
+  } catch { /* workspace path may not exist yet */ }
   const config = loadWorkspaceConfig(workspace.rootPath)
   if (config?.defaults?.workingDirectory) {
     dirs.push(config.defaults.workingDirectory)
+    try {
+      const realWd = realpathSync(config.defaults.workingDirectory)
+      if (realWd !== config.defaults.workingDirectory) dirs.push(realWd)
+    } catch { /* ignore */ }
   }
   return dirs
 }


### PR DESCRIPTION
# Fix: `validateFilePath` rejects session files when workspace root is a symlink

## Summary

On my homelab server I run the Craft Agent headless server with the workspace directory symlinked to an NFS mount (so it syncs to other machines via Syncthing). With this layout, any `html-preview`, `pdf-preview`, `image-preview` or `datatable` block with an absolute `src` path under the session folder fails with:

> Failed to read file: Access denied: file path is outside allowed directories

Pasted image attachments render fine (different code path), so the failure is specific to `src`-based file-backed previews.

## Root cause

`packages/server-core/src/handlers/utils.ts → validateFilePath()`:

- Resolves the **target file path** through `realpath()` (so symlinks are followed).
- Compares it against an allow-list containing `homedir()`, `tmpdir()`, `workspace.rootPath`, and `workspace.defaults.workingDirectory` — none of which are realpath'd.

When `workspace.rootPath` is a symlink (e.g. `~/.craft-agent/workspaces/my-workspace → /mnt/nfs/.../my-workspace`), the post-`realpath` file path lives outside every entry in the allow-list and gets rejected.

## Fix

In `getWorkspaceAllowedDirs()`, also push the `realpathSync()` of the workspace rootPath and workingDirectory into the returned dirs. The subsequent comparison in `validateFilePath` then matches.

- Minimal: ~12 lines in one function.
- Safe: only adds a resolved form of directories that are already trusted.
- Sensitive-file regex (`.ssh/`, `.env`, `.pem`, etc.) still applies after the match.

## Test setup

- Debian 12 VM, headless server (v0.8.9) built from `main`.
- Workspace dir is `~/.craft-agent/workspaces/my-workspace` → symlink → NFS mount.
- Before patch: `html-preview` with `src` = absolute session-data path rejected every time.
- After patch + `server:build:subprocess` + `webui:build` + `systemctl restart craft-server`: renders cleanly. Image attachments still render (no regression).

## Notes

Fix developed with AI assistance, reviewed and tested by me on my own install. Happy to iterate on naming / placement if you'd prefer the realpath logic inside `validateFilePath` itself rather than in the dir-builder.
