### PR TITLE
fix(electron): prevent settings controls from stretching on narrow panels

### DIFF
--- a/apps/electron/src/renderer/components/settings/SettingsSegmentedControl.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsSegmentedControl.tsx
@@ -54,7 +54,7 @@ export function SettingsSegmentedControl<T extends string = string>({
   return (
     <div
       role="radiogroup"
-      className={cn('inline-flex gap-1', className)}
+      className={cn('inline-flex flex-wrap gap-1', className)}
     >
       {options.map((option) => {
         const isSelected = option.value === value

--- a/apps/electron/src/renderer/index.css
+++ b/apps/electron/src/renderer/index.css
@@ -1305,13 +1305,13 @@ html.dark[data-scenic] .fullscreen-overlay-background {
 
 /* Settings rows: stack vertically in narrow panels */
 @container panel (max-width: 448px) {
-  [data-layout="settings-row"] {
+  [data-layout="settings-row"]:not(:has(> [data-slot="switch"])) {
     flex-direction: column;
     align-items: stretch;
     gap: 10px;
   }
 
-  [data-layout="settings-row"] > [data-layout="settings-control"] {
+  [data-layout="settings-row"]:not(:has(> [data-slot="switch"])) > [data-layout="settings-control"] {
     width: 100%;
     min-width: 0;
     margin-left: 0;


### PR DESCRIPTION
## Summary
- Toggle switch rows no longer stack vertically on narrow panels — they stay horizontal with the switch on the right
- Segmented controls (mode, font) wrap their buttons when the panel is too narrow for a single row

## Test plan
- [ ] Resize window to narrow width, check Settings > Appearance > Interface toggles stay inline
- [ ] Check Settings > Appearance > Default Theme mode/font controls wrap cleanly at narrow widths
- [ ] Verify wider layouts are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)