### PR TITLE
feat(electron): render source SVG icons inline for theme-aware coloring

### DIFF
--- a/apps/electron/src/renderer/components/ui/source-avatar.tsx
+++ b/apps/electron/src/renderer/components/ui/source-avatar.tsx
@@ -12,7 +12,7 @@
 import * as React from 'react'
 import { Globe, HardDrive, Mail, Plug } from 'lucide-react'
 import { EntityIcon, type IconComponent } from '@/components/ui/entity-icon'
-import { useEntityIcon, logoUrlCache } from '@/lib/icon-cache'
+import { useEntityIcon, resolveRawSvgIcon, logoUrlCache } from '@/lib/icon-cache'
 import { McpIcon } from '@/components/icons/McpIcon'
 import type { LoadedSource } from '@craft-agent/shared/sources/types'
 import type { IconSize, ResolvedEntityIcon } from '@craft-agent/shared/icons'
@@ -143,13 +143,23 @@ function useFaviconFallback(
 // ============================================================================
 
 export function SourceAvatar({ source, size = 'md', fluid, showStatus, className }: SourceAvatarProps) {
-  const icon = useEntityIcon({
+  // When raw SVG is available (server pre-reads the icon file), resolve it directly
+  // for inline rendering with currentColor normalization — same approach as tool icons.
+  // Falls back to useEntityIcon for non-SVG icons, emojis, and favicon resolution.
+  const rawSvgIcon = React.useMemo<ResolvedEntityIcon | null>(
+    () => source.rawSvg ? resolveRawSvgIcon(source.rawSvg, '') : null,
+    [source.rawSvg]
+  )
+
+  const hookIcon = useEntityIcon({
     workspaceId: source.workspaceId,
     entityType: 'source',
     identifier: source.config.slug,
     iconDir: `sources/${source.config.slug}`,
     iconValue: source.config.icon,
   })
+
+  const icon = rawSvgIcon ?? hookIcon
 
   // Source-specific: favicon as secondary fallback when no local icon found
   const faviconUrl = useFaviconFallback(source, icon)

--- a/packages/shared/src/sources/storage.ts
+++ b/packages/shared/src/sources/storage.ts
@@ -308,8 +308,12 @@ export function loadSource(workspaceRootPath: string, sourceSlug: string): Loade
   // Credentials are keyed by folder name (e.g., "046a02d0-..."), not full path
   const workspaceId = basename(workspaceRootPath);
 
-  // Pre-compute icon path for renderer (avoids fs access in browser)
+  // Pre-compute icon path and raw SVG for renderer (avoids fs access in browser)
   const iconPath = findIconFile(folderPath);
+  let rawSvg: string | undefined;
+  if (iconPath?.endsWith('.svg')) {
+    try { rawSvg = readFileSync(iconPath, 'utf-8'); } catch {}
+  }
 
   return {
     config,
@@ -318,6 +322,7 @@ export function loadSource(workspaceRootPath: string, sourceSlug: string): Loade
     workspaceRootPath,
     workspaceId,
     iconPath,
+    rawSvg,
   };
 }
 

--- a/packages/shared/src/sources/types.ts
+++ b/packages/shared/src/sources/types.ts
@@ -525,6 +525,9 @@ export interface LoadedSource {
    * Computed during source loading so renderer doesn't need filesystem access.
    */
   iconPath?: string;
+
+  /** Raw SVG content for inline rendering (SVG icons only) */
+  rawSvg?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Server pre-reads SVG icon files at source load time (`rawSvg` on `LoadedSource`)
- `SourceAvatar` resolves via `resolveRawSvgIcon` for inline rendering with `currentColor` normalization
- Same approach as tool icons — no changes to `useEntityIcon` or `icon-cache.ts`
- Non-SVG icons, emojis, and favicon fallback unchanged

## Test plan
- [ ] Sources with SVG icons render inline (inspect DOM — should be `<svg>` not `<img>`)
- [ ] Icons inherit text color (toggle light/dark mode)
- [ ] Sources with emoji icons still work
- [ ] Sources without icons fall back to favicon
- [ ] Sources with raster icons (PNG) render as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)