### PR TITLE
Fix Pi custom endpoint auth and packaging

### DIFF
--- a/apps/electron/scripts/copy-assets.ts
+++ b/apps/electron/scripts/copy-assets.ts
@@ -11,7 +11,7 @@
  * Run: bun scripts/copy-assets.ts
  */
 
-import { cpSync, copyFileSync, mkdirSync } from 'fs';
+import { cpSync, copyFileSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 
 // Copy all resources (icons, themes, docs, permissions, tool-icons, etc.)
@@ -30,4 +30,27 @@ try {
 } catch (err) {
   // Only warn - PowerShell validation is optional on non-Windows platforms
   console.log('⚠ powershell-parser.ps1 copy skipped (not critical on non-Windows)');
+}
+
+const bundledServerOutputs = [
+  {
+    name: 'session-mcp-server',
+    src: join('..', '..', 'packages', 'session-mcp-server', 'dist', 'index.js'),
+  },
+  {
+    name: 'pi-agent-server',
+    src: join('..', '..', 'packages', 'pi-agent-server', 'dist', 'index.js'),
+  },
+];
+
+for (const server of bundledServerOutputs) {
+  if (!existsSync(server.src)) {
+    console.log(`Warning: ${server.name} copy skipped (dist output not found)`);
+    continue;
+  }
+
+  const destDir = join('dist', 'resources', server.name);
+  mkdirSync(destDir, { recursive: true });
+  copyFileSync(server.src, join(destDir, 'index.js'));
+  console.log(`Copied ${server.name} to dist/resources/${server.name}/`);
 }

--- a/packages/shared/src/agent/pi-agent.ts
+++ b/packages/shared/src/agent/pi-agent.ts
@@ -380,14 +380,16 @@ export class PiAgent extends BaseAgent {
       }
     }
 
-    // Retrieve auth credentials for the subprocess.
+    // Retrieve auth credentials for the subprocess. Connection-scoped keys are
+    // allowed for custom endpoints, but global fallback stays disabled there.
     // Custom endpoint mode must NOT fall back to global API keys — keyless local endpoints
-    // are valid, and non-local endpoints should fail explicitly instead of using unrelated creds.
     const piAuth = await this.getPiAuth();
     const isCustomEndpointMode = !!runtime.customEndpoint;
-    const legacyApiKey = (!piAuth && !isCustomEndpointMode) ? await this.getApiKey() : undefined;
+    const legacyApiKey = !piAuth
+      ? await this.getApiKey({ allowGlobalFallback: !isCustomEndpointMode })
+      : undefined;
     if (isCustomEndpointMode && !piAuth) {
-      this.debug('Custom endpoint mode: no provider credential configured, sending empty API key');
+      this.debug(`Custom endpoint mode: ${legacyApiKey ? 'using connection-scoped API key' : 'no provider credential configured, sending empty API key'}`);
     }
 
     // Derive AWS env vars from the piAuth credential (single fetch, no race).
@@ -751,16 +753,29 @@ export class PiAgent extends BaseAgent {
    * Legacy fallback when piAuthProvider is not set.
    * The subprocess expects a single API key string (passed via init.apiKey).
    */
-  private async getApiKey(): Promise<string | null> {
+  private async getApiKey(options: { allowGlobalFallback?: boolean } = {}): Promise<string | null> {
     try {
       const credentialManager = getCredentialManager();
       const slug = this.config.connectionSlug || 'pi';
+
+      // Prefer connection-scoped API keys. Custom endpoint credentials are stored here,
+      // and using this first keeps per-connection auth isolated from global defaults.
+      const llmApiKey = await credentialManager.getLlmApiKey(slug);
+      if (llmApiKey) {
+        this.debug('Retrieved API key from LLM connection');
+        return llmApiKey;
+      }
 
       // Try LLM OAuth first (for OAuth-based connections)
       const oauth = await credentialManager.getLlmOAuth(slug);
       if (oauth?.accessToken) {
         this.debug('Retrieved API key from LLM OAuth');
         return oauth.accessToken;
+      }
+
+      if (options.allowGlobalFallback === false) {
+        this.debug('No connection-scoped API key found for Pi agent');
+        return null;
       }
 
       // Try Anthropic API key


### PR DESCRIPTION
## Summary
- Use connection-scoped API keys for Pi custom endpoints without falling back to unrelated global keys
- Copy bundled session and Pi agent server outputs into Electron resources so packaged apps can spawn subprocesses

## Verification
- bun run typecheck:shared
- bun test packages/shared/src/agent/backend/__tests__/factory.test.ts packages/shared/src/agent/__tests__/pi-agent-bedrock-env.test.ts
- Built Windows installer locally and confirmed pi-agent-server/index.js is present in win-unpacked resources