### PR TITLE
[codex] Fix Telegram MarkdownV2 rendering

### DIFF
--- a/packages/messaging-gateway/src/adapters/telegram/format.test.ts
+++ b/packages/messaging-gateway/src/adapters/telegram/format.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  escapeTelegramMarkdown,
+  formatForTelegram,
+  formatPlainTextForTelegram,
+} from './format'
+
+describe('formatForTelegram', () => {
+  it('renders headings as bold Telegram MarkdownV2 lines', () => {
+    expect(formatForTelegram('# Release Notes')).toBe('*Release Notes*')
+  })
+
+  it('renders common inline Markdown entities', () => {
+    expect(formatForTelegram('Hello **bold** and _em_ ~~gone~~.')).toBe(
+      'Hello *bold* and _em_ ~gone~\\.',
+    )
+  })
+
+  it('escapes raw Telegram MarkdownV2 punctuation in plain text', () => {
+    expect(formatForTelegram('snake_case (x) #1!')).toBe(
+      'snake\\_case \\(x\\) \\#1\\!',
+    )
+  })
+
+  it('renders unordered and ordered lists with escaped markers', () => {
+    expect(formatForTelegram('- first item\n- a_b')).toBe(
+      '\\- first item\n\\- a\\_b',
+    )
+    expect(formatForTelegram('2. first\n3. second')).toBe(
+      '2\\. first\n3\\. second',
+    )
+  })
+
+  it('renders inline links and escapes closing parens in URLs', () => {
+    expect(formatForTelegram('[Open](<https://example.com/a)b>)')).toBe(
+      '[Open](https://example.com/a\\)b)',
+    )
+  })
+
+  it('renders inline and fenced code without escaping normal code punctuation', () => {
+    expect(formatForTelegram('Use `a_b()` now.')).toBe('Use `a_b()` now\\.')
+    expect(formatForTelegram('```ts\nconst value = `x_y`;\n```')).toBe(
+      '```ts\nconst value = \\`x_y\\`;\n```',
+    )
+  })
+
+  it('renders blockquotes using Telegram MarkdownV2 quote markers', () => {
+    expect(formatForTelegram('> quoted #1')).toBe('>quoted \\#1')
+  })
+})
+
+describe('formatPlainTextForTelegram', () => {
+  it('escapes source Markdown so fallback messages remain plain text', () => {
+    expect(formatPlainTextForTelegram('**bold**')).toBe('\\*\\*bold\\*\\*')
+  })
+})
+
+describe('escapeTelegramMarkdown', () => {
+  it('escapes every Telegram MarkdownV2 special character', () => {
+    expect(escapeTelegramMarkdown('_*[]()~`>#+-=|{}.!\\')).toBe(
+      '\\_\\*\\[\\]\\(\\)\\~\\`\\>\\#\\+\\-\\=\\|\\{\\}\\.\\!\\\\',
+    )
+  })
+})

--- a/packages/messaging-gateway/src/adapters/telegram/format.ts
+++ b/packages/messaging-gateway/src/adapters/telegram/format.ts
@@ -1,22 +1,216 @@
 /**
- * Markdown → Telegram MarkdownV2 formatting.
+ * Markdown -> Telegram MarkdownV2 formatting.
  *
- * Telegram MarkdownV2 requires escaping special characters outside of
- * code blocks. For Phase 1 we send plain text — formatting added in Phase 2.
+ * Telegram MarkdownV2 is not CommonMark. We parse common Markdown with marked,
+ * then render only the entity forms Telegram supports and escape everything
+ * else as plain text.
  */
+
+import { lexer, type Token, type Tokens } from 'marked'
 
 /** Characters that must be escaped in Telegram MarkdownV2. */
 const TG_SPECIAL_CHARS = /([_*\[\]()~`>#+\-=|{}.!\\])/g
+const TG_CODE_CHARS = /([`\\])/g
+const TG_LINK_URL_CHARS = /([)\\])/g
+const TG_LANGUAGE_CHARS = /[^A-Za-z0-9_-]/g
 
 /** Escape text for Telegram MarkdownV2 parse mode. */
 export function escapeTelegramMarkdown(text: string): string {
   return text.replace(TG_SPECIAL_CHARS, '\\$1')
 }
 
