### PR TITLE
Fix OpenAI streamed tool call replay

### DIFF
--- a/packages/shared/src/__tests__/unified-network-interceptor.sse.test.ts
+++ b/packages/shared/src/__tests__/unified-network-interceptor.sse.test.ts
@@ -12,6 +12,15 @@ let stripMetadataFieldsFromRawJson: typeof import('../unified-network-intercepto
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
+function parseSseData(output: string): unknown[] {
+  return output
+    .split('\n')
+    .filter(line => line.startsWith('data: '))
+    .map(line => line.slice(6))
+    .filter(data => data !== '[DONE]')
+    .map(data => JSON.parse(data));
+}
+
 async function runThroughProcessor(
   processor: TransformStream<Uint8Array, Uint8Array>,
   chunks: string[],
@@ -81,6 +90,142 @@ describe('unified-network-interceptor SSE processors', () => {
     expect(toolMetadataStore.get('call_2', sessionDir)?.displayName).toBe('Display 2');
 
     rmSync(sessionDir, { recursive: true, force: true });
+  });
+
+  it('OpenAI: replays complete multi-tool calls when init chunks precede argument chunks', async () => {
+    const sse = [
+      'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_ls","type":"function","function":{"name":"ls","arguments":""}},{"index":1,"id":"call_find","type":"function","function":{"name":"find","arguments":""}}]}}]}\n\n',
+      'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"path\\":\\".\\",\\"_intent\\":\\"list files\\""}},{"index":1,"function":{"arguments":"{\\"path\\":\\".\\",\\"pattern\\":\\"*.txt\\""}}]}}]}\n\n',
+      'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":",\\"_displayName\\":\\"List Files\\"}"}},{"index":1,"function":{"arguments":",\\"_intent\\":\\"find text\\",\\"_displayName\\":\\"Find Text\\"}"}}]}}]}\n\n',
+      'data: {"choices":[{"index":0,"finish_reason":"tool_calls"}]}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    const out = await runThroughProcessor(createOpenAiSseStrippingStream(), sse);
+    const events = parseSseData(out) as Array<{
+      choices: Array<{
+        delta?: {
+          tool_calls?: Array<{
+            index: number;
+            id: string;
+            type: string;
+            function: { name: string; arguments: string };
+          }>;
+        };
+        finish_reason?: string;
+      }>;
+    }>;
+    const toolCalls = events.flatMap(event => event.choices.flatMap(choice => choice.delta?.tool_calls ?? []));
+
+    expect(toolCalls).toHaveLength(2);
+    expect(toolCalls[0]).toEqual({
+      index: 0,
+      id: 'call_ls',
+      type: 'function',
+      function: { name: 'ls', arguments: '{"path":"."}' },
+    });
+    expect(toolCalls[1]).toEqual({
+      index: 1,
+      id: 'call_find',
+      type: 'function',
+      function: { name: 'find', arguments: '{"path":".","pattern":"*.txt"}' },
+    });
+    expect(out).not.toContain('_intent');
+    expect(out).not.toContain('_displayName');
+    expect(out).not.toContain('"id":""');
+    expect(out).not.toContain('"name":""');
+    expect(events.at(-1)?.choices[0]?.finish_reason).toBe('tool_calls');
+
+    expect(toolMetadataStore.get('call_ls', sessionDir)?.displayName).toBe('List Files');
+    expect(toolMetadataStore.get('call_find', sessionDir)?.intent).toBe('find text');
+  });
+
+  it('OpenAI: strips original tool_calls from finish events after replaying complete calls', async () => {
+    const sse = [
+      'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_finish","type":"function","function":{"name":"finishTool","arguments":"{\\"ok\\":true,\\"_intent\\":\\"finish\\"}"}}]},"finish_reason":"tool_calls"}]}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    const out = await runThroughProcessor(createOpenAiSseStrippingStream(), sse);
+    const events = parseSseData(out) as Array<{
+      choices: Array<{
+        delta?: {
+          tool_calls?: Array<{
+            id: string;
+            function: { name: string; arguments: string };
+          }>;
+        };
+        finish_reason?: string;
+      }>;
+    }>;
+    const toolCalls = events.flatMap(event => event.choices.flatMap(choice => choice.delta?.tool_calls ?? []));
+
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0]?.id).toBe('call_finish');
+    expect(toolCalls[0]?.function.arguments).toBe('{"ok":true}');
+    expect(events.at(-1)?.choices[0]?.finish_reason).toBe('tool_calls');
+    expect(events.at(-1)?.choices[0]?.delta?.tool_calls).toBeUndefined();
+    expect(out).not.toContain('_intent');
+  });
+
+  it('OpenAI: flushes pending complete tool calls before DONE without finish_reason', async () => {
+    const sse = [
+      'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_done","type":"function","function":{"name":"toolDone","arguments":"{\\"ok\\":true,\\"_intent\\":\\"done\\"}"}}]}}]}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    const out = await runThroughProcessor(createOpenAiSseStrippingStream(), sse);
+    const events = parseSseData(out) as Array<{
+      choices: Array<{
+        delta?: {
+          tool_calls?: Array<{
+            id: string;
+            function: { name: string; arguments: string };
+          }>;
+        };
+      }>;
+    }>;
+    expect(events[0]).toBeDefined();
+    expect(events[0]?.choices[0]).toBeDefined();
+    const toolCall = events[0]?.choices[0]?.delta?.tool_calls?.[0];
+
+    expect(toolCall?.id).toBe('call_done');
+    expect(toolCall?.function.name).toBe('toolDone');
+    expect(toolCall?.function.arguments).toBe('{"ok":true}');
+    expect(out.trim().endsWith('data: [DONE]')).toBe(true);
+    expect(toolMetadataStore.get('call_done', sessionDir)?.intent).toBe('done');
+  });
+
+  it('OpenAI: preserves complete tool-call identity when JSON parsing fails', async () => {
+    const sse = [
+      'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_bad","type":"function","function":{"name":"badTool","arguments":"{\\"path\\":"}}]}}]}\n\n',
+      'data: {"choices":[{"index":0,"finish_reason":"tool_calls"}]}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    const out = await runThroughProcessor(createOpenAiSseStrippingStream(), sse);
+    const events = parseSseData(out) as Array<{
+      choices: Array<{
+        delta?: {
+          tool_calls?: Array<{
+            index: number;
+            id: string;
+            type: string;
+            function: { name: string; arguments: string };
+          }>;
+        };
+      }>;
+    }>;
+    expect(events[0]).toBeDefined();
+    expect(events[0]?.choices[0]).toBeDefined();
+    const toolCall = events[0]?.choices[0]?.delta?.tool_calls?.[0];
+
+    expect(toolCall).toEqual({
+      index: 0,
+      id: 'call_bad',
+      type: 'function',
+      function: { name: 'badTool', arguments: '{"path":' },
+    });
   });
 
   it('OpenAI: processes tool calls for multiple choices', async () => {

--- a/packages/shared/src/unified-network-interceptor.ts
+++ b/packages/shared/src/unified-network-interceptor.ts
@@ -739,6 +739,7 @@ const anthropicAdapter: ApiAdapter = {
 interface TrackedToolCall {
   id: string;
   name: string;
+  type: string;
   choiceIndex: number;
   toolIndex: number;
   arguments: string;
@@ -768,45 +769,43 @@ export function createOpenAiSseStrippingStream(): TransformStream<Uint8Array, Ui
     controller.enqueue(encoder.encode(`data: ${dataStr}\n\n`));
   }
 
+  function emitTrackedCall(tc: TrackedToolCall, args: string, controller: TransformStreamDefaultController<Uint8Array>): void {
+    const deltaEvent = {
+      choices: [{
+        index: tc.choiceIndex,
+        delta: {
+          tool_calls: [{
+            index: tc.toolIndex,
+            id: tc.id,
+            type: tc.type || 'function',
+            function: {
+              name: tc.name,
+              arguments: args,
+            },
+          }],
+        },
+      }],
+    };
+    emitSseLine(JSON.stringify(deltaEvent), controller);
+  }
+
   function flushTrackedCalls(controller: TransformStreamDefaultController<Uint8Array>): void {
-    for (const tc of trackedCalls.values()) {
-      if (!tc.arguments) continue;
+    const calls = [...trackedCalls.values()].sort((a, b) => (
+      a.choiceIndex - b.choiceIndex || a.toolIndex - b.toolIndex
+    ));
+
+    for (const tc of calls) {
+      const rawArgs = tc.arguments || '{}';
 
       try {
-        const parsed = JSON.parse(tc.arguments);
+        const parsed = JSON.parse(rawArgs);
         captureMetadataFromInput(tc.id, tc.name, parsed);
         delete parsed._intent;
         delete parsed._displayName;
-        const cleanArgs = JSON.stringify(parsed);
-
-        // Re-emit as a single argument delta with the clean JSON
-        const deltaEvent = {
-          choices: [{
-            index: tc.choiceIndex,
-            delta: {
-              tool_calls: [{
-                index: tc.toolIndex,
-                function: { arguments: cleanArgs },
-              }],
-            },
-          }],
-        };
-        emitSseLine(JSON.stringify(deltaEvent), controller);
+        emitTrackedCall(tc, JSON.stringify(parsed), controller);
       } catch {
         debugLog(`[OpenAI SSE] Failed to parse arguments for ${tc.name} (${tc.id}), passing through`);
-        // Emit original buffered arguments on parse failure
-        const deltaEvent = {
-          choices: [{
-            index: tc.choiceIndex,
-            delta: {
-              tool_calls: [{
-                index: tc.toolIndex,
-                function: { arguments: tc.arguments },
-              }],
-            },
-          }],
-        };
-        emitSseLine(JSON.stringify(deltaEvent), controller);
+        emitTrackedCall(tc, tc.arguments, controller);
       }
     }
     trackedCalls.clear();
@@ -851,7 +850,7 @@ export function createOpenAiSseStrippingStream(): TransformStream<Uint8Array, Ui
 
     let handledToolCalls = false;
 
-    // Buffer tool_call argument deltas (across all choices)
+    // Buffer tool_call deltas (across all choices) and replay complete calls on finish.
     for (const choice of choices) {
       if (!choice?.delta?.tool_calls) continue;
       handledToolCalls = true;
@@ -860,50 +859,26 @@ export function createOpenAiSseStrippingStream(): TransformStream<Uint8Array, Ui
       for (const tc of choice.delta.tool_calls) {
         const toolIndex = tc.index ?? 0;
         const key = `${choiceIndex}:${toolIndex}`;
+        let tracked = trackedCalls.get(key);
 
-        if (tc.id) {
-          // First chunk for a tool call — has id, name, maybe initial args
-          trackedCalls.set(key, {
-            id: tc.id,
-            name: tc.function?.name || 'unknown',
+        if (!tracked) {
+          tracked = {
+            id: '',
+            name: '',
+            type: 'function',
             choiceIndex,
             toolIndex,
-            arguments: tc.function?.arguments || '',
-          });
-          bufferingToolCalls = true;
-
-          // Emit the initial tool_call event WITHOUT arguments (preserves id/name/type)
-          const initEvent = {
-            ...data,
-            choices: [{
-              ...choice,
-              delta: {
-                ...choice.delta,
-                tool_calls: [{
-                  ...tc,
-                  function: {
-                    name: tc.function?.name,
-                    // Omit arguments from initial event — we'll emit clean args on flush
-                    arguments: '',
-                  },
-                }],
-              },
-            }],
+            arguments: '',
           };
-          emitSseLine(JSON.stringify(initEvent), controller);
-        } else {
-          // Subsequent argument delta — buffer and suppress
-          const existing = trackedCalls.get(key);
-          if (existing && tc.function?.arguments) {
-            existing.arguments += tc.function.arguments;
-          }
+          trackedCalls.set(key, tracked);
         }
-      }
-    }
 
-    // Suppress original tool_call delta payloads (we re-emit cleaned payloads later)
-    if (handledToolCalls) {
-      return;
+        if (tc.id) tracked.id = tc.id;
+        if (tc.type) tracked.type = tc.type;
+        if (tc.function?.name) tracked.name = tc.function.name;
+        if (tc.function?.arguments) tracked.arguments += tc.function.arguments;
+        bufferingToolCalls = true;
+      }
     }
 
     // On finish, flush buffered tool calls with clean args BEFORE emitting finish event
@@ -912,7 +887,22 @@ export function createOpenAiSseStrippingStream(): TransformStream<Uint8Array, Ui
       if (bufferingToolCalls) {
         flushTrackedCalls(controller);
       }
-      emitSseLine(dataStr, controller);
+      const finishEvent = handledToolCalls
+        ? {
+          ...data,
+          choices: choices.map(choice => {
+            if (!choice?.delta?.tool_calls) return choice;
+            const { tool_calls: _toolCalls, ...delta } = choice.delta;
+            return { ...choice, delta };
+          }),
+        }
+        : data;
+      emitSseLine(JSON.stringify(finishEvent), controller);
+      return;
+    }
+
+    // Suppress original tool_call delta payloads (we re-emit cleaned payloads later)
+    if (handledToolCalls) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- Buffer OpenAI-compatible streamed tool call deltas while stripping Craft metadata.
- Replay each completed tool call as a complete delta containing index, id, type, name, and cleaned arguments.
- Add regressions for multi-tool streaming, DONE flushing, finish-event replay, and malformed JSON fallback.

## Linked issues
- Fixes #612
- Refs #609
- Refs #613

## Test plan
- `bun test packages/shared/src/__tests__/unified-network-interceptor.sse.test.ts`
- `cd packages/shared && bun run tsc --noEmit`