### PR TITLE
fix: support explicit Telegram HTML formatting

### DIFF
--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -539,10 +539,10 @@ export interface AgentEventUsage {
  * turnId: Correlation ID from the API's message.id, groups all events in an assistant turn
  */
 export type AgentEvent =
-  | { type: 'status'; message: string }
-  | { type: 'info'; message: string }
+  | { type: 'status'; message: string; format?: 'plain' | 'html' }
+  | { type: 'info'; message: string; format?: 'plain' | 'html' }
   | { type: 'text_delta'; text: string; turnId?: string; parentToolUseId?: string }
-  | { type: 'text_complete'; text: string; isIntermediate?: boolean; turnId?: string; parentToolUseId?: string; sdkTurnAnchor?: string }
+  | { type: 'text_complete'; text: string; format?: 'plain' | 'html'; isIntermediate?: boolean; turnId?: string; parentToolUseId?: string; sdkTurnAnchor?: string }
   | { type: 'tool_start'; toolName: string; toolUseId: string; input: Record<string, unknown>; intent?: string; displayName?: string; turnId?: string; parentToolUseId?: string; toolDisplayMeta?: ToolDisplayMeta }
   | { type: 'tool_result'; toolUseId: string; toolName?: string; result: string; isError: boolean; input?: Record<string, unknown>; turnId?: string; parentToolUseId?: string }
   | {
@@ -560,7 +560,7 @@ export type AgentEvent =
       commandHash?: string;
       approvalTtlSeconds?: number;
     }
-  | { type: 'error'; message: string }
+  | { type: 'error'; message: string; format?: 'plain' | 'html' }
   | { type: 'typed_error'; error: TypedError }
   | { type: 'complete'; usage?: AgentEventUsage }
   | { type: 'working_directory_changed'; workingDirectory: string }

--- a/packages/messaging-gateway/src/__tests__/renderer.test.ts
+++ b/packages/messaging-gateway/src/__tests__/renderer.test.ts
@@ -320,6 +320,41 @@ describe('Renderer — final_only mode', () => {
     expect(sends[0]!.text).toBe('<b>ready</b>')
     expect(sends[0]!.options).toEqual({ format: 'html' })
   })
+
+
+  it('keeps near-limit Telegram HTML formatted when the rendered text still fits', async () => {
+    const adapter = makeAdapter()
+    const binding = makeBinding({ responseMode: 'final_only' as ResponseMode })
+    const html = `<b>${'x'.repeat(4094)}</b>`
+    await play(renderer, binding, adapter, [ev.finalHtml(html), ev.complete()])
+
+    const sends = adapter.calls.filter((c) => c.kind === 'sendText')
+    expect(sends.length).toBe(1)
+    expect(sends[0]!.options).toEqual({ format: 'html' })
+  })
+
+
+  it('falls back to plain text when explicit HTML exceeds adapter limits', async () => {
+    const adapter = makeAdapter({ maxMessageLength: 20 })
+    const binding = makeBinding({ responseMode: 'final_only' as ResponseMode })
+    await play(renderer, binding, adapter, [ev.finalHtml('<b>' + 'x'.repeat(30) + '</b>'), ev.complete()])
+
+    const sends = adapter.calls.filter((c) => c.kind === 'sendText')
+    expect(sends.length).toBeGreaterThan(1)
+    expect(sends.every((call) => call.options === undefined)).toBe(true)
+  })
+
+
+  it('downgrades mixed plain and HTML final buffers to readable plain text', async () => {
+    const adapter = makeAdapter()
+    const binding = makeBinding({ responseMode: 'final_only' as ResponseMode })
+    await play(renderer, binding, adapter, [ev.final('plain'), ev.finalHtml('<b>html</b>'), ev.complete()])
+
+    const sends = adapter.calls.filter((c) => c.kind === 'sendText')
+    expect(sends.length).toBe(1)
+    expect(sends[0]!.text).toBe(`plain\n\nhtml`)
+    expect(sends[0]!.options).toBeUndefined()
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -492,5 +527,27 @@ describe('Renderer — WhatsApp desktop-only approvals', () => {
     expect(sends).toHaveLength(1)
     expect(sends[0]!.text).toContain('plan is ready')
     expect(sends[0]!.text).toContain('desktop app')
+  })
+
+  it('HTML-formatted errors are downgraded for WhatsApp adapters', async () => {
+    const renderer = new Renderer()
+    const adapter = makeAdapter({ inlineButtons: false, messageEditing: false, markdown: 'whatsapp' })
+    ;(adapter as any).platform = 'whatsapp'
+    const binding = {
+      ...makeBinding(),
+      platform: 'whatsapp' as const,
+      channelId: 'wa-1',
+    }
+
+    await renderer.handle(
+      { type: 'error', sessionId: 's', error: '<b>boom</b>', format: 'html' } as SessionEvent,
+      binding,
+      adapter,
+    )
+
+    const sends = adapter.calls.filter((c) => c.kind === 'sendText')
+    expect(sends).toHaveLength(1)
+    expect(sends[0]!.text).toBe('❌ boom')
+    expect(sends[0]!.options).toBeUndefined()
   })
 })

--- a/packages/messaging-gateway/src/__tests__/renderer.test.ts
+++ b/packages/messaging-gateway/src/__tests__/renderer.test.ts
@@ -21,6 +21,7 @@ import {
   type SentMessage,
   type BindingConfig,
   type ResponseMode,
+  type OutboundTextOptions,
 } from '../types'
 
 // ---------------------------------------------------------------------------
@@ -32,6 +33,7 @@ interface Call {
   channelId: string
   messageId?: string
   text?: string
+  options?: OutboundTextOptions
 }
 
 function makeAdapter(
@@ -61,17 +63,17 @@ function makeAdapter(
     },
     onMessage() {},
     onButtonPress() {},
-    async sendText(channelId: string, text: string): Promise<SentMessage> {
+    async sendText(channelId: string, text: string, options?: OutboundTextOptions): Promise<SentMessage> {
       const messageId = String(nextId++)
-      calls.push({ kind: 'sendText', channelId, text, messageId })
+      calls.push({ kind: 'sendText', channelId, text, messageId, options })
       return { platform: 'telegram', channelId, messageId }
     },
-    async editMessage(channelId: string, messageId: string, text: string): Promise<void> {
-      calls.push({ kind: 'editMessage', channelId, messageId, text })
+    async editMessage(channelId: string, messageId: string, text: string, options?: OutboundTextOptions): Promise<void> {
+      calls.push({ kind: 'editMessage', channelId, messageId, text, options })
     },
-    async sendButtons(channelId: string, text: string): Promise<SentMessage> {
+    async sendButtons(channelId: string, text: string, _buttons: unknown[], options?: OutboundTextOptions): Promise<SentMessage> {
       const messageId = String(nextId++)
-      calls.push({ kind: 'sendButtons', channelId, text, messageId })
+      calls.push({ kind: 'sendButtons', channelId, text, messageId, options })
       return { platform: 'telegram', channelId, messageId }
     },
     async sendTyping(channelId: string): Promise<void> {
@@ -134,6 +136,13 @@ const ev = {
     type: 'text_complete',
     sessionId: 's',
     text,
+  }),
+  finalHtml: (text: string): SessionEvent => ({
+    type: 'text_complete',
+    sessionId: 's',
+    text,
+    format: 'html',
+    isIntermediate: false,
   }),
   toolStart: (displayName?: string): SessionEvent => ({
     type: 'tool_start',
@@ -298,6 +307,18 @@ describe('Renderer — final_only mode', () => {
     const sends = adapter.calls.filter((c) => c.kind === 'sendText')
     expect(sends.length).toBe(1)
     expect(sends[0]!.text).toBe('legacy-shape-text')
+  })
+
+
+  it('forwards explicit HTML format from final assistant text', async () => {
+    const adapter = makeAdapter()
+    const binding = makeBinding({ responseMode: 'final_only' as ResponseMode })
+    await play(renderer, binding, adapter, [ev.finalHtml('<b>ready</b>'), ev.complete()])
+
+    const sends = adapter.calls.filter((c) => c.kind === 'sendText')
+    expect(sends.length).toBe(1)
+    expect(sends[0]!.text).toBe('<b>ready</b>')
+    expect(sends[0]!.options).toEqual({ format: 'html' })
   })
 })
 

--- a/packages/messaging-gateway/src/adapters/telegram/format.test.ts
+++ b/packages/messaging-gateway/src/adapters/telegram/format.test.ts
@@ -1,37 +1,35 @@
 import { describe, expect, it } from 'bun:test'
-import { TELEGRAM_PARSE_MODE, formatForTelegram } from './format'
+import { TELEGRAM_PARSE_MODE, prepareTelegramText, sanitizeTelegramHtml } from './format'
 
-describe('formatForTelegram', () => {
-  it('exports HTML parse mode', () => {
-    expect(TELEGRAM_PARSE_MODE).toBe('HTML')
+describe('prepareTelegramText', () => {
+  it('keeps plain text untouched by default', () => {
+    expect(prepareTelegramText('**bold** <b>tag</b>')).toEqual({ text: '**bold** <b>tag</b>' })
   })
 
-  it('renders common markdown as Telegram HTML', () => {
-    const formatted = formatForTelegram('# Title\n\n**bold** *italic* ~~strike~~ [link](https://example.com) `code`')
-
-    expect(formatted).toContain('<b>Title</b>')
-    expect(formatted).toContain('<b>bold</b>')
-    expect(formatted).toContain('<i>italic</i>')
-    expect(formatted).toContain('<s>strike</s>')
-    expect(formatted).toContain('<a href="https://example.com/">link</a>')
-    expect(formatted).toContain('<code>code</code>')
+  it('uses HTML parse mode only when explicitly requested', () => {
+    expect(prepareTelegramText('<b>bold</b>', { format: 'html' })).toEqual({
+      text: '<b>bold</b>',
+      parseMode: TELEGRAM_PARSE_MODE,
+    })
   })
+})
 
+describe('sanitizeTelegramHtml', () => {
   it('preserves supported Telegram HTML tags', () => {
-    const formatted = formatForTelegram('already <b>bold</b> and <i>italic</i>')
-
-    expect(formatted).toBe('already <b>bold</b> and <i>italic</i>')
-  })
-
-  it('renders fenced code blocks and escapes their contents', () => {
-    const formatted = formatForTelegram('```ts\nconst x = 1 < 2 && 3 > 1\n```')
-
-    expect(formatted).toBe('<pre><code>const x = 1 &lt; 2 &amp;&amp; 3 &gt; 1</code></pre>')
+    expect(sanitizeTelegramHtml('already <b>bold</b> and <i>italic</i>')).toBe(
+      'already <b>bold</b> and <i>italic</i>',
+    )
   })
 
   it('escapes unsupported raw HTML', () => {
-    const formatted = formatForTelegram('<script>alert(1)</script>')
+    expect(sanitizeTelegramHtml('<script>alert(1)</script>')).toBe(
+      '&lt;script&gt;alert(1)&lt;/script&gt;',
+    )
+  })
 
-    expect(formatted).toBe('&lt;script&gt;alert(1)&lt;/script&gt;')
+  it('sanitizes invalid links instead of preserving raw anchors', () => {
+    expect(sanitizeTelegramHtml('<a href="javascript:alert(1)">bad</a>')).toBe(
+      '&lt;a href="javascript:alert(1)"&gt;bad</a>',
+    )
   })
 })

--- a/packages/messaging-gateway/src/adapters/telegram/format.test.ts
+++ b/packages/messaging-gateway/src/adapters/telegram/format.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test'
+import { TELEGRAM_PARSE_MODE, formatForTelegram } from './format'
+
+describe('formatForTelegram', () => {
+  it('exports HTML parse mode', () => {
+    expect(TELEGRAM_PARSE_MODE).toBe('HTML')
+  })
+
+  it('renders common markdown as Telegram HTML', () => {
+    const formatted = formatForTelegram('# Title\n\n**bold** *italic* ~~strike~~ [link](https://example.com) `code`')
+
+    expect(formatted).toContain('<b>Title</b>')
+    expect(formatted).toContain('<b>bold</b>')
+    expect(formatted).toContain('<i>italic</i>')
+    expect(formatted).toContain('<s>strike</s>')
+    expect(formatted).toContain('<a href="https://example.com/">link</a>')
+    expect(formatted).toContain('<code>code</code>')
+  })
+
+  it('preserves supported Telegram HTML tags', () => {
+    const formatted = formatForTelegram('already <b>bold</b> and <i>italic</i>')
+
+    expect(formatted).toBe('already <b>bold</b> and <i>italic</i>')
+  })
+
+  it('renders fenced code blocks and escapes their contents', () => {
+    const formatted = formatForTelegram('```ts\nconst x = 1 < 2 && 3 > 1\n```')
+
+    expect(formatted).toBe('<pre><code>const x = 1 &lt; 2 &amp;&amp; 3 &gt; 1</code></pre>')
+  })
+
+  it('escapes unsupported raw HTML', () => {
+    const formatted = formatForTelegram('<script>alert(1)</script>')
+
+    expect(formatted).toBe('&lt;script&gt;alert(1)&lt;/script&gt;')
+  })
+})

--- a/packages/messaging-gateway/src/adapters/telegram/format.test.ts
+++ b/packages/messaging-gateway/src/adapters/telegram/format.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'bun:test'
-import { TELEGRAM_PARSE_MODE, prepareTelegramText, sanitizeTelegramHtml } from './format'
+import {
+  TELEGRAM_PARSE_MODE,
+  prepareTelegramText,
+  sanitizeTelegramHtml,
+  telegramHtmlToPlainText,
+} from './format'
 
 describe('prepareTelegramText', () => {
   it('keeps plain text untouched by default', () => {
@@ -21,6 +26,30 @@ describe('sanitizeTelegramHtml', () => {
     )
   })
 
+  it('preserves existing HTML entities', () => {
+    expect(sanitizeTelegramHtml('<b>AT&amp;T &lt;3</b>')).toBe('<b>AT&amp;T &lt;3</b>')
+  })
+
+  it('preserves language-qualified code tags in Telegram HTML', () => {
+    expect(sanitizeTelegramHtml('<pre><code class="language-ts">const x = 1;</code></pre>')).toBe(
+      '<pre><code>const x = 1;</code></pre>',
+    )
+  })
+
+  it('escapes unsupported named HTML entities', () => {
+    expect(sanitizeTelegramHtml('<b>&nbsp;</b>')).toBe('<b>&amp;nbsp;</b>')
+  })
+
+  it('does not throw on invalid numeric entities in plain-text fallback', () => {
+    expect(telegramHtmlToPlainText('&#999999999;')).toBe('&#999999999;')
+  })
+
+  it('preserves link destinations in plain-text fallback', () => {
+    expect(telegramHtmlToPlainText('<a href="https://example.com">click here</a>')).toBe(
+      'click here (https://example.com/)',
+    )
+  })
+
   it('escapes unsupported raw HTML', () => {
     expect(sanitizeTelegramHtml('<script>alert(1)</script>')).toBe(
       '&lt;script&gt;alert(1)&lt;/script&gt;',
@@ -29,7 +58,21 @@ describe('sanitizeTelegramHtml', () => {
 
   it('sanitizes invalid links instead of preserving raw anchors', () => {
     expect(sanitizeTelegramHtml('<a href="javascript:alert(1)">bad</a>')).toBe(
-      '&lt;a href="javascript:alert(1)"&gt;bad</a>',
+      '&lt;a href="javascript:alert(1)"&gt;bad&lt;/a&gt;',
     )
   })
-})
+
+  it('escapes unmatched closing tags', () => {
+    expect(sanitizeTelegramHtml('oops </b>')).toBe('oops &lt;/b&gt;')
+  })
+
+  it('falls back to escaped plain text for unclosed supported tags', () => {
+    expect(sanitizeTelegramHtml('<b>oops')).toBe('&lt;b&gt;oops')
+  })
+
+  it('falls back to escaped plain text for mismatched nesting', () => {
+    expect(sanitizeTelegramHtml('<b><i>x</b></i>')).toBe('&lt;b&gt;&lt;i&gt;x&lt;/b&gt;&lt;/i&gt;')
+  })
+}
+
+)

--- a/packages/messaging-gateway/src/adapters/telegram/format.ts
+++ b/packages/messaging-gateway/src/adapters/telegram/format.ts
@@ -25,6 +25,11 @@ const SUPPORTED_HTML_TAGS: Record<string, string> = {
   pre: 'pre',
   blockquote: 'blockquote',
 }
+const SUPPORTED_TAG_PATTERN = Object.keys(SUPPORTED_HTML_TAGS).join('|')
+const TELEGRAM_TAG_RE = new RegExp(`<a\\s+href=("|')(.*?)\\1\\s*>|<\\/a>|<(\\/?)\\s*(${SUPPORTED_TAG_PATTERN})\\s*>`, 'gi')
+const TELEGRAM_CODE_CLASS_RE = /<code\s+class=("|')[^"']*\1\s*>/gi
+const TELEGRAM_RENDERED_TAG_RE = /<a href="[^"]*">|<\/a>|<\/?(?:b|i|u|s|code|pre|blockquote)>/gi
+const TELEGRAM_SUPPORTED_ENTITY_RE = /&(lt|gt|amp|quot);|&#(\d+);|&#x([0-9a-fA-F]+);/gi
 
 function stash(replacements: string[], value: string): string {
   const index = replacements.push(value) - 1
@@ -37,7 +42,7 @@ function restore(text: string, replacements: string[]): string {
 
 function escapeTelegramHtml(text: string): string {
   return text
-    .replace(/&/g, '&amp;')
+    .replace(/&(?!(?:lt|gt|amp|quot|#\d+|#x[0-9a-fA-F]+);)/gi, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
 }
@@ -56,23 +61,126 @@ function sanitizeUrl(url: string): string | null {
   }
 }
 
+function decodeTelegramEntity(
+  match: string,
+  named?: string,
+  decimal?: string,
+  hex?: string,
+): string {
+  if (named === 'lt') return '<'
+  if (named === 'gt') return '>'
+  if (named === 'amp') return '&'
+  if (named === 'quot') return '"'
+
+  const codePoint = decimal
+    ? Number.parseInt(decimal, 10)
+    : hex
+      ? Number.parseInt(hex, 16)
+      : Number.NaN
+
+  if (!Number.isFinite(codePoint) || codePoint < 0 || codePoint > 0x10FFFF) {
+    return match
+  }
+
+  try {
+    return String.fromCodePoint(codePoint)
+  } catch {
+    return match
+  }
+}
+
 export function sanitizeTelegramHtml(text: string): string {
+  const normalizedInput = text.replace(TELEGRAM_CODE_CLASS_RE, '<code>')
   const replacements: string[] = []
+  const stack: string[] = []
+  let malformed = false
+  let lastIndex = 0
+  let out = ''
 
-  let out = text.replace(/<a\s+href=("|')(.*?)\1\s*>/gi, (match, _quote, href: string) => {
-    const safeHref = sanitizeUrl(href.trim())
-    if (!safeHref) return match
-    return stash(replacements, `<a href="${escapeTelegramAttribute(safeHref)}">`)
-  })
+  let match: RegExpExecArray | null
+  while ((match = TELEGRAM_TAG_RE.exec(normalizedInput)) !== null) {
+    const full = match[0]
+    const index = match.index
+    out += normalizedInput.slice(lastIndex, index)
+    lastIndex = index + full.length
 
-  out = out.replace(/<\/a>/gi, () => stash(replacements, '</a>'))
+    const href = match[2]
+    const slash = match[3]
+    const tag = match[4]
+    const lastTag = stack[stack.length - 1]
 
-  out = out.replace(/<(\/?)\s*(b|strong|i|em|u|ins|s|strike|del|code|pre|blockquote)\s*>/gi, (_match, slash: string, tag: string) => {
-    const normalized = SUPPORTED_HTML_TAGS[tag.toLowerCase()]
-    return stash(replacements, `<${slash}${normalized}>`)
-  })
+    if (full.toLowerCase() === '</a>') {
+      if (lastTag !== 'a') {
+        malformed = true
+        out += full
+      } else {
+        stack.pop()
+        out += stash(replacements, '</a>')
+      }
+      continue
+    }
+
+    if (href !== undefined) {
+      const safeHref = sanitizeUrl(href.trim())
+      if (!safeHref) {
+        malformed = true
+        out += full
+      } else {
+        stack.push('a')
+        out += stash(replacements, `<a href="${escapeTelegramAttribute(safeHref)}">`)
+      }
+      continue
+    }
+
+    const normalized = tag ? SUPPORTED_HTML_TAGS[tag.toLowerCase()] : undefined
+    if (!normalized) {
+      malformed = true
+      out += full
+      continue
+    }
+
+    if (slash) {
+      if (lastTag !== normalized) {
+        malformed = true
+        out += full
+      } else {
+        stack.pop()
+        out += stash(replacements, `</${normalized}>`)
+      }
+      continue
+    }
+
+    stack.push(normalized)
+    out += stash(replacements, `<${normalized}>`)
+  }
+  TELEGRAM_TAG_RE.lastIndex = 0
+
+  out += normalizedInput.slice(lastIndex)
+
+  if (malformed || stack.length > 0) {
+    return escapeTelegramHtml(normalizedInput)
+  }
 
   return restore(escapeTelegramHtml(out), replacements)
+}
+
+function telegramHtmlToRenderedText(text: string, includeHrefTargets: boolean): string {
+  const sanitized = sanitizeTelegramHtml(text)
+  const withLinks = includeHrefTargets
+    ? sanitized.replace(/<a href="([^"]*)">([\s\S]*?)<\/a>/gi, '$2 ($1)')
+    : sanitized
+
+  return withLinks
+    .replace(TELEGRAM_RENDERED_TAG_RE, '')
+    .replace(TELEGRAM_SUPPORTED_ENTITY_RE, decodeTelegramEntity)
+}
+
+export function telegramHtmlToPlainText(text: string): string {
+  return telegramHtmlToRenderedText(text, true)
+}
+
+export function getTelegramHtmlTextLength(text: string): number {
+  return telegramHtmlToRenderedText(text, false).length
 }
 
 export function prepareTelegramText(

--- a/packages/messaging-gateway/src/adapters/telegram/format.ts
+++ b/packages/messaging-gateway/src/adapters/telegram/format.ts
@@ -1,11 +1,11 @@
 /**
- * Markdown / limited HTML → Telegram HTML formatting.
+ * Telegram outbound text formatting helpers.
  *
- * Telegram supports a small HTML subset via `parse_mode: 'HTML'`. This file
- * converts the most common Markdown emitted by the agent (headings, emphasis,
- * links, inline code, fenced code blocks, lists) and preserves already-valid
- * Telegram HTML tags like `<b>` / `<i>` / `<code>`.
+ * Plain text remains plain by default. Callers must explicitly request
+ * `format: 'html'` to send Telegram HTML.
  */
+
+import type { OutboundTextOptions } from '../../types'
 
 export const TELEGRAM_PARSE_MODE = 'HTML' as const
 
@@ -35,10 +35,6 @@ function restore(text: string, replacements: string[]): string {
   return text.replace(/\uE000(\d+)\uE001/g, (match, index) => replacements[Number(index)] ?? match)
 }
 
-function normalizeLineEndings(text: string): string {
-  return text.replace(/\r\n?/g, '\n')
-}
-
 function escapeTelegramHtml(text: string): string {
   return text
     .replace(/&/g, '&amp;')
@@ -60,7 +56,9 @@ function sanitizeUrl(url: string): string | null {
   }
 }
 
-function preserveSupportedHtml(text: string, replacements: string[]): string {
+export function sanitizeTelegramHtml(text: string): string {
+  const replacements: string[] = []
+
   let out = text.replace(/<a\s+href=("|')(.*?)\1\s*>/gi, (match, _quote, href: string) => {
     const safeHref = sanitizeUrl(href.trim())
     if (!safeHref) return match
@@ -74,71 +72,19 @@ function preserveSupportedHtml(text: string, replacements: string[]): string {
     return stash(replacements, `<${slash}${normalized}>`)
   })
 
-  return out
+  return restore(escapeTelegramHtml(out), replacements)
 }
 
-function formatInline(text: string): string {
-  const replacements: string[] = []
-  let out = preserveSupportedHtml(text, replacements)
-
-  out = out.replace(/`([^`]+?)`/g, (_match, code: string) => stash(replacements, `<code>${escapeTelegramHtml(code)}</code>`))
-
-  out = out.replace(/\[([^\]]+?)\]\((https?:\/\/[^\s)]+)\)/g, (match, label: string, url: string) => {
-    const safeHref = sanitizeUrl(url)
-    if (!safeHref) return match
-    return stash(replacements, `<a href="${escapeTelegramAttribute(safeHref)}">${formatInline(label)}</a>`)
-  })
-
-  out = out.replace(/\*\*(?=\S)(.+?\S)\*\*/g, (_match, content: string) => stash(replacements, `<b>${formatInline(content)}</b>`))
-  out = out.replace(/__(?=\S)(.+?\S)__/g, (_match, content: string) => stash(replacements, `<b>${formatInline(content)}</b>`))
-  out = out.replace(/~~(?=\S)(.+?\S)~~/g, (_match, content: string) => stash(replacements, `<s>${formatInline(content)}</s>`))
-  out = out.replace(/\*(?=\S)(.+?\S)\*(?!\*)/g, (_match, content: string) => stash(replacements, `<i>${formatInline(content)}</i>`))
-  out = out.replace(/(^|[^_])_(?=\S)(.+?\S)_(?!_)/g, (_match, prefix: string, content: string) => `${prefix}${stash(replacements, `<i>${formatInline(content)}</i>`)}`)
-
-  out = escapeTelegramHtml(out)
-  return restore(out, replacements)
-}
-
-function formatLine(line: string): string {
-  const headingMatch = line.match(/^#{1,6}\s+(.+)$/)
-  if (headingMatch) return `<b>${formatInline(headingMatch[1]!.trim())}</b>`
-
-  const orderedListMatch = line.match(/^(\s*)(\d+)\.\s+(.+)$/)
-  if (orderedListMatch) {
-    const [, indent, index, content] = orderedListMatch
-    return `${indent}${index}. ${formatInline(content!)}`
+export function prepareTelegramText(
+  text: string,
+  options?: OutboundTextOptions,
+): { text: string; parseMode?: typeof TELEGRAM_PARSE_MODE } {
+  if (options?.format === 'html') {
+    return {
+      text: sanitizeTelegramHtml(text),
+      parseMode: TELEGRAM_PARSE_MODE,
+    }
   }
 
-  const unorderedListMatch = line.match(/^(\s*)[-*+]\s+(.+)$/)
-  if (unorderedListMatch) {
-    const [, indent, content] = unorderedListMatch
-    return `${indent}• ${formatInline(content!)}`
-  }
-
-  const blockquoteMatch = line.match(/^>\s?(.*)$/)
-  if (blockquoteMatch) {
-    return `<blockquote>${formatInline(blockquoteMatch[1] ?? '')}</blockquote>`
-  }
-
-  return formatInline(line)
-}
-
-function renderCodeBlock(code: string): string {
-  return `<pre><code>${escapeTelegramHtml(code.replace(/\n+$/g, ''))}</code></pre>`
-}
-
-export function formatForTelegram(text: string): string {
-  const normalized = normalizeLineEndings(text)
-  const replacements: string[] = []
-
-  const withoutCodeBlocks = normalized.replace(/```(?:[A-Za-z0-9_+-]+)?\n?([\s\S]*?)```/g, (_match, code: string) => {
-    return stash(replacements, renderCodeBlock(code))
-  })
-
-  const formatted = withoutCodeBlocks
-    .split('\n')
-    .map((line) => line.length === 0 ? '' : formatLine(line))
-    .join('\n')
-
-  return restore(formatted, replacements)
+  return { text }
 }

--- a/packages/messaging-gateway/src/adapters/telegram/format.ts
+++ b/packages/messaging-gateway/src/adapters/telegram/format.ts
@@ -1,22 +1,144 @@
 /**
- * Markdown → Telegram MarkdownV2 formatting.
+ * Markdown / limited HTML → Telegram HTML formatting.
  *
- * Telegram MarkdownV2 requires escaping special characters outside of
- * code blocks. For Phase 1 we send plain text — formatting added in Phase 2.
+ * Telegram supports a small HTML subset via `parse_mode: 'HTML'`. This file
+ * converts the most common Markdown emitted by the agent (headings, emphasis,
+ * links, inline code, fenced code blocks, lists) and preserves already-valid
+ * Telegram HTML tags like `<b>` / `<i>` / `<code>`.
  */
 
-/** Characters that must be escaped in Telegram MarkdownV2. */
-const TG_SPECIAL_CHARS = /([_*\[\]()~`>#+\-=|{}.!\\])/g
+export const TELEGRAM_PARSE_MODE = 'HTML' as const
 
-/** Escape text for Telegram MarkdownV2 parse mode. */
-export function escapeTelegramMarkdown(text: string): string {
-  return text.replace(TG_SPECIAL_CHARS, '\\$1')
+const PLACEHOLDER_START = '\uE000'
+const PLACEHOLDER_END = '\uE001'
+const SUPPORTED_HTML_TAGS: Record<string, string> = {
+  b: 'b',
+  strong: 'b',
+  i: 'i',
+  em: 'i',
+  u: 'u',
+  ins: 'u',
+  s: 's',
+  strike: 's',
+  del: 's',
+  code: 'code',
+  pre: 'pre',
+  blockquote: 'blockquote',
 }
 
-/**
- * For Phase 1 we send plain text (no parse_mode).
- * This avoids escaping issues while we validate the core flow.
- */
-export function formatForTelegram(text: string): string {
+function stash(replacements: string[], value: string): string {
+  const index = replacements.push(value) - 1
+  return `${PLACEHOLDER_START}${index}${PLACEHOLDER_END}`
+}
+
+function restore(text: string, replacements: string[]): string {
+  return text.replace(/\uE000(\d+)\uE001/g, (match, index) => replacements[Number(index)] ?? match)
+}
+
+function normalizeLineEndings(text: string): string {
+  return text.replace(/\r\n?/g, '\n')
+}
+
+function escapeTelegramHtml(text: string): string {
   return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+function escapeTelegramAttribute(text: string): string {
+  return escapeTelegramHtml(text).replace(/"/g, '&quot;')
+}
+
+function sanitizeUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+    return parsed.toString()
+  } catch {
+    return null
+  }
+}
+
+function preserveSupportedHtml(text: string, replacements: string[]): string {
+  let out = text.replace(/<a\s+href=("|')(.*?)\1\s*>/gi, (match, _quote, href: string) => {
+    const safeHref = sanitizeUrl(href.trim())
+    if (!safeHref) return match
+    return stash(replacements, `<a href="${escapeTelegramAttribute(safeHref)}">`)
+  })
+
+  out = out.replace(/<\/a>/gi, () => stash(replacements, '</a>'))
+
+  out = out.replace(/<(\/?)\s*(b|strong|i|em|u|ins|s|strike|del|code|pre|blockquote)\s*>/gi, (_match, slash: string, tag: string) => {
+    const normalized = SUPPORTED_HTML_TAGS[tag.toLowerCase()]
+    return stash(replacements, `<${slash}${normalized}>`)
+  })
+
+  return out
+}
+
+function formatInline(text: string): string {
+  const replacements: string[] = []
+  let out = preserveSupportedHtml(text, replacements)
+
+  out = out.replace(/`([^`]+?)`/g, (_match, code: string) => stash(replacements, `<code>${escapeTelegramHtml(code)}</code>`))
+
+  out = out.replace(/\[([^\]]+?)\]\((https?:\/\/[^\s)]+)\)/g, (match, label: string, url: string) => {
+    const safeHref = sanitizeUrl(url)
+    if (!safeHref) return match
+    return stash(replacements, `<a href="${escapeTelegramAttribute(safeHref)}">${formatInline(label)}</a>`)
+  })
+
+  out = out.replace(/\*\*(?=\S)(.+?\S)\*\*/g, (_match, content: string) => stash(replacements, `<b>${formatInline(content)}</b>`))
+  out = out.replace(/__(?=\S)(.+?\S)__/g, (_match, content: string) => stash(replacements, `<b>${formatInline(content)}</b>`))
+  out = out.replace(/~~(?=\S)(.+?\S)~~/g, (_match, content: string) => stash(replacements, `<s>${formatInline(content)}</s>`))
+  out = out.replace(/\*(?=\S)(.+?\S)\*(?!\*)/g, (_match, content: string) => stash(replacements, `<i>${formatInline(content)}</i>`))
+  out = out.replace(/(^|[^_])_(?=\S)(.+?\S)_(?!_)/g, (_match, prefix: string, content: string) => `${prefix}${stash(replacements, `<i>${formatInline(content)}</i>`)}`)
+
+  out = escapeTelegramHtml(out)
+  return restore(out, replacements)
+}
+
+function formatLine(line: string): string {
+  const headingMatch = line.match(/^#{1,6}\s+(.+)$/)
+  if (headingMatch) return `<b>${formatInline(headingMatch[1]!.trim())}</b>`
+
+  const orderedListMatch = line.match(/^(\s*)(\d+)\.\s+(.+)$/)
+  if (orderedListMatch) {
+    const [, indent, index, content] = orderedListMatch
+    return `${indent}${index}. ${formatInline(content!)}`
+  }
+
+  const unorderedListMatch = line.match(/^(\s*)[-*+]\s+(.+)$/)
+  if (unorderedListMatch) {
+    const [, indent, content] = unorderedListMatch
+    return `${indent}• ${formatInline(content!)}`
+  }
+
+  const blockquoteMatch = line.match(/^>\s?(.*)$/)
+  if (blockquoteMatch) {
+    return `<blockquote>${formatInline(blockquoteMatch[1] ?? '')}</blockquote>`
+  }
+
+  return formatInline(line)
+}
+
+function renderCodeBlock(code: string): string {
+  return `<pre><code>${escapeTelegramHtml(code.replace(/\n+$/g, ''))}</code></pre>`
+}
+
+export function formatForTelegram(text: string): string {
+  const normalized = normalizeLineEndings(text)
+  const replacements: string[] = []
+
+  const withoutCodeBlocks = normalized.replace(/```(?:[A-Za-z0-9_+-]+)?\n?([\s\S]*?)```/g, (_match, code: string) => {
+    return stash(replacements, renderCodeBlock(code))
+  })
+
+  const formatted = withoutCodeBlocks
+    .split('\n')
+    .map((line) => line.length === 0 ? '' : formatLine(line))
+    .join('\n')
+
+  return restore(formatted, replacements)
 }

--- a/packages/messaging-gateway/src/adapters/telegram/index.ts
+++ b/packages/messaging-gateway/src/adapters/telegram/index.ts
@@ -20,7 +20,7 @@ import type {
   ButtonPress,
   MessagingLogger,
 } from '../../types'
-import { formatForTelegram } from './format'
+import { formatForTelegram, TELEGRAM_PARSE_MODE } from './format'
 
 /**
  * Hard cap for downloaded attachment size. Matches `MAX_FILE_SIZE` in
@@ -504,7 +504,9 @@ export class TelegramAdapter implements PlatformAdapter {
   async sendText(channelId: string, text: string): Promise<SentMessage> {
     if (!this.bot) throw new Error('Telegram adapter not initialized')
     const formatted = formatForTelegram(text)
-    const sent = await this.bot.api.sendMessage(Number(channelId), formatted)
+    const sent = await this.bot.api.sendMessage(Number(channelId), formatted, {
+      parse_mode: TELEGRAM_PARSE_MODE,
+    })
     return {
       platform: 'telegram',
       channelId,
@@ -515,12 +517,15 @@ export class TelegramAdapter implements PlatformAdapter {
   async editMessage(channelId: string, messageId: string, text: string): Promise<void> {
     if (!this.bot) throw new Error('Telegram adapter not initialized')
     const formatted = formatForTelegram(text)
-    await this.bot.api.editMessageText(Number(channelId), Number(messageId), formatted)
+    await this.bot.api.editMessageText(Number(channelId), Number(messageId), formatted, {
+      parse_mode: TELEGRAM_PARSE_MODE,
+    })
   }
 
   async sendButtons(channelId: string, text: string, buttons: InlineButton[]): Promise<SentMessage> {
     if (!this.bot) throw new Error('Telegram adapter not initialized')
 
+    const formatted = formatForTelegram(text)
     const keyboard = {
       inline_keyboard: buttons.map((b) => [{
         text: b.label,
@@ -528,7 +533,8 @@ export class TelegramAdapter implements PlatformAdapter {
       }]),
     }
 
-    const sent = await this.bot.api.sendMessage(Number(channelId), text, {
+    const sent = await this.bot.api.sendMessage(Number(channelId), formatted, {
+      parse_mode: TELEGRAM_PARSE_MODE,
       reply_markup: keyboard,
     })
 
@@ -548,7 +554,12 @@ export class TelegramAdapter implements PlatformAdapter {
     if (!this.bot) throw new Error('Telegram adapter not initialized')
 
     const inputFile = new InputFile(file, filename)
-    const sent = await this.bot.api.sendDocument(Number(channelId), inputFile, { caption })
+    const sent = await this.bot.api.sendDocument(Number(channelId), inputFile, caption
+      ? {
+        caption: formatForTelegram(caption),
+        parse_mode: TELEGRAM_PARSE_MODE,
+      }
+      : undefined)
 
     return {
       platform: 'telegram',

--- a/packages/messaging-gateway/src/adapters/telegram/index.ts
+++ b/packages/messaging-gateway/src/adapters/telegram/index.ts
@@ -21,7 +21,7 @@ import type {
   MessagingLogger,
   OutboundTextOptions,
 } from '../../types'
-import { prepareTelegramText } from './format'
+import { getTelegramHtmlTextLength, prepareTelegramText, telegramHtmlToPlainText } from './format'
 
 /**
  * Hard cap for downloaded attachment size. Matches `MAX_FILE_SIZE` in
@@ -30,6 +30,7 @@ import { prepareTelegramText } from './format'
  * with a user-visible reply instead of silently dropping.
  */
 const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024
+const MAX_CAPTION_LENGTH = 1024
 
 /**
  * Minimal mime → extension fallback used when Telegram's `file_path` is
@@ -48,6 +49,19 @@ const MIME_EXT_FALLBACK: Record<string, string> = {
   'audio/mp4': '.m4a',
   'video/mp4': '.mp4',
   'video/quicktime': '.mov',
+}
+
+
+function normalizeTelegramPayload(
+  text: string,
+  maxLength: number,
+  options?: OutboundTextOptions,
+): ReturnType<typeof prepareTelegramText> {
+  if (options?.format === 'html' && getTelegramHtmlTextLength(text) > maxLength) {
+    return { text: telegramHtmlToPlainText(text).slice(0, maxLength) }
+  }
+
+  return prepareTelegramText(text, options)
 }
 
 const NOOP_LOGGER: MessagingLogger = {
@@ -504,7 +518,7 @@ export class TelegramAdapter implements PlatformAdapter {
 
   async sendText(channelId: string, text: string, options?: OutboundTextOptions): Promise<SentMessage> {
     if (!this.bot) throw new Error('Telegram adapter not initialized')
-    const payload = prepareTelegramText(text, options)
+    const payload = normalizeTelegramPayload(text, this.capabilities.maxMessageLength, options)
     const sent = payload.parseMode
       ? await this.bot.api.sendMessage(Number(channelId), payload.text, {
         parse_mode: payload.parseMode,
@@ -519,7 +533,7 @@ export class TelegramAdapter implements PlatformAdapter {
 
   async editMessage(channelId: string, messageId: string, text: string, options?: OutboundTextOptions): Promise<void> {
     if (!this.bot) throw new Error('Telegram adapter not initialized')
-    const payload = prepareTelegramText(text, options)
+    const payload = normalizeTelegramPayload(text, this.capabilities.maxMessageLength, options)
     if (payload.parseMode) {
       await this.bot.api.editMessageText(Number(channelId), Number(messageId), payload.text, {
         parse_mode: payload.parseMode,
@@ -532,7 +546,7 @@ export class TelegramAdapter implements PlatformAdapter {
   async sendButtons(channelId: string, text: string, buttons: InlineButton[], options?: OutboundTextOptions): Promise<SentMessage> {
     if (!this.bot) throw new Error('Telegram adapter not initialized')
 
-    const payload = prepareTelegramText(text, options)
+    const payload = normalizeTelegramPayload(text, this.capabilities.maxMessageLength, options)
     const keyboard = {
       inline_keyboard: buttons.map((b) => [{
         text: b.label,
@@ -561,7 +575,7 @@ export class TelegramAdapter implements PlatformAdapter {
     if (!this.bot) throw new Error('Telegram adapter not initialized')
 
     const inputFile = new InputFile(file, filename)
-    const captionPayload = caption ? prepareTelegramText(caption, captionOptions) : undefined
+    const captionPayload = caption ? normalizeTelegramPayload(caption, MAX_CAPTION_LENGTH, captionOptions) : undefined
     const sent = await this.bot.api.sendDocument(Number(channelId), inputFile, captionPayload
       ? {
         caption: captionPayload.text,

--- a/packages/messaging-gateway/src/adapters/telegram/index.ts
+++ b/packages/messaging-gateway/src/adapters/telegram/index.ts
@@ -19,8 +19,9 @@ import type {
   InlineButton,
   ButtonPress,
   MessagingLogger,
+  OutboundTextOptions,
 } from '../../types'
-import { formatForTelegram, TELEGRAM_PARSE_MODE } from './format'
+import { prepareTelegramText } from './format'
 
 /**
  * Hard cap for downloaded attachment size. Matches `MAX_FILE_SIZE` in
@@ -501,12 +502,14 @@ export class TelegramAdapter implements PlatformAdapter {
     this.buttonHandler = handler
   }
 
-  async sendText(channelId: string, text: string): Promise<SentMessage> {
+  async sendText(channelId: string, text: string, options?: OutboundTextOptions): Promise<SentMessage> {
     if (!this.bot) throw new Error('Telegram adapter not initialized')
-    const formatted = formatForTelegram(text)
-    const sent = await this.bot.api.sendMessage(Number(channelId), formatted, {
-      parse_mode: TELEGRAM_PARSE_MODE,
-    })
+    const payload = prepareTelegramText(text, options)
+    const sent = payload.parseMode
+      ? await this.bot.api.sendMessage(Number(channelId), payload.text, {
+        parse_mode: payload.parseMode,
+      })
+      : await this.bot.api.sendMessage(Number(channelId), payload.text)
     return {
       platform: 'telegram',
       channelId,
@@ -514,18 +517,22 @@ export class TelegramAdapter implements PlatformAdapter {
     }
   }
 
-  async editMessage(channelId: string, messageId: string, text: string): Promise<void> {
+  async editMessage(channelId: string, messageId: string, text: string, options?: OutboundTextOptions): Promise<void> {
     if (!this.bot) throw new Error('Telegram adapter not initialized')
-    const formatted = formatForTelegram(text)
-    await this.bot.api.editMessageText(Number(channelId), Number(messageId), formatted, {
-      parse_mode: TELEGRAM_PARSE_MODE,
-    })
+    const payload = prepareTelegramText(text, options)
+    if (payload.parseMode) {
+      await this.bot.api.editMessageText(Number(channelId), Number(messageId), payload.text, {
+        parse_mode: payload.parseMode,
+      })
+      return
+    }
+    await this.bot.api.editMessageText(Number(channelId), Number(messageId), payload.text)
   }
 
-  async sendButtons(channelId: string, text: string, buttons: InlineButton[]): Promise<SentMessage> {
+  async sendButtons(channelId: string, text: string, buttons: InlineButton[], options?: OutboundTextOptions): Promise<SentMessage> {
     if (!this.bot) throw new Error('Telegram adapter not initialized')
 
-    const formatted = formatForTelegram(text)
+    const payload = prepareTelegramText(text, options)
     const keyboard = {
       inline_keyboard: buttons.map((b) => [{
         text: b.label,
@@ -533,8 +540,8 @@ export class TelegramAdapter implements PlatformAdapter {
       }]),
     }
 
-    const sent = await this.bot.api.sendMessage(Number(channelId), formatted, {
-      parse_mode: TELEGRAM_PARSE_MODE,
+    const sent = await this.bot.api.sendMessage(Number(channelId), payload.text, {
+      ...(payload.parseMode ? { parse_mode: payload.parseMode } : {}),
       reply_markup: keyboard,
     })
 
@@ -550,14 +557,15 @@ export class TelegramAdapter implements PlatformAdapter {
     await this.bot.api.sendChatAction(Number(channelId), 'typing').catch(() => {})
   }
 
-  async sendFile(channelId: string, file: Buffer, filename: string, caption?: string): Promise<SentMessage> {
+  async sendFile(channelId: string, file: Buffer, filename: string, caption?: string, captionOptions?: OutboundTextOptions): Promise<SentMessage> {
     if (!this.bot) throw new Error('Telegram adapter not initialized')
 
     const inputFile = new InputFile(file, filename)
-    const sent = await this.bot.api.sendDocument(Number(channelId), inputFile, caption
+    const captionPayload = caption ? prepareTelegramText(caption, captionOptions) : undefined
+    const sent = await this.bot.api.sendDocument(Number(channelId), inputFile, captionPayload
       ? {
-        caption: formatForTelegram(caption),
-        parse_mode: TELEGRAM_PARSE_MODE,
+        caption: captionPayload.text,
+        ...(captionPayload.parseMode ? { parse_mode: captionPayload.parseMode } : {}),
       }
       : undefined)
 

--- a/packages/messaging-gateway/src/adapters/telegram/send-format.test.ts
+++ b/packages/messaging-gateway/src/adapters/telegram/send-format.test.ts
@@ -8,7 +8,7 @@ function makeAdapterWithApi(api: Record<string, (...args: unknown[]) => Promise<
 }
 
 describe('TelegramAdapter outbound formatting', () => {
-  it('sendText formats content and passes HTML parse_mode', async () => {
+  it('sendText keeps plain text plain by default', async () => {
     const calls: unknown[][] = []
     const adapter = makeAdapterWithApi({
       sendMessage: async (...args) => {
@@ -17,13 +17,27 @@ describe('TelegramAdapter outbound formatting', () => {
       },
     })
 
-    const sent = await adapter.sendText('123', '**bold**')
+    const sent = await adapter.sendText('123', '<b>bold</b>')
 
-    expect(calls).toEqual([[123, '<b>bold</b>', { parse_mode: 'HTML' }]])
+    expect(calls).toEqual([[123, '<b>bold</b>']])
     expect(sent).toEqual({ platform: 'telegram', channelId: '123', messageId: '42' })
   })
 
-  it('editMessage formats content and passes HTML parse_mode', async () => {
+  it('sendText uses parse_mode HTML only when explicitly requested', async () => {
+    const calls: unknown[][] = []
+    const adapter = makeAdapterWithApi({
+      sendMessage: async (...args) => {
+        calls.push(args)
+        return { message_id: 43 }
+      },
+    })
+
+    await adapter.sendText('123', '<b>bold</b>', { format: 'html' })
+
+    expect(calls).toEqual([[123, '<b>bold</b>', { parse_mode: 'HTML' }]])
+  })
+
+  it('editMessage forwards explicit HTML format', async () => {
     const calls: unknown[][] = []
     const adapter = makeAdapterWithApi({
       editMessageText: async (...args) => {
@@ -31,12 +45,12 @@ describe('TelegramAdapter outbound formatting', () => {
       },
     })
 
-    await adapter.editMessage('123', '77', '*italic*')
+    await adapter.editMessage('123', '77', '<i>italic</i>', { format: 'html' })
 
     expect(calls).toEqual([[123, 77, '<i>italic</i>', { parse_mode: 'HTML' }]])
   })
 
-  it('sendButtons formats content and keeps the inline keyboard', async () => {
+  it('sendButtons preserves inline keyboard and optional HTML format', async () => {
     const calls: unknown[][] = []
     const adapter = makeAdapterWithApi({
       sendMessage: async (...args) => {
@@ -45,7 +59,7 @@ describe('TelegramAdapter outbound formatting', () => {
       },
     })
 
-    await adapter.sendButtons('123', '# Plan', [{ id: 'accept', label: 'Accept' }])
+    await adapter.sendButtons('123', '<b>Plan</b>', [{ id: 'accept', label: 'Accept' }], { format: 'html' })
 
     expect(calls).toEqual([[
       123,
@@ -59,7 +73,7 @@ describe('TelegramAdapter outbound formatting', () => {
     ]])
   })
 
-  it('sendFile formats caption and passes HTML parse_mode', async () => {
+  it('sendFile keeps captions plain by default and formats explicitly when requested', async () => {
     const calls: unknown[][] = []
     const adapter = makeAdapterWithApi({
       sendDocument: async (...args) => {
@@ -68,12 +82,13 @@ describe('TelegramAdapter outbound formatting', () => {
       },
     })
 
-    await adapter.sendFile('123', Buffer.from('hello'), 'note.txt', '**caption**')
+    await adapter.sendFile('123', Buffer.from('hello'), 'note.txt', '<b>plain</b>')
+    await adapter.sendFile('123', Buffer.from('hello'), 'note.txt', '<b>html</b>', { format: 'html' })
 
-    expect(calls).toHaveLength(1)
-    expect(calls[0]?.[0]).toBe(123)
-    expect(calls[0]?.[2]).toEqual({
-      caption: '<b>caption</b>',
+    expect(calls).toHaveLength(2)
+    expect(calls[0]?.[2]).toEqual({ caption: '<b>plain</b>' })
+    expect(calls[1]?.[2]).toEqual({
+      caption: '<b>html</b>',
       parse_mode: 'HTML',
     })
   })

--- a/packages/messaging-gateway/src/adapters/telegram/send-format.test.ts
+++ b/packages/messaging-gateway/src/adapters/telegram/send-format.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'bun:test'
+import { TelegramAdapter } from './index'
+
+function makeAdapterWithApi(api: Record<string, (...args: unknown[]) => Promise<unknown>>): TelegramAdapter {
+  const adapter = new TelegramAdapter()
+  ;(adapter as unknown as { bot: { api: typeof api } }).bot = { api }
+  return adapter
+}
+
+describe('TelegramAdapter outbound formatting', () => {
+  it('sendText formats content and passes HTML parse_mode', async () => {
+    const calls: unknown[][] = []
+    const adapter = makeAdapterWithApi({
+      sendMessage: async (...args) => {
+        calls.push(args)
+        return { message_id: 42 }
+      },
+    })
+
+    const sent = await adapter.sendText('123', '**bold**')
+
+    expect(calls).toEqual([[123, '<b>bold</b>', { parse_mode: 'HTML' }]])
+    expect(sent).toEqual({ platform: 'telegram', channelId: '123', messageId: '42' })
+  })
+
+  it('editMessage formats content and passes HTML parse_mode', async () => {
+    const calls: unknown[][] = []
+    const adapter = makeAdapterWithApi({
+      editMessageText: async (...args) => {
+        calls.push(args)
+      },
+    })
+
+    await adapter.editMessage('123', '77', '*italic*')
+
+    expect(calls).toEqual([[123, 77, '<i>italic</i>', { parse_mode: 'HTML' }]])
+  })
+
+  it('sendButtons formats content and keeps the inline keyboard', async () => {
+    const calls: unknown[][] = []
+    const adapter = makeAdapterWithApi({
+      sendMessage: async (...args) => {
+        calls.push(args)
+        return { message_id: 7 }
+      },
+    })
+
+    await adapter.sendButtons('123', '# Plan', [{ id: 'accept', label: 'Accept' }])
+
+    expect(calls).toEqual([[
+      123,
+      '<b>Plan</b>',
+      {
+        parse_mode: 'HTML',
+        reply_markup: {
+          inline_keyboard: [[{ text: 'Accept', callback_data: 'accept' }]],
+        },
+      },
+    ]])
+  })
+
+  it('sendFile formats caption and passes HTML parse_mode', async () => {
+    const calls: unknown[][] = []
+    const adapter = makeAdapterWithApi({
+      sendDocument: async (...args) => {
+        calls.push(args)
+        return { message_id: 8 }
+      },
+    })
+
+    await adapter.sendFile('123', Buffer.from('hello'), 'note.txt', '**caption**')
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.[0]).toBe(123)
+    expect(calls[0]?.[2]).toEqual({
+      caption: '<b>caption</b>',
+      parse_mode: 'HTML',
+    })
+  })
+})

--- a/packages/messaging-gateway/src/adapters/telegram/send-format.test.ts
+++ b/packages/messaging-gateway/src/adapters/telegram/send-format.test.ts
@@ -84,12 +84,16 @@ describe('TelegramAdapter outbound formatting', () => {
 
     await adapter.sendFile('123', Buffer.from('hello'), 'note.txt', '<b>plain</b>')
     await adapter.sendFile('123', Buffer.from('hello'), 'note.txt', '<b>html</b>', { format: 'html' })
+    await adapter.sendFile('123', Buffer.from('hello'), 'note.txt', `<b>${'x'.repeat(1025)}</b>`, { format: 'html' })
 
-    expect(calls).toHaveLength(2)
+    expect(calls).toHaveLength(3)
     expect(calls[0]?.[2]).toEqual({ caption: '<b>plain</b>' })
     expect(calls[1]?.[2]).toEqual({
       caption: '<b>html</b>',
       parse_mode: 'HTML',
+    })
+    expect(calls[2]?.[2]).toEqual({
+      caption: 'x'.repeat(1024),
     })
   })
 })

--- a/packages/messaging-gateway/src/adapters/whatsapp/index.ts
+++ b/packages/messaging-gateway/src/adapters/whatsapp/index.ts
@@ -33,6 +33,7 @@ import type {
   InlineButton,
   ButtonPress,
   MessagingLogger,
+  OutboundTextOptions,
 } from '../../types'
 
 const NOOP_LOGGER: MessagingLogger = {
@@ -274,7 +275,7 @@ export class WhatsAppAdapter implements PlatformAdapter {
     this.sendCommand({ type: 'submit_pairing_phone', phoneNumber })
   }
 
-  async sendText(channelId: string, text: string): Promise<SentMessage> {
+  async sendText(channelId: string, text: string, _options?: OutboundTextOptions): Promise<SentMessage> {
     const id = String(this.nextCmdId++)
     const result = await this.sendWithResult({ id, type: 'send_text', channelId, text })
     if (!result.ok) throw new Error(result.error ?? 'Send failed')
@@ -285,7 +286,7 @@ export class WhatsAppAdapter implements PlatformAdapter {
     }
   }
 
-  async editMessage(_channelId: string, _messageId: string, _text: string): Promise<void> {
+  async editMessage(_channelId: string, _messageId: string, _text: string, _options?: OutboundTextOptions): Promise<void> {
     throw new Error('WhatsApp edit not supported in this adapter')
   }
 
@@ -293,6 +294,7 @@ export class WhatsAppAdapter implements PlatformAdapter {
     channelId: string,
     text: string,
     buttons: InlineButton[],
+    _options?: OutboundTextOptions,
   ): Promise<SentMessage> {
     const numbered = buttons
       .map((b, i) => `${i + 1}. ${b.label}`)
@@ -311,6 +313,7 @@ export class WhatsAppAdapter implements PlatformAdapter {
     file: Buffer,
     filename: string,
     caption?: string,
+    _captionOptions?: OutboundTextOptions,
   ): Promise<SentMessage> {
     const id = String(this.nextCmdId++)
     const result = await this.sendWithResult({

--- a/packages/messaging-gateway/src/renderer.ts
+++ b/packages/messaging-gateway/src/renderer.ts
@@ -34,6 +34,7 @@ import type {
   OutboundTextFormat,
   OutboundTextOptions,
 } from './types'
+import { getTelegramHtmlTextLength, telegramHtmlToPlainText } from './adapters/telegram/format'
 import type { PlanTokenRegistry } from './plan-tokens'
 
 /** Session event shape (subset of the full SessionEvent from server-core). */
@@ -315,9 +316,9 @@ export class Renderer {
         const isIntermediate = Boolean(event.isIntermediate)
         const text = typeof event.text === 'string' ? event.text : ''
         if (!isIntermediate && text.trim()) {
-          // Last assistant text of the run — keep it for the final edit.
-          state.finalBuffer = appendFinal(state.finalBuffer, text)
-          state.finalFormat = mergeOutboundTextFormat(state.finalFormat, event.format)
+          const next = appendFinalWithFormat(state.finalBuffer, state.finalFormat, text, event.format)
+          state.finalBuffer = next.text
+          state.finalFormat = next.format
         }
         // Intermediate text is dropped. Make sure the bubble exists and shows
         // thinking status so the user knows the run is alive.
@@ -352,7 +353,7 @@ export class Renderer {
               adapter,
               binding.channelId,
               state.progressMessageId,
-              truncateForAdapter(finalText, adapter),
+              finalText,
               state,
               toOutboundTextOptions(state.finalFormat),
             )
@@ -416,8 +417,9 @@ export class Renderer {
         const isIntermediate = Boolean(event.isIntermediate)
         const text = typeof event.text === 'string' ? event.text : ''
         if (!isIntermediate && text.trim()) {
-          state.finalBuffer = appendFinal(state.finalBuffer, text)
-          state.finalFormat = mergeOutboundTextFormat(state.finalFormat, event.format)
+          const next = appendFinalWithFormat(state.finalBuffer, state.finalFormat, text, event.format)
+          state.finalBuffer = next.text
+          state.finalFormat = next.format
         }
         return
       }
@@ -577,7 +579,7 @@ Approve in the desktop app to continue.`,
   ): Promise<void> {
     const errorMsg = extractErrorMessage(event.error)
     this.cancelEditTimer(state)
-    await adapter.sendText(binding.channelId, `❌ ${errorMsg}`, toOutboundTextOptions(event.format))
+    await this.sendText(adapter, binding, `❌ ${errorMsg}`, toOutboundTextOptions(event.format))
     this.resetRun(state)
   }
 
@@ -593,10 +595,13 @@ Approve in the desktop app to continue.`,
     state: RenderState,
     options?: OutboundTextOptions,
   ): Promise<void> {
-    const truncated = truncateForAdapter(text, adapter)
+    const normalized = normalizeOutboundTextPayload(text, adapter, options)
+    const truncated = normalized.length <= adapter.capabilities.maxMessageLength
+      ? normalized.text
+      : truncateForAdapter(normalized.text, adapter)
 
     try {
-      await adapter.editMessage(channelId, messageId, truncated, options)
+      await adapter.editMessage(channelId, messageId, truncated, normalized.options)
       state.currentEditIntervalMs = DEFAULT_EDIT_INTERVAL_MS
     } catch (err: unknown) {
       const is429 =
@@ -639,15 +644,16 @@ Approve in the desktop app to continue.`,
     text: string,
     options?: OutboundTextOptions,
   ): Promise<SentMessage | undefined> {
+    const normalized = normalizeOutboundTextPayload(text, adapter, options)
     const maxLen = adapter.capabilities.maxMessageLength
-    if (text.length <= maxLen) {
-      return adapter.sendText(binding.channelId, text, options)
+    if (normalized.length <= maxLen) {
+      return adapter.sendText(binding.channelId, normalized.text, normalized.options)
     }
 
-    const chunks = splitText(text, maxLen)
+    const chunks = splitText(normalized.text, maxLen)
     let last: SentMessage | undefined
     for (const chunk of chunks) {
-      last = await adapter.sendText(binding.channelId, chunk, options)
+      last = await adapter.sendText(binding.channelId, chunk, normalized.options)
     }
     return last
   }
@@ -667,13 +673,50 @@ Approve in the desktop app to continue.`,
 // ---------------------------------------------------------------------------
 
 
-function mergeOutboundTextFormat(
-  current: OutboundTextFormat | undefined,
-  next: unknown,
-): OutboundTextFormat {
-  const resolved = next === 'html' ? 'html' : 'plain'
-  if (!current) return resolved
-  return current === resolved ? current : 'plain'
+
+function normalizeOutboundTextPayload(
+  text: string,
+  adapter: PlatformAdapter,
+  options?: OutboundTextOptions,
+): { text: string; options?: OutboundTextOptions; length: number } {
+  if (options?.format === 'html') {
+    if (adapter.platform === 'telegram') {
+      const length = getTelegramHtmlTextLength(text)
+      if (length <= adapter.capabilities.maxMessageLength) {
+        return { text, options, length }
+      }
+      const plainText = telegramHtmlToPlainText(text)
+      return { text: plainText, length: plainText.length }
+    }
+
+    const plainText = telegramHtmlToPlainText(text)
+    return { text: plainText, length: plainText.length }
+  }
+
+  return { text, options, length: text.length }
+}
+
+function appendFinalWithFormat(
+  currentText: string,
+  currentFormat: OutboundTextFormat | undefined,
+  nextText: string,
+  nextFormatValue: unknown,
+): { text: string; format: OutboundTextFormat } {
+  const nextFormat = nextFormatValue === 'html' ? 'html' : 'plain'
+  if (!currentFormat) {
+    return { text: appendFinal('', nextText), format: nextFormat }
+  }
+  if (currentFormat === nextFormat) {
+    return { text: appendFinal(currentText, nextText), format: currentFormat }
+  }
+  return {
+    text: appendFinal(toPlainTextForFormat(currentText, currentFormat), toPlainTextForFormat(nextText, nextFormat)),
+    format: 'plain',
+  }
+}
+
+function toPlainTextForFormat(text: string, format: OutboundTextFormat): string {
+  return format === 'html' ? telegramHtmlToPlainText(text) : text
 }
 
 function toOutboundTextOptions(format: unknown): OutboundTextOptions | undefined {

--- a/packages/messaging-gateway/src/renderer.ts
+++ b/packages/messaging-gateway/src/renderer.ts
@@ -31,6 +31,8 @@ import type {
   SentMessage,
   InlineButton,
   ResponseMode,
+  OutboundTextFormat,
+  OutboundTextOptions,
 } from './types'
 import type { PlanTokenRegistry } from './plan-tokens'
 
@@ -72,6 +74,8 @@ interface RenderState {
   progressMessageId: string | null
   /** Progress: last status label written to the bubble, to avoid redundant edits. */
   progressStatus: string | null
+  /** Format of accumulated final assistant text for this run. */
+  finalFormat: OutboundTextFormat | undefined
 }
 
 const DEFAULT_EDIT_INTERVAL_MS = 3500
@@ -125,6 +129,7 @@ export class Renderer {
         finalBuffer: '',
         progressMessageId: null,
         progressStatus: null,
+        finalFormat: undefined,
       }
       this.states.set(bindingId, state)
     }
@@ -193,14 +198,15 @@ export class Renderer {
 
       case 'text_complete': {
         const text = typeof event.text === 'string' ? event.text : state.textBuffer
+        const options = toOutboundTextOptions(event.format)
         this.cancelEditTimer(state)
 
         if (state.streamingMessageId && adapter.capabilities.messageEditing) {
           if (text.trim()) {
-            await this.tryEditMessage(adapter, binding.channelId, state.streamingMessageId, text.trim(), state)
+            await this.tryEditMessage(adapter, binding.channelId, state.streamingMessageId, text.trim(), state, options)
           }
         } else if (text.trim()) {
-          await this.sendText(adapter, binding, text.trim())
+          await this.sendText(adapter, binding, text.trim(), options)
         }
 
         state.textBuffer = ''
@@ -311,6 +317,7 @@ export class Renderer {
         if (!isIntermediate && text.trim()) {
           // Last assistant text of the run — keep it for the final edit.
           state.finalBuffer = appendFinal(state.finalBuffer, text)
+          state.finalFormat = mergeOutboundTextFormat(state.finalFormat, event.format)
         }
         // Intermediate text is dropped. Make sure the bubble exists and shows
         // thinking status so the user knows the run is alive.
@@ -347,6 +354,7 @@ export class Renderer {
               state.progressMessageId,
               truncateForAdapter(finalText, adapter),
               state,
+              toOutboundTextOptions(state.finalFormat),
             )
           }
           // If the run ended with no final text, leave the last status in
@@ -354,7 +362,7 @@ export class Renderer {
           // Telegram "message is not modified" errors and keeps a trace.
         } else if (finalText) {
           // Adapter can't edit (WhatsApp) — send one message at the end.
-          await this.sendText(adapter, binding, finalText)
+          await this.sendText(adapter, binding, finalText, toOutboundTextOptions(state.finalFormat))
         }
         this.resetRun(state)
         return
@@ -409,6 +417,7 @@ export class Renderer {
         const text = typeof event.text === 'string' ? event.text : ''
         if (!isIntermediate && text.trim()) {
           state.finalBuffer = appendFinal(state.finalBuffer, text)
+          state.finalFormat = mergeOutboundTextFormat(state.finalFormat, event.format)
         }
         return
       }
@@ -416,7 +425,7 @@ export class Renderer {
       case 'complete': {
         const finalText = state.finalBuffer.trim()
         if (finalText) {
-          await this.sendText(adapter, binding, finalText)
+          await this.sendText(adapter, binding, finalText, toOutboundTextOptions(state.finalFormat))
         }
         this.resetRun(state)
         return
@@ -568,7 +577,7 @@ Approve in the desktop app to continue.`,
   ): Promise<void> {
     const errorMsg = extractErrorMessage(event.error)
     this.cancelEditTimer(state)
-    await adapter.sendText(binding.channelId, `❌ ${errorMsg}`)
+    await adapter.sendText(binding.channelId, `❌ ${errorMsg}`, toOutboundTextOptions(event.format))
     this.resetRun(state)
   }
 
@@ -582,11 +591,12 @@ Approve in the desktop app to continue.`,
     messageId: string,
     text: string,
     state: RenderState,
+    options?: OutboundTextOptions,
   ): Promise<void> {
     const truncated = truncateForAdapter(text, adapter)
 
     try {
-      await adapter.editMessage(channelId, messageId, truncated)
+      await adapter.editMessage(channelId, messageId, truncated, options)
       state.currentEditIntervalMs = DEFAULT_EDIT_INTERVAL_MS
     } catch (err: unknown) {
       const is429 =
@@ -619,6 +629,7 @@ Approve in the desktop app to continue.`,
     state.finalBuffer = ''
     state.progressMessageId = null
     state.progressStatus = null
+    state.finalFormat = undefined
   }
 
   /** Send text, splitting if it exceeds platform limits. */
@@ -626,16 +637,17 @@ Approve in the desktop app to continue.`,
     adapter: PlatformAdapter,
     binding: ChannelBinding,
     text: string,
+    options?: OutboundTextOptions,
   ): Promise<SentMessage | undefined> {
     const maxLen = adapter.capabilities.maxMessageLength
     if (text.length <= maxLen) {
-      return adapter.sendText(binding.channelId, text)
+      return adapter.sendText(binding.channelId, text, options)
     }
 
     const chunks = splitText(text, maxLen)
     let last: SentMessage | undefined
     for (const chunk of chunks) {
-      last = await adapter.sendText(binding.channelId, chunk)
+      last = await adapter.sendText(binding.channelId, chunk, options)
     }
     return last
   }
@@ -653,6 +665,20 @@ Approve in the desktop app to continue.`,
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+
+function mergeOutboundTextFormat(
+  current: OutboundTextFormat | undefined,
+  next: unknown,
+): OutboundTextFormat {
+  const resolved = next === 'html' ? 'html' : 'plain'
+  if (!current) return resolved
+  return current === resolved ? current : 'plain'
+}
+
+function toOutboundTextOptions(format: unknown): OutboundTextOptions | undefined {
+  return format === 'html' ? { format: 'html' } : undefined
+}
 
 function resolveResponseMode(
   responseMode: ResponseMode | undefined,

--- a/packages/messaging-gateway/src/types.ts
+++ b/packages/messaging-gateway/src/types.ts
@@ -113,6 +113,12 @@ export interface SentMessage {
   messageId: string
 }
 
+export type OutboundTextFormat = 'plain' | 'html'
+
+export interface OutboundTextOptions {
+  format?: OutboundTextFormat
+}
+
 export interface InlineButton {
   id: string
   label: string
@@ -152,11 +158,11 @@ export interface PlatformAdapter {
   onMessage(handler: (msg: IncomingMessage) => Promise<void>): void
   onButtonPress(handler: (press: ButtonPress) => Promise<void>): void
 
-  sendText(channelId: string, text: string): Promise<SentMessage>
-  editMessage(channelId: string, messageId: string, text: string): Promise<void>
-  sendButtons(channelId: string, text: string, buttons: InlineButton[]): Promise<SentMessage>
+  sendText(channelId: string, text: string, options?: OutboundTextOptions): Promise<SentMessage>
+  editMessage(channelId: string, messageId: string, text: string, options?: OutboundTextOptions): Promise<void>
+  sendButtons(channelId: string, text: string, buttons: InlineButton[], options?: OutboundTextOptions): Promise<SentMessage>
   sendTyping(channelId: string): Promise<void>
-  sendFile(channelId: string, file: Buffer, filename: string, caption?: string): Promise<SentMessage>
+  sendFile(channelId: string, file: Buffer, filename: string, caption?: string, captionOptions?: OutboundTextOptions): Promise<SentMessage>
 
   /**
    * Clear the inline keyboard on a previously-sent message. Optional because

--- a/packages/server-core/src/sessions/SessionManager.ts
+++ b/packages/server-core/src/sessions/SessionManager.ts
@@ -6130,7 +6130,7 @@ export class SessionManager implements ISessionManager {
           }
         }
 
-        this.sendEvent({ type: 'text_complete', sessionId, text: event.text, isIntermediate: event.isIntermediate, turnId: event.turnId, parentToolUseId: event.parentToolUseId, timestamp: assistantMessage.timestamp, messageId: assistantMessage.id }, workspaceId)
+        this.sendEvent({ type: 'text_complete', sessionId, text: event.text, format: event.format, isIntermediate: event.isIntermediate, turnId: event.turnId, parentToolUseId: event.parentToolUseId, timestamp: assistantMessage.timestamp, messageId: assistantMessage.id }, workspaceId)
 
         // Persist session after complete message to prevent data loss on quit
         this.persistSession(managed)
@@ -6381,6 +6381,7 @@ export class SessionManager implements ISessionManager {
           type: 'status',
           sessionId,
           message: event.message,
+          format: event.format,
           statusType: event.message.includes('Compacting') ? 'compacting' : undefined
         }, workspaceId)
         break
@@ -6426,6 +6427,7 @@ export class SessionManager implements ISessionManager {
           type: 'info',
           sessionId,
           message: event.message,
+          format: event.format,
           statusType: isCompactionComplete ? 'compaction_complete' : undefined,
           timestamp: infoTimestamp,
         }, workspaceId)
@@ -6467,7 +6469,7 @@ export class SessionManager implements ISessionManager {
           timestamp: this.monotonic()
         }
         managed.messages.push(errorMessage)
-        this.sendEvent({ type: 'error', sessionId, error: event.message, timestamp: errorMessage.timestamp }, workspaceId)
+        this.sendEvent({ type: 'error', sessionId, error: event.message, format: event.format, timestamp: errorMessage.timestamp }, workspaceId)
         break
       }
 

--- a/packages/shared/src/protocol/dto.ts
+++ b/packages/shared/src/protocol/dto.ts
@@ -166,15 +166,15 @@ export interface PermissionModeState {
 // turnId: Correlation ID from the API's message.id, groups all events in an assistant turn
 export type SessionEvent =
   | { type: 'text_delta'; sessionId: string; delta: string; turnId?: string }
-  | { type: 'text_complete'; sessionId: string; text: string; isIntermediate?: boolean; turnId?: string; parentToolUseId?: string; timestamp?: number; messageId?: string }
+  | { type: 'text_complete'; sessionId: string; text: string; format?: 'plain' | 'html'; isIntermediate?: boolean; turnId?: string; parentToolUseId?: string; timestamp?: number; messageId?: string }
   | { type: 'tool_start'; sessionId: string; toolName: string; toolUseId: string; toolInput: Record<string, unknown>; toolIntent?: string; toolDisplayName?: string; toolDisplayMeta?: ToolDisplayMeta; turnId?: string; parentToolUseId?: string; timestamp?: number }
   | { type: 'tool_result'; sessionId: string; toolUseId: string; toolName: string; result: string; turnId?: string; parentToolUseId?: string; isError?: boolean; timestamp?: number }
-  | { type: 'error'; sessionId: string; error: string; timestamp?: number }
+  | { type: 'error'; sessionId: string; error: string; format?: 'plain' | 'html'; timestamp?: number }
   | { type: 'typed_error'; sessionId: string; error: TypedError; timestamp?: number }
   | { type: 'complete'; sessionId: string; tokenUsage?: Session['tokenUsage']; hasUnread?: boolean }
   | { type: 'interrupted'; sessionId: string; message?: Message; queuedMessages?: string[] }
-  | { type: 'status'; sessionId: string; message: string; statusType?: 'compacting' }
-  | { type: 'info'; sessionId: string; message: string; statusType?: 'compaction_complete'; level?: 'info' | 'warning' | 'error' | 'success'; timestamp?: number }
+  | { type: 'status'; sessionId: string; message: string; format?: 'plain' | 'html'; statusType?: 'compacting' }
+  | { type: 'info'; sessionId: string; message: string; format?: 'plain' | 'html'; statusType?: 'compaction_complete'; level?: 'info' | 'warning' | 'error' | 'success'; timestamp?: number }
   | { type: 'title_generated'; sessionId: string; title: string }
   | { type: 'title_regenerating'; sessionId: string; isRegenerating: boolean }
   | { type: 'async_operation'; sessionId: string; isOngoing: boolean }


### PR DESCRIPTION
## Summary
- add an explicit outbound text format option so Telegram stays plain text by default
- enable `format: 'html'` for Telegram only when the caller explicitly requests it
- sanitize Telegram HTML, preserve safe formatting, and fall back safely for malformed or over-limit content
- cover renderer behavior, Telegram adapter behavior, captions, mixed-format runs, and fallback edge cases with focused tests

## Testing
- `bun test packages/messaging-gateway/src/adapters/telegram/format.test.ts packages/messaging-gateway/src/adapters/telegram/send-format.test.ts packages/messaging-gateway/src/adapters/telegram/dm-only.test.ts packages/messaging-gateway/src/__tests__/renderer.test.ts`