-/**
- * For Phase 1 we send plain text (no parse_mode).
- * This avoids escaping issues while we validate the core flow.
- */
+/** Escape source text as plain MarkdownV2 without preserving Markdown styling. */
+export function formatPlainTextForTelegram(text: string): string {
+  return escapeTelegramMarkdown(text)
+}
+
+/** Convert common Markdown into Telegram MarkdownV2. */
 export function formatForTelegram(text: string): string {
-  return text
+  if (!text) return ''
+  const tokens = lexer(text, { gfm: true, breaks: false })
+  return renderBlockTokens(tokens).trim()
+}
+
+/** Escape content inside Telegram code/pre entities. */
+function escapeTelegramCode(text: string): string {
+  return text.replace(TG_CODE_CHARS, '\\$1')
+}
+
+/** Escape the URL portion of a Telegram MarkdownV2 inline link. */
+function escapeTelegramLinkUrl(url: string): string {
+  return url.replace(TG_LINK_URL_CHARS, '\\$1')
+}
+
+function renderBlockTokens(tokens: readonly Token[]): string {
+  const blocks: string[] = []
+
+  for (const token of tokens) {
+    const rendered = renderBlockToken(token).trimEnd()
+    if (rendered) blocks.push(rendered)
+  }
+
+  return blocks.join('\n\n').replace(/\n{3,}/g, '\n\n')
+}
+
+function renderBlockToken(token: Token): string {
+  switch (token.type) {
+    case 'space':
+      return ''
+    case 'heading':
+      return renderHeading(token as Tokens.Heading)
+    case 'paragraph':
+      return renderInlineTokens((token as Tokens.Paragraph).tokens ?? [])
+    case 'blockquote':
+      return renderBlockquote(token as Tokens.Blockquote)
+    case 'list':
+      return renderList(token as Tokens.List)
+    case 'code':
+      return renderCodeBlock(token as Tokens.Code)
+    case 'hr':
+      return escapeTelegramMarkdown('---')
+    case 'html':
+      return escapeTelegramMarkdown(token.text)
+    case 'table':
+      return renderTable(token as Tokens.Table)
+    case 'text':
+      return token.tokens ? renderInlineTokens(token.tokens) : escapeTelegramMarkdown(token.text)
+    default:
+      return renderUnknownToken(token)
+  }
+}
+
+function renderInlineTokens(tokens: readonly Token[]): string {
+  return tokens.map(renderInlineToken).join('')
+}
+
+function renderInlineToken(token: Token): string {
+  switch (token.type) {
+    case 'text':
+      return token.tokens ? renderInlineTokens(token.tokens) : escapeTelegramMarkdown(token.text)
+    case 'escape':
+      return escapeTelegramMarkdown(token.text)
+    case 'strong':
+      return `*${renderInlineTokens((token as Tokens.Strong).tokens ?? [])}*`
+    case 'em':
+      return `_${renderInlineTokens((token as Tokens.Em).tokens ?? [])}_`
+    case 'del':
+      return `~${renderInlineTokens((token as Tokens.Del).tokens ?? [])}~`
+    case 'codespan':
+      return `\`${escapeTelegramCode(token.text)}\``
+    case 'br':
+      return '\n'
+    case 'link':
+      return renderLink(token as Tokens.Link)
+    case 'image':
+      return renderImage(token as Tokens.Image)
+    case 'html':
+      return escapeTelegramMarkdown(token.text)
+    default:
+      return renderUnknownToken(token)
+  }
+}
+
+function renderHeading(token: Tokens.Heading): string {
+  const text = renderPlainInlineTokens(token.tokens || [])
+  return text ? `*${text}*` : ''
+}
+
+function renderBlockquote(token: Tokens.Blockquote): string {
+  const body = renderBlockTokens(token.tokens).trim()
+  if (!body) return ''
+  return body
+    .split('\n')
+    .map((line) => `>${line}`)
+    .join('\n')
+}
+
+function renderList(token: Tokens.List): string {
+  const start = typeof token.start === 'number' ? token.start : 1
+
+  return token.items
+    .map((item, index) => {
+      const marker = token.ordered ? `${start + index}\\.` : '\\-'
+      const body = renderListItem(item)
+      if (!body) return marker
+
+      const lines = body.split('\n')
+      const [first = '', ...rest] = lines
+      const continuation = rest.map((line) => `  ${line}`).join('\n')
+      return continuation ? `${marker} ${first}\n${continuation}` : `${marker} ${first}`
+    })
+    .join('\n')
+}
+
+function renderListItem(item: Tokens.ListItem): string {
+  const body = renderBlockTokens(item.tokens).trim()
+  if (!item.task) return body
+
+  const checkbox = item.checked ? '\\[x\\]' : '\\[ \\]'
+  return body ? `${checkbox} ${body}` : checkbox
+}
+
+function renderCodeBlock(token: Tokens.Code): string {
+  const lang = (token.lang ?? '').replace(TG_LANGUAGE_CHARS, '')
+  const opener = lang ? `\`\`\`${lang}` : '```'
+  const body = escapeTelegramCode(token.text.replace(/\n$/, ''))
+  return `${opener}\n${body}\n\`\`\``
+}
+
+function renderLink(token: Tokens.Link): string {
+  const label = renderInlineTokens(token.tokens).trim() || escapeTelegramMarkdown(token.href)
+  if (!token.href) return label
+  return `[${label}](${escapeTelegramLinkUrl(token.href)})`
+}
+
+function renderImage(token: Tokens.Image): string {
+  const label = escapeTelegramMarkdown(token.text || token.href)
+  if (!token.href) return label
+  return `[${label}](${escapeTelegramLinkUrl(token.href)})`
+}
+
+function renderTable(token: Tokens.Table): string {
+  const rows = [token.header, ...token.rows]
+  return rows
+    .map((row) => row.map((cell) => renderInlineTokens(cell.tokens)).join(' \\| '))
+    .join('\n')
+}
+
+function renderUnknownToken(token: Token): string {
+  const maybeTokens = (token as { tokens?: Token[] }).tokens
+  if (maybeTokens) return renderInlineTokens(maybeTokens)
+
+  const maybeText = (token as { text?: unknown }).text
+  if (typeof maybeText === 'string') return escapeTelegramMarkdown(maybeText)
+
+  return escapeTelegramMarkdown(token.raw ?? '')
+}
+
+function renderPlainInlineTokens(tokens: readonly Token[]): string {
+  return tokens.map(renderPlainInlineToken).join('')
+}
+
+function renderPlainInlineToken(token: Token): string {
+  switch (token.type) {
+    case 'text':
+      return token.tokens ? renderPlainInlineTokens(token.tokens) : escapeTelegramMarkdown(token.text)
+    case 'escape':
+      return escapeTelegramMarkdown(token.text)
+    case 'strong':
+    case 'em':
+    case 'del':
+      return renderPlainInlineTokens((token as Tokens.Strong | Tokens.Em | Tokens.Del).tokens ?? [])
+    case 'codespan':
+      return escapeTelegramMarkdown(token.text)
+    case 'br':
+      return '\n'
+    case 'link':
+      return renderPlainInlineTokens((token as Tokens.Link).tokens ?? []) ||
+        escapeTelegramMarkdown((token as Tokens.Link).href)
+    case 'image':
+      return escapeTelegramMarkdown(token.text || token.href)
+    case 'html':
+      return escapeTelegramMarkdown(token.text)
+    default:
+      return renderUnknownToken(token)
+  }
 }

