### PR TITLE
fix: expand tilde in path before opening with shell (#573)

### DIFF
--- a/apps/electron/src/main/platform.ts
+++ b/apps/electron/src/main/platform.ts
@@ -6,6 +6,7 @@
  */
 
 import type { PlatformServices } from '../runtime/platform'
+import os from 'node:os'
 
 export interface ElectronPlatformOptions {
   app: Electron.App
@@ -27,7 +28,11 @@ export function createElectronPlatform(opts: ElectronPlatformOptions): PlatformS
     isPackaged: app.isPackaged,
     appVersion: app.getVersion(),
     openExternal: (url) => shell.openExternal(url),
-    openPath: (p) => shell.openPath(p).then(() => {}),
+    openPath: (p) => {
+      // Expand ~ to home directory before passing to shell.openPath
+      const expandedPath = p.startsWith('~/') ? p.replace('~', os.homedir()) : p
+      return shell.openPath(expandedPath).then(() => {})
+    },
     showItemInFolder: (p) => shell.showItemInFolder(p),
     quit: () => app.quit(),
     systemDarkMode: () => nativeTheme.shouldUseDarkColors,


### PR DESCRIPTION
Fixes #573

When openPath receives a path starting with ~ (e.g. ~/Downloads), expand it to the actual home directory so shell.openPath can resolve it correctly.