### PR TITLE
feat(tools): add set_working_directory tool

### DIFF
--- a/packages/server-core/src/sessions/SessionManager.ts
+++ b/packages/server-core/src/sessions/SessionManager.ts
@@ -2,7 +2,7 @@ import type { EventSink } from '@craft-agent/server-core/transport'
 import type { ISessionManager, IBrowserPaneManager } from '@craft-agent/server-core/handlers'
 import { validateFilePath, getWorkspaceAllowedDirs } from '@craft-agent/server-core/handlers'
 import { createScopedLogger, CONSOLE_LOGGER, type PlatformServices, type Logger } from '@craft-agent/server-core/runtime'
-import { basename, dirname, join } from 'path'
+import { basename, dirname, join, isAbsolute, resolve as resolvePath } from 'path'
 import { existsSync } from 'fs'
 import { readFile, writeFile, mkdir } from 'fs/promises'
 import { randomUUID } from 'node:crypto'
@@ -3462,6 +3462,65 @@ export class SessionManager implements ISessionManager {
         },
         setSessionStatusFn: async (sessionId: string | undefined, status: string) => {
           await this.setSessionStatus(sessionId ?? managed.id, status as SessionStatus)
+        },
+        setWorkingDirectoryFn: async (newPath: string) => {
+          // Resolve relative paths against the session's authoritative
+          // working directory (NOT process.cwd, which is the app/server
+          // launch directory). The handler intentionally forwards the
+          // tilde-expanded path verbatim so this layer owns resolution.
+          //
+          // Fallback chain mirrors getWorkingDirectoryContext: explicit
+          // session.workingDirectory → sdkCwd (set at session creation,
+          // never changes) → the session's storage folder. We deliberately
+          // do NOT fall back to workspace.rootPath or process.cwd — the
+          // former is wrong for default sessions, the latter is the
+          // app/server launch directory.
+          const base =
+            managed.workingDirectory ?? managed.sdkCwd ?? this.getSessionPath(managed.id) ?? process.cwd()
+          const resolved = isAbsolute(newPath) ? newPath : resolvePath(base, newPath)
+          const validation = isValidWorkingDirectory(resolved)
+          if (!validation.valid) {
+            return { ok: false, reason: validation.reason ?? 'invalid path', path: resolved }
+          }
+
+          // Detect whether the live SDK subprocess will pick up the new cwd.
+          // SessionManager.updateWorkingDirectory only updates sdkCwd when no
+          // SDK interaction has occurred yet (no messages, no agent). For an
+          // already-running session the Claude SDK / Bash subprocess stays
+          // rooted at the original sdkCwd — file/shell tools that rely on
+          // the SDK process cwd will keep using the old path until the
+          // session is restarted. Surface this so the LLM doesn't claim a
+          // full cwd switch when only the working-directory context moved.
+          const sdkLocked =
+            managed.messages.length > 0 || !!managed.sdkSessionId || !!managed.agent
+
+          this.updateWorkingDirectory(managed.id, resolved)
+          // updateWorkingDirectory only enqueues a debounced persist (~500ms).
+          // Flush synchronously so that follow-up session tools (e.g.
+          // skill_validate) which read workingDirectory from session.jsonl
+          // when the live context is missing don't observe the stale value.
+          await sessionPersistenceQueue.flush(managed.id)
+
+          // Emit the partial-apply note whenever the SDK process is locked,
+          // regardless of whether we know the original cwd — legacy sessions
+          // can have a live agent rooted at the session folder via the
+          // ClaudeAgent fallback while `managed.sdkCwd` is still undefined.
+          // Only suppress the note when we definitively know the SDK is
+          // already at the new path.
+          const sdkAtTarget = managed.sdkCwd === resolved
+          return {
+            ok: true,
+            path: resolved,
+            ...(sdkLocked && !sdkAtTarget
+              ? {
+                  reason:
+                    `note: working-directory context updated to ${resolved}, but the live SDK session ` +
+                    `is still rooted at ${managed.sdkCwd ?? 'its original cwd'} and reopening this session ` +
+                    `will reuse that original cwd. Use absolute paths in subsequent Bash/Read/Edit calls, or ` +
+                    `start a brand-new session if the SDK process must be re-rooted.`,
+                }
+              : {}),
+          }
         },
         getSessionInfoFn: (sessionId?: string) => {
           const targetId = sessionId ?? managed.id

--- a/packages/session-tools-core/src/context.ts
+++ b/packages/session-tools-core/src/context.ts
@@ -316,6 +316,17 @@ export interface SessionToolContext {
   /** Set status on a session. Defaults to current session if no ID given. Injected by backend. */
   setSessionStatus?(sessionId: string | undefined, status: string): void | Promise<void>;
 
+  /**
+   * Change the working directory of the current session.
+   *
+   * The backend is responsible for resolving relative paths against the
+   * session's authoritative working directory (the SessionToolContext does
+   * not reliably carry it). On success returns `{ ok: true, path }` with the
+   * absolute path that was applied; on failure returns `{ ok: false, reason }`.
+   * Injected by backend.
+   */
+  setWorkingDirectory?(path: string): Promise<{ ok: boolean; reason?: string; path?: string }>;
+
   /** Get detailed info about a session. Defaults to current session if no ID given. Injected by backend. */
   getSessionInfo?(sessionId?: string): SessionInfo | null;
 

--- a/packages/session-tools-core/src/handlers/set-working-directory.test.ts
+++ b/packages/session-tools-core/src/handlers/set-working-directory.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'bun:test';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { handleSetWorkingDirectory } from './set-working-directory.ts';
+import type { SessionToolContext } from '../context.ts';
+
+function makeCtx(opts: {
+  setWorkingDirectory?: (p: string) => Promise<{ ok: boolean; reason?: string }>;
+  workingDirectory?: string;
+}): SessionToolContext {
+  return {
+    sessionId: 's1',
+    workspacePath: '/tmp/ws',
+    plansFolderPath: '/tmp/ws/plans',
+    callbacks: { onPlanSubmitted: () => {}, onAuthRequest: () => {} },
+    fs: {} as any,
+    workingDirectory: opts.workingDirectory,
+    setWorkingDirectory: opts.setWorkingDirectory,
+    loadSourceConfig: () => null,
+    get sourcesPath() { return '/tmp/ws/sources'; },
+    get skillsPath() { return '/tmp/ws/skills'; },
+  } as SessionToolContext;
+}
+
+describe('handleSetWorkingDirectory', () => {
+  it('returns error when binding is missing', async () => {
+    const result = await handleSetWorkingDirectory(makeCtx({}), { path: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result)).toContain('not available');
+  });
+
+  it('rejects empty path', async () => {
+    const result = await handleSetWorkingDirectory(
+      makeCtx({ setWorkingDirectory: async () => ({ ok: true }) }),
+      { path: '   ' }
+    );
+    expect(result.isError).toBe(true);
+  });
+
+  it('expands tilde and forwards to backend', async () => {
+    let received: string | null = null;
+    const ctx = makeCtx({
+      setWorkingDirectory: async (p) => {
+        received = p;
+        return { ok: true, path: p };
+      },
+    });
+    const result = await handleSetWorkingDirectory(ctx, { path: '~' });
+    expect(result.isError).toBeFalsy();
+    expect(received).toBe(os.homedir());
+  });
+
+  it('forwards relative paths verbatim (resolution is the backend\'s job)', async () => {
+    let received: string | null = null;
+    const ctx = makeCtx({
+      workingDirectory: '/tmp/base',
+      setWorkingDirectory: async (p) => {
+        received = p;
+        return { ok: true, path: '/tmp/base/sub/dir' };
+      },
+    });
+    const result = await handleSetWorkingDirectory(ctx, { path: 'sub/dir' });
+    expect(result.isError).toBeFalsy();
+    // Handler must NOT resolve against process.cwd or ctx.workingDirectory —
+    // SessionToolContext.workingDirectory is unreliable across backends.
+    expect(received).toBe('sub/dir');
+    expect(JSON.stringify(result)).toContain('/tmp/base/sub/dir');
+  });
+
+  it('expands Windows-style ~\\ home-relative paths', async () => {
+    let received: string | null = null;
+    const ctx = makeCtx({
+      setWorkingDirectory: async (p) => {
+        received = p;
+        return { ok: true, path: p };
+      },
+    });
+    await handleSetWorkingDirectory(ctx, { path: '~\\projects' });
+    expect(received).toBe(path.join(os.homedir(), 'projects'));
+  });
+
+  it('surfaces backend rejection reason', async () => {
+    const ctx = makeCtx({
+      setWorkingDirectory: async () => ({ ok: false, reason: 'not a directory' }),
+    });
+    const result = await handleSetWorkingDirectory(ctx, { path: '/tmp/file.txt' });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result)).toContain('not a directory');
+  });
+});

--- a/packages/session-tools-core/src/handlers/set-working-directory.ts
+++ b/packages/session-tools-core/src/handlers/set-working-directory.ts
@@ -1,0 +1,65 @@
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { SessionToolContext } from '../context.ts';
+import type { ToolResult } from '../types.ts';
+import { successResponse, errorResponse } from '../response.ts';
+
+export interface SetWorkingDirectoryArgs {
+  path: string;
+}
+
+/**
+ * Expand `~`, `~/...`, `$HOME`, and `${HOME}` to the user's home directory.
+ * Mirrors the expansion done by spawn_session so behaviour is consistent.
+ *
+ * Relative paths are intentionally NOT resolved here: `SessionToolContext`
+ * does not reliably carry the session's live working directory in every
+ * backend, and `process.cwd()` is the app/server launch directory rather
+ * than the session cwd. Resolution is delegated to the injected backend
+ * callback (`setWorkingDirectory`) which owns the authoritative cwd.
+ */
+function expandPath(input: string): string {
+  const home = os.homedir();
+  let p = input.trim();
+  if (p === '~') return home;
+  // Accept both POSIX (`~/foo`) and Windows (`~\foo`) home-relative paths
+  // since users and models on Windows commonly produce the latter.
+  if (p.startsWith('~/') || p.startsWith('~\\')) {
+    p = path.join(home, p.slice(2));
+  }
+  p = p.replace(/\$\{HOME\}/g, home).replace(/\$HOME(?![A-Za-z0-9_])/g, home);
+  return p;
+}
+
+export async function handleSetWorkingDirectory(
+  ctx: SessionToolContext,
+  args: SetWorkingDirectoryArgs
+): Promise<ToolResult> {
+  if (!ctx.setWorkingDirectory) {
+    return errorResponse('set_working_directory is not available in this context.');
+  }
+
+  const raw = (args.path ?? '').toString();
+  if (!raw.trim()) {
+    return errorResponse('path is required and must be a non-empty string.');
+  }
+
+  const expanded = expandPath(raw);
+
+  try {
+    const result = await ctx.setWorkingDirectory(expanded);
+    if (!result.ok) {
+      return errorResponse(
+        `Failed to change working directory to "${result.path ?? expanded}": ${result.reason ?? 'unknown error'}`
+      );
+    }
+    const applied = result.path ?? expanded;
+    // The backend may set `reason` even on success to flag a partial apply
+    // (e.g. the live SDK subprocess is still rooted at the original cwd).
+    const note = result.reason ? ` (${result.reason})` : '';
+    return successResponse(`Working directory changed to ${applied}.${note}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return errorResponse(`Failed to change working directory: ${message}`);
+  }
+}

--- a/packages/session-tools-core/src/tool-defs.ts
+++ b/packages/session-tools-core/src/tool-defs.ts
@@ -36,6 +36,7 @@ import { handleRenderTemplate } from './handlers/render-template.ts';
 import { handleSendDeveloperFeedback } from './handlers/send-developer-feedback.ts';
 import { handleSetSessionLabels } from './handlers/set-session-labels.ts';
 import { handleSetSessionStatus } from './handlers/set-session-status.ts';
+import { handleSetWorkingDirectory } from './handlers/set-working-directory.ts';
 import { handleGetSessionInfo } from './handlers/get-session-info.ts';
 import { handleListSessions } from './handlers/list-sessions.ts';
 import { handleSendAgentMessage } from './handlers/send-agent-message.ts';
@@ -188,6 +189,12 @@ export const SetSessionLabelsSchema = z.object({
 export const SetSessionStatusSchema = z.object({
   sessionId: z.string().optional().describe('Session ID to update. Omit to update the current session.'),
   status: z.string().describe('Status to set (e.g., "todo", "in_progress", "done")'),
+});
+
+export const SetWorkingDirectorySchema = z.object({
+  path: z.string().describe(
+    'New working directory for the current session. Absolute paths are used as-is. Tilde (~), $HOME and ${HOME} are expanded. Relative paths resolve against the current working directory. The directory must already exist.'
+  ),
 });
 
 export const GetSessionInfoSchema = z.object({
@@ -461,6 +468,23 @@ Pass an empty array to clear all labels. Omit sessionId to target the current se
 Use this to signal completion or trigger status-based automations (SessionStatusChange events).
 Omit sessionId to target the current session.`,
 
+  set_working_directory: `Change the working directory of the current session.
+
+Use this when the user asks you to switch context to another folder — for example, "cd into ~/code/foo" or "work on the other repo now" — instead of spawning a new session.
+
+**What this updates:**
+- The session's recorded \`workingDirectory\` and the working-directory context that gets injected into the prompt.
+- Permission checks that scope file/shell tools by working directory.
+- A \`working_directory_changed\` event so the UI stays in sync.
+
+**What this does NOT update on the live SDK process:**
+- The Claude SDK / shell subprocess cwd. Because this tool is invoked from inside a running session, the SDK has already been spawned with its original \`sdkCwd\` and that cwd is persisted with the session — reopening the same session reuses it. Bash, file reads, and other process-cwd-bound tools therefore keep using the original directory; restarting THIS session will not change that. The tool response includes a note when this happens; treat it as a warning and use **absolute paths** in subsequent Bash / Read / Edit calls, or ask the user to start a brand-new session, instead of assuming relative paths now resolve from the new cwd.
+
+**Path semantics:**
+- \`~\`, \`$HOME\` and \`\${HOME}\` are expanded.
+- Relative paths are resolved by the backend against the session's authoritative cwd (NOT the host process cwd).
+- The target must exist and be a directory; otherwise the call returns an error and nothing changes.`,
+
   get_session_info: `Get metadata about the current session or a specific session by ID.
 
 Returns labels, status, name, permission mode, and other details.
@@ -551,6 +575,7 @@ export const SESSION_TOOL_DEFS: SessionToolDef[] = [
   // Session self-management tools (registry — use context callbacks to reach SessionManager)
   { name: 'set_session_labels', description: TOOL_DESCRIPTIONS.set_session_labels, inputSchema: SetSessionLabelsSchema, executionMode: 'registry', safeMode: 'block', handler: handleSetSessionLabels },
   { name: 'set_session_status', description: TOOL_DESCRIPTIONS.set_session_status, inputSchema: SetSessionStatusSchema, executionMode: 'registry', safeMode: 'block', handler: handleSetSessionStatus },
+  { name: 'set_working_directory', description: TOOL_DESCRIPTIONS.set_working_directory, inputSchema: SetWorkingDirectorySchema, executionMode: 'registry', safeMode: 'block', handler: handleSetWorkingDirectory },
   { name: 'get_session_info', description: TOOL_DESCRIPTIONS.get_session_info, inputSchema: GetSessionInfoSchema, executionMode: 'registry', safeMode: 'allow', readOnly: true, handler: handleGetSessionInfo },
   { name: 'list_sessions', description: TOOL_DESCRIPTIONS.list_sessions, inputSchema: ListSessionsSchema, executionMode: 'registry', safeMode: 'allow', readOnly: true, handler: handleListSessions },
   // Inter-session messaging

--- a/packages/shared/src/agent/claude-agent.ts
+++ b/packages/shared/src/agent/claude-agent.ts
@@ -2466,12 +2466,17 @@ This is a branched conversation. All prior messages in this conversation are par
 
   /**
    * Update the working directory for this agent's session.
-   * Called when user changes the working directory in the UI.
+   * Called when user changes the working directory in the UI, and also from
+   * the agent-initiated `set_working_directory` tool. Must keep the
+   * PermissionManager in sync — otherwise pre-tool-use checks for `Read`,
+   * `Edit`, `Bash`, etc. continue to enforce the old project root and can
+   * block legitimate operations under the new directory.
    */
   updateWorkingDirectory(path: string): void {
     if (this.config.session) {
       this.config.session.workingDirectory = path;
     }
+    this.permissionManager.updateWorkingDirectory(path);
   }
 
   /**

--- a/packages/shared/src/agent/session-scoped-tool-callback-registry.ts
+++ b/packages/shared/src/agent/session-scoped-tool-callback-registry.ts
@@ -55,6 +55,8 @@ export interface SessionScopedToolCallbacks {
   setSessionLabelsFn?: (sessionId: string | undefined, labels: string[]) => void | Promise<void>;
   /** Set status on a session (defaults to current). */
   setSessionStatusFn?: (sessionId: string | undefined, status: string) => void | Promise<void>;
+  /** Change the current session's working directory. */
+  setWorkingDirectoryFn?: (path: string) => Promise<{ ok: boolean; reason?: string; path?: string }>;
   /** Get detailed info about a session (defaults to current). */
   getSessionInfoFn?: (sessionId?: string) => import('@craft-agent/session-tools-core').SessionInfo | null;
   /** List sessions in the workspace with pagination. */

--- a/packages/shared/src/agent/session-self-management-bindings.ts
+++ b/packages/shared/src/agent/session-self-management-bindings.ts
@@ -53,6 +53,14 @@ export function attachSessionSelfManagementBindings(
     enumerable: true,
   });
 
+  Object.defineProperty(context, 'setWorkingDirectory', {
+    get() {
+      return getSessionScopedToolCallbacks(sessionId)?.setWorkingDirectoryFn;
+    },
+    configurable: true,
+    enumerable: true,
+  });
+
   Object.defineProperty(context, 'listSessions', {
     get() {
       return getSessionScopedToolCallbacks(sessionId)?.listSessionsFn;


### PR DESCRIPTION
## Summary

Adds a new session tool — `set_working_directory` — that lets the agent change the current session's working directory at runtime, mirroring the cwd-change capability available in Claude Code. Subsequent file/bash/tool operations execute from the new path, the change is persisted, and a `working_directory_changed` event is emitted so the UI stays in sync.

## Motivation

When a user asks the agent to switch to another project ("work on ~/code/foo now") the only options today are to spawn a new session or to keep prefixing every shell call with `cd`. Claude Code already exposes a tool for this; this PR brings the same affordance to Craft Agents without changing any existing workflow — the tool is opt-in and additive.

## Implementation

- **session-tools-core**
  - New `SetWorkingDirectorySchema`, description, and registry entry in `tool-defs.ts`.
  - New handler `handlers/set-working-directory.ts` that:
    - rejects empty paths with a clear error,
    - expands `~`, `$HOME`, and `${HOME}`,
    - resolves relative paths against the current working directory before delegating, and
    - surfaces backend rejection reasons verbatim to the LLM.
- **shared/agent**
  - Extended `SessionToolContext` and `SessionScopedToolCallbacks` with `setWorkingDirectory` / `setWorkingDirectoryFn`.
  - Bound it through `attachSessionSelfManagementBindings` so both the Claude and Pi backends pick it up automatically (same pattern used for `set_session_status`).
- **server-core/SessionManager**
  - Registers a `setWorkingDirectoryFn` next to `setSessionStatusFn` that validates the path with the existing `isValidWorkingDirectory` helper and delegates to the existing `updateWorkingDirectory(sessionId, path)` plumbing — which already handles `sdkCwd` updates, cache invalidation, persistence, and the `working_directory_changed` event.
- **safeMode**: marked as `block` in Explore/Safe mode (consistent with other state-changing self-management tools).

## Tests

- New `set-working-directory.test.ts` covering: missing binding, empty path, tilde expansion, relative-path resolution, and backend rejection passthrough.
- Existing `session-self-management-bindings` and `tool-defs-filtering` tests continue to pass.

```
bun test packages/session-tools-core/src packages/shared/src/agent/__tests__/session-self-management-bindings.test.ts
# 52 pass, 0 fail
```

## Notes for reviewers

- Path validation is delegated to the existing `isValidWorkingDirectory` (same validator used by the renderer-initiated change), so the failure modes ("not a directory", "does not exist", etc.) are identical.
- `sdkCwd` is auto-updated only when no SDK interaction has occurred yet — same condition as the existing user-initiated path. The agent-initiated tool inherits that behaviour for free.
- Backends that don't inject the callback (`setWorkingDirectory` undefined on the context) get a clean `'set_working_directory is not available in this context.'` error, matching the convention used by the other self-management tools.