--- a/packages/messaging-gateway/src/adapters/telegram/index.ts
+++ b/packages/messaging-gateway/src/adapters/telegram/index.ts
@@ -20,7 +20,7 @@ import type {
   ButtonPress,
   MessagingLogger,
 } from '../../types'
-import { formatForTelegram } from './format'
+import { formatForTelegram, formatPlainTextForTelegram } from './format'
 
 /**
  * Hard cap for downloaded attachment size. Matches `MAX_FILE_SIZE` in
@@ -48,6 +48,8 @@ const MIME_EXT_FALLBACK: Record<string, string> = {
   'video/mp4': '.mp4',
   'video/quicktime': '.mov',
 }
+
+const TELEGRAM_PARSE_MODE = 'MarkdownV2' as const
 
 const NOOP_LOGGER: MessagingLogger = {
   info: () => {},
@@ -98,6 +100,46 @@ function describeError(err: unknown, depth = 0): Record<string, unknown> {
   }
   if (err && typeof err === 'object') return { value: String(err), raw: err as object }
   return { value: String(err) }
+}
+
+function collectErrorMessages(err: unknown, depth = 0): string[] {
+  if (depth > 3 || err == null) return []
+
+  if (typeof err === 'string') return [err]
+
+  if (err instanceof Error) {
+    const messages = [err.message]
+    const grammyInner = (err as { error?: unknown }).error
+    const cause = (err as { cause?: unknown }).cause
+    messages.push(...collectErrorMessages(grammyInner, depth + 1))
+    messages.push(...collectErrorMessages(cause, depth + 1))
+    return messages
+  }
+
+  if (typeof err === 'object') {
+    const record = err as Record<string, unknown>
+    const messages: string[] = []
+    for (const key of ['message', 'description', 'error']) {
+      const value = record[key]
+      if (typeof value === 'string') {
+        messages.push(value)
+      } else {
+        messages.push(...collectErrorMessages(value, depth + 1))
+      }
+    }
+    return messages
+  }
+
+  return []
+}
+
+function isTelegramEntityParseError(err: unknown): boolean {
+  return collectErrorMessages(err).some((message) => {
+    const lower = message.toLowerCase()
+    return lower.includes("can't parse entities") ||
+      lower.includes('cant parse entities') ||
+      lower.includes('parse entities')
+  })
 }
 
 /**
@@ -504,7 +546,17 @@ export class TelegramAdapter implements PlatformAdapter {
   async sendText(channelId: string, text: string): Promise<SentMessage> {
     if (!this.bot) throw new Error('Telegram adapter not initialized')
     const formatted = formatForTelegram(text)
-    const sent = await this.bot.api.sendMessage(Number(channelId), formatted)
+    let sent
+    try {
+      sent = await this.bot.api.sendMessage(Number(channelId), formatted, {
+        parse_mode: TELEGRAM_PARSE_MODE,
+      })
+    } catch (err) {
+      if (!isTelegramEntityParseError(err)) throw err
+      sent = await this.bot.api.sendMessage(Number(channelId), formatPlainTextForTelegram(text), {
+        parse_mode: TELEGRAM_PARSE_MODE,
+      })
+    }
     return {
       platform: 'telegram',
       channelId,
@@ -515,7 +567,19 @@ export class TelegramAdapter implements PlatformAdapter {
   async editMessage(channelId: string, messageId: string, text: string): Promise<void> {
     if (!this.bot) throw new Error('Telegram adapter not initialized')
     const formatted = formatForTelegram(text)
-    await this.bot.api.editMessageText(Number(channelId), Number(messageId), formatted)
+    try {
+      await this.bot.api.editMessageText(Number(channelId), Number(messageId), formatted, {
+        parse_mode: TELEGRAM_PARSE_MODE,
+      })
+    } catch (err) {
+      if (!isTelegramEntityParseError(err)) throw err
+      await this.bot.api.editMessageText(
+        Number(channelId),
+        Number(messageId),
+        formatPlainTextForTelegram(text),
+        { parse_mode: TELEGRAM_PARSE_MODE },
+      )
+    }
   }
 
   async sendButtons(channelId: string, text: string, buttons: InlineButton[]): Promise<SentMessage> {
@@ -528,9 +592,20 @@ export class TelegramAdapter implements PlatformAdapter {
       }]),
     }
 
-    const sent = await this.bot.api.sendMessage(Number(channelId), text, {
-      reply_markup: keyboard,
-    })
+    const formatted = formatForTelegram(text)
+    let sent
+    try {
+      sent = await this.bot.api.sendMessage(Number(channelId), formatted, {
+        parse_mode: TELEGRAM_PARSE_MODE,
+        reply_markup: keyboard,
+      })
+    } catch (err) {
+      if (!isTelegramEntityParseError(err)) throw err
+      sent = await this.bot.api.sendMessage(Number(channelId), formatPlainTextForTelegram(text), {
+        parse_mode: TELEGRAM_PARSE_MODE,
+        reply_markup: keyboard,
+      })
+    }
 
     return {
       platform: 'telegram',
@@ -547,8 +622,28 @@ export class TelegramAdapter implements PlatformAdapter {
   async sendFile(channelId: string, file: Buffer, filename: string, caption?: string): Promise<SentMessage> {
     if (!this.bot) throw new Error('Telegram adapter not initialized')
 
-    const inputFile = new InputFile(file, filename)
-    const sent = await this.bot.api.sendDocument(Number(channelId), inputFile, { caption })
+    const sendDocument = (formattedCaption?: string) => {
+      const inputFile = new InputFile(file, filename)
+      return this.bot!.api.sendDocument(
+        Number(channelId),
+        inputFile,
+        formattedCaption
+          ? {
+              caption: formattedCaption,
+              parse_mode: TELEGRAM_PARSE_MODE,
+            }
+          : undefined,
+      )
+    }
+
+    let sent
+    const formattedCaption = caption ? formatForTelegram(caption) : undefined
+    try {
+      sent = await sendDocument(formattedCaption)
+    } catch (err) {
+      if (!caption || !isTelegramEntityParseError(err)) throw err
+      sent = await sendDocument(formatPlainTextForTelegram(caption))
+    }
 
     return {
       platform: 'telegram',

--- a/packages/messaging-gateway/src/adapters/telegram/send-format.test.ts
+++ b/packages/messaging-gateway/src/adapters/telegram/send-format.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'bun:test'
+import { TelegramAdapter } from './index'
+import { formatPlainTextForTelegram } from './format'
+
+interface ApiCall {
+  method: 'sendMessage' | 'editMessageText' | 'sendDocument'
+  chatId: number
+  messageId?: number
+  text?: string
+  other?: Record<string, unknown>
+}
+
+interface FakeTelegramApi {
+  sendMessage?: (
+    chatId: number,
+    text: string,
+    other?: Record<string, unknown>,
+  ) => Promise<{ message_id: number }>
+  editMessageText?: (
+    chatId: number,
+    messageId: number,
+    text: string,
+    other?: Record<string, unknown>,
+  ) => Promise<unknown>
+  sendDocument?: (
+    chatId: number,
+    document: unknown,
+    other?: Record<string, unknown>,
+  ) => Promise<{ message_id: number }>
+}
+
+function makeAdapter(api: FakeTelegramApi): TelegramAdapter {
+  const adapter = new TelegramAdapter()
+  ;(adapter as unknown as { bot: { api: FakeTelegramApi; token: string } }).bot = {
+    api,
+    token: 'TEST_TOKEN',
+  }
+  return adapter
+}
+
+function entityParseError(): Error {
+  const err = new Error("Bad Request: can't parse entities: Character '*' is reserved")
+  ;(err as Error & { description: string; error_code: number }).description =
+    "Bad Request: can't parse entities: Character '*' is reserved"
+  ;(err as Error & { description: string; error_code: number }).error_code = 400
+  return err
+}
+
+describe('TelegramAdapter MarkdownV2 sending', () => {
+  it('passes parse_mode for text messages', async () => {
+    const calls: ApiCall[] = []
+    const adapter = makeAdapter({
+      async sendMessage(chatId, text, other) {
+        calls.push({ method: 'sendMessage', chatId, text, other })
+        return { message_id: 1 }
+      },
+    })
+
+    await adapter.sendText('42', '**bold**')
+
+    expect(calls).toEqual([
+      {
+        method: 'sendMessage',
+        chatId: 42,
+        text: '*bold*',
+        other: { parse_mode: 'MarkdownV2' },
+      },
+    ])
+  })
+
+  it('passes parse_mode for message edits', async () => {
+    const calls: ApiCall[] = []
+    const adapter = makeAdapter({
+      async editMessageText(chatId, messageId, text, other) {
+        calls.push({ method: 'editMessageText', chatId, messageId, text, other })
+        return true
+      },
+    })
+
+    await adapter.editMessage('42', '7', '_done_')
+
+    expect(calls).toEqual([
+      {
+        method: 'editMessageText',
+        chatId: 42,
+        messageId: 7,
+        text: '_done_',
+        other: { parse_mode: 'MarkdownV2' },
+      },
+    ])
+  })
+
+  it('passes parse_mode alongside inline keyboards', async () => {
+    const calls: ApiCall[] = []
+    const adapter = makeAdapter({
+      async sendMessage(chatId, text, other) {
+        calls.push({ method: 'sendMessage', chatId, text, other })
+        return { message_id: 2 }
+      },
+    })
+
+    await adapter.sendButtons('42', '# Plan', [{ id: 'accept', label: 'Accept' }])
+
+    expect(calls).toEqual([
+      {
+        method: 'sendMessage',
+        chatId: 42,
+        text: '*Plan*',
+        other: {
+          parse_mode: 'MarkdownV2',
+          reply_markup: {
+            inline_keyboard: [[{ text: 'Accept', callback_data: 'accept' }]],
+          },
+        },
+      },
+    ])
+  })
+
+  it('passes parse_mode for document captions', async () => {
+    const calls: ApiCall[] = []
+    const adapter = makeAdapter({
+      async sendDocument(chatId, _document, other) {
+        calls.push({ method: 'sendDocument', chatId, other })
+        return { message_id: 3 }
+      },
+    })
+
+    await adapter.sendFile('42', Buffer.from('hello'), 'hello.txt', '**Full plan**')
+
+    expect(calls).toEqual([
+      {
+        method: 'sendDocument',
+        chatId: 42,
+        other: {
+          caption: '*Full plan*',
+          parse_mode: 'MarkdownV2',
+        },
+      },
+    ])
+  })
+
+  it('retries entity parse failures as escaped plain text', async () => {
+    const calls: ApiCall[] = []
+    let attempt = 0
+    const adapter = makeAdapter({
+      async sendMessage(chatId, text, other) {
+        calls.push({ method: 'sendMessage', chatId, text, other })
+        attempt += 1
+        if (attempt === 1) throw entityParseError()
+        return { message_id: 4 }
+      },
+    })
+
+    await adapter.sendText('42', '**bold**')
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0]?.text).toBe('*bold*')
+    expect(calls[1]).toEqual({
+      method: 'sendMessage',
+      chatId: 42,
+      text: formatPlainTextForTelegram('**bold**'),
+      other: { parse_mode: 'MarkdownV2' },
+    })
+  })
+
+  it('does not retry non-entity Telegram failures', async () => {
+    const adapter = makeAdapter({
+      async sendMessage() {
+        throw new Error('Forbidden: bot was blocked by the user')
+      },
+    })
+
+    await expect(adapter.sendText('42', '**bold**')).rejects.toThrow('Forbidden')
+  })
+})

--- a/scripts/build-wa-worker.ts
+++ b/scripts/build-wa-worker.ts
@@ -4,28 +4,17 @@
  * Bundles the Baileys-backed WhatsApp subprocess into a single CJS file at
  * packages/messaging-whatsapp-worker/dist/worker.cjs.
  *
- * Baileys is bundled INTO the output (not marked external) so the packaged
- * app ships a self-contained worker — users don't have to install anything.
- * The dynamic import at runtime still works because esbuild resolves literal
- * dynamic-import strings at bundle time.
- *
- * The worker is spawned as a Node subprocess by the WhatsAppAdapter:
- *   - Electron: re-enters its embedded Node via ELECTRON_RUN_AS_NODE=1.
- *   - Headless/Bun server: spawns a system `node` binary (Bun cannot run the
- *     CJS worker because Baileys' crypto deps depend on Node's runtime).
- * That's why we emit CJS + platform=node — it must stay Node-compatible.
+ * Baileys is bundled into the output so the packaged app ships a
+ * self-contained worker. The dynamic import at runtime still works because
+ * esbuild resolves literal dynamic-import strings at bundle time.
  */
 
 import { spawn } from "bun";
 import { execSync } from "child_process";
 import { existsSync, mkdirSync, statSync } from "fs";
 import { join } from "path";
