### PR TITLE
Fix title generation language on startup

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -59,8 +59,9 @@ Sentry.init({
 })
 
 // Initialize i18n for main process (menus, dialogs, etc.)
-import { setupI18n, i18n } from '@craft-agent/shared/i18n'
+import { setupI18n, i18n, applyPersistedAppLanguage, persistAppLanguage } from '@craft-agent/shared/i18n'
 setupI18n()
+applyPersistedAppLanguage()
 
 // Set anonymous machine ID for Sentry user tracking (no PII — just a hash).
 // Uses hostname + homedir to produce a stable per-machine identifier.
@@ -871,7 +872,8 @@ app.whenReady().then(async () => {
 
       // Language change: sync from renderer to main process and rebuild native menu
       ipcMain.handle('i18n:changeLanguage', async (_event, lang: string) => {
-        i18n.changeLanguage(lang)
+        persistAppLanguage(lang)
+        await i18n.changeLanguage(lang)
         const { rebuildMenu } = await import('./menu')
         await rebuildMenu()
       })

--- a/packages/server-core/src/sessions/SessionManager.ts
+++ b/packages/server-core/src/sessions/SessionManager.ts
@@ -22,7 +22,7 @@ import { getLlmConnection, getLlmConnections, getDefaultLlmConnection, getDefaul
 import { PrivilegedExecutionBroker } from '@craft-agent/server-core/services'
 import { isValidWorkingDirectory } from '../utils/path-validation'
 import { InitGate } from '@craft-agent/server-core/domain'
-import { i18n, LOCALE_REGISTRY, type LanguageCode } from '@craft-agent/shared/i18n'
+import { LOCALE_REGISTRY, resolveAppLanguage } from '@craft-agent/shared/i18n'
 import {
   getWorkspaces,
   getWorkspaceByNameOrId,
@@ -4315,7 +4315,7 @@ export class SessionManager implements ISessionManager {
     const assistantResponse = lastAssistantMsg?.content ?? ''
 
     // Derive language from app's i18n setting for language-aware title generation
-    const titleLangCode = (i18n.resolvedLanguage ?? 'en') as LanguageCode
+    const titleLangCode = resolveAppLanguage()
     const titleLangEntry = LOCALE_REGISTRY[titleLangCode]
     const titleOptions = { language: titleLangEntry?.nativeName }
 
@@ -6001,7 +6001,7 @@ export class SessionManager implements ISessionManager {
     }
 
     try {
-      const genLangCode = (i18n.resolvedLanguage ?? 'en') as LanguageCode
+      const genLangCode = resolveAppLanguage()
       const genLangEntry = LOCALE_REGISTRY[genLangCode]
       const title = await agent.generateTitle(userMessage, { language: genLangEntry?.nativeName })
       if (title) {

--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -3,3 +3,9 @@ export { SUPPORTED_LANGUAGE_CODES, LANGUAGES } from "./languages";
 export type { LanguageCode, LanguageConfig } from "./languages";
 export { getDateLocale } from "./date-locale";
 export { LOCALE_REGISTRY } from "./registry";
+export {
+  applyPersistedAppLanguage,
+  loadPersistedAppLanguage,
+  persistAppLanguage,
+  resolveAppLanguage,
+} from "./persisted-language";

--- a/packages/shared/src/i18n/persisted-language.ts
+++ b/packages/shared/src/i18n/persisted-language.ts
@@ -1,0 +1,45 @@
+import { existsSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { readJsonFileSync } from '../utils/files.ts';
+import { ensureConfigDir } from '../config/storage.ts';
+import { CONFIG_DIR } from '../config/paths.ts';
+import { i18n } from './setupI18n.ts';
+import { LOCALE_REGISTRY, type LanguageCode } from './registry.ts';
+
+const APP_LANGUAGE_FILE = join(CONFIG_DIR, 'app-language.json');
+
+function isSupportedLanguageCode(value: string): value is LanguageCode {
+  return value in LOCALE_REGISTRY;
+}
+
+export function loadPersistedAppLanguage(): LanguageCode | null {
+  try {
+    if (!existsSync(APP_LANGUAGE_FILE)) return null;
+    const data = readJsonFileSync<{ language?: string }>(APP_LANGUAGE_FILE);
+    const language = data?.language;
+    return language && isSupportedLanguageCode(language) ? language : null;
+  } catch {
+    return null;
+  }
+}
+
+export function persistAppLanguage(language: string): LanguageCode | null {
+  if (!isSupportedLanguageCode(language)) return null;
+  ensureConfigDir();
+  writeFileSync(APP_LANGUAGE_FILE, JSON.stringify({ language }, null, 2), 'utf-8');
+  return language;
+}
+
+export function resolveAppLanguage(defaultLanguage: LanguageCode = 'en'): LanguageCode {
+  const resolved = i18n.resolvedLanguage;
+  if (resolved && isSupportedLanguageCode(resolved)) {
+    return resolved;
+  }
+  return loadPersistedAppLanguage() ?? defaultLanguage;
+}
+
+export function applyPersistedAppLanguage(defaultLanguage: LanguageCode = 'en'): LanguageCode {
+  const language = resolveAppLanguage(defaultLanguage);
+  void i18n.changeLanguage(language);
+  return language;
+}


### PR DESCRIPTION
## Summary
- persist the selected Appearance language for use outside the renderer process
- apply the persisted language when the Electron main process boots
- use the resolved persisted app language for both auto-title generation and manual title regeneration

## Root cause
Session title generation runs from main/server-side session orchestration, but the shared i18n instance in the main process was only updated when the renderer explicitly called `changeLanguage` during the current app session.

On cold start, main-process i18n stayed on the default English fallback, so title generation often resolved the language as English even when the user had already configured a different Appearance language.

## Fix
- add a small shared helper that persists and resolves the selected app language
- load/apply that persisted language during Electron main-process startup
- persist the language whenever the renderer updates Appearance > Language
- switch `SessionManager` title-generation code to resolve language via the shared persisted-language helper instead of directly reading `i18n.resolvedLanguage`

This keeps automatic title generation and manual title regeneration aligned with the configured Appearance language across launches.

## Validation
- `bun run typecheck:shared`
- `cd packages/server-core && bun run tsc --noEmit`

Closes #230