+import * as esbuild from "esbuild";
 
-/**
- * Resolve a short git SHA for the build, suffixed with `+dirty` when the
- * working tree has uncommitted changes. Returns `unknown` outside a git
- * checkout.
- */
 function resolveGitSha(cwd: string): string {
   try {
     const sha = execSync("git rev-parse --short HEAD", { cwd }).toString().trim();
@@ -34,7 +23,7 @@ function resolveGitSha(cwd: string): string {
       const status = execSync("git status --porcelain", { cwd }).toString().trim();
       dirty = status.length > 0;
     } catch {
-      // ignore — treat as clean
+      // Treat status failures as clean so build provenance remains best-effort.
     }
     return dirty ? `${sha}+dirty` : sha;
   } catch {
@@ -66,7 +55,7 @@ async function verifyJsFile(filePath: string): Promise<{ valid: boolean; error?:
 
 async function main(): Promise<void> {
   if (!existsSync(SOURCE)) {
-    console.error("❌ WhatsApp worker source not found at", SOURCE);
+    console.error("WhatsApp worker source not found at", SOURCE);
     process.exit(1);
   }
 
@@ -76,56 +65,40 @@ async function main(): Promise<void> {
 
   const buildId = new Date().toISOString();
   const gitSha = resolveGitSha(ROOT_DIR);
-  console.log(`📨 Building WhatsApp worker (bundling Baileys) — build ${buildId} (${gitSha})...`);
+  console.log(`Building WhatsApp worker (bundling Baileys) - build ${buildId} (${gitSha})...`);
 
-  const proc = spawn({
-    cmd: [
-      "bun", "run", "esbuild",
-      SOURCE,
-      "--bundle",
-      "--platform=node",
-      "--format=cjs",
-      "--target=node20",
-      `--outfile=${OUTPUT}`,
-      // Inject build provenance. The worker logs these on startup so an
-      // operator can confirm a rebuild actually propagated to the running
-      // subprocess after `bun run build:wa-worker`.
-      `--define:__WA_WORKER_BUILD_ID__=${JSON.stringify(buildId)}`,
-      `--define:__WA_WORKER_GIT_SHA__=${JSON.stringify(gitSha)}`,
-      // Mark only Electron + Baileys' runtime-optional peers external.
-      // Baileys itself and all its required transitive deps get bundled.
-      //
-      // The three optional deps below are unused by Craft Agent (no link
-      // previews, no terminal QR, no inline image transforms). Baileys
-      // guards them with try/catch so they fail silently at runtime.
-      "--external:electron",
-      "--external:link-preview-js",
-      "--external:qrcode-terminal",
-      "--external:jimp",
-    ],
-    cwd: ROOT_DIR,
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-
-  const exitCode = await proc.exited;
-  if (exitCode !== 0) {
-    console.error("❌ WhatsApp worker build failed with exit code", exitCode);
-    process.exit(exitCode);
+  try {
+    await esbuild.build({
+      entryPoints: [SOURCE],
+      bundle: true,
+      platform: "node",
+      format: "cjs",
+      target: "node20",
+      outfile: OUTPUT,
+      define: {
+        __WA_WORKER_BUILD_ID__: JSON.stringify(buildId),
+        __WA_WORKER_GIT_SHA__: JSON.stringify(gitSha),
+      },
+      external: ["electron", "link-preview-js", "qrcode-terminal", "jimp"],
+      logLevel: "info",
+    });
+  } catch (err) {
+    console.error("WhatsApp worker build failed:", err);
+    process.exit(1);
   }
 
-  console.log("🔍 Verifying worker output...");
+  console.log("Verifying worker output...");
   const verification = await verifyJsFile(OUTPUT);
   if (!verification.valid) {
-    console.error("❌ Worker build verification failed:", verification.error);
+    console.error("Worker build verification failed:", verification.error);
     process.exit(1);
   }
 
   const { size } = statSync(OUTPUT);
-  console.log(`✅ WhatsApp worker built (${(size / 1024 / 1024).toFixed(2)} MB) → ${OUTPUT}`);
+  console.log(`WhatsApp worker built (${(size / 1024 / 1024).toFixed(2)} MB) -> ${OUTPUT}`);
 }
 
 main().catch((err) => {
-  console.error("❌ Unexpected error:", err);
+  console.error("Unexpected error:", err);
   process.exit(1);
 });


### PR DESCRIPTION
﻿## Summary
- Render outbound Telegram messages as Telegram MarkdownV2 instead of raw Markdown text.
- Pass `parse_mode: "MarkdownV2"` for text sends, edits, inline-button messages, and document captions.
- Retry only Telegram entity-parse failures with escaped plain text so malformed Markdown does not drop messages.
- Switch the WhatsApp worker build script to the esbuild JS API so `electron:dev` can pass string defines reliably during verification.

## Validation
- `bun test packages/messaging-gateway/src/adapters/telegram/dm-only.test.ts packages/messaging-gateway/src/adapters/telegram/format.test.ts packages/messaging-gateway/src/adapters/telegram/send-format.test.ts packages/messaging-gateway/src/__tests__/renderer.test.ts packages/messaging-gateway/src/__tests__/renderer-plan.test.ts`
- `bun run scripts/build-wa-worker.ts`
- `bun run electron:dev`
- Manual Telegram test confirmed Markdown rendering works.

## Notes
- Existing unrelated local changes were left out of this commit.
