### PR TITLE
Use neutral User-Agent for custom endpoints

### DIFF
--- a/packages/pi-agent-server/src/custom-endpoint-headers.test.ts
+++ b/packages/pi-agent-server/src/custom-endpoint-headers.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'bun:test'
+import { APP_VERSION } from '../../shared/src/version/index.ts'
+import { buildCustomEndpointRequestHeaders } from './custom-endpoint-headers.ts'
+
+describe('buildCustomEndpointRequestHeaders', () => {
+  it('uses the Craft app version in the user agent', () => {
+    expect(buildCustomEndpointRequestHeaders()).toEqual({
+      'User-Agent': `CraftAgents/${APP_VERSION}`,
+    })
+  })
+})

--- a/packages/pi-agent-server/src/custom-endpoint-headers.ts
+++ b/packages/pi-agent-server/src/custom-endpoint-headers.ts
@@ -1,0 +1,7 @@
+import { APP_VERSION } from '../../shared/src/version/index.ts';
+
+export function buildCustomEndpointRequestHeaders(): Record<string, string> {
+  return {
+    'User-Agent': `CraftAgents/${APP_VERSION}`,
+  };
+}

--- a/packages/pi-agent-server/src/index.ts
+++ b/packages/pi-agent-server/src/index.ts
@@ -71,6 +71,7 @@ import { createWebFetchTool } from './tools/web-fetch.ts';
 import { resolveSearchProvider } from './tools/search/resolve-provider.ts';
 import { createSearchTool } from './tools/search/create-search-tool.ts';
 import { allowCraftMetadataProperties, stripCraftMetadata } from './craft-metadata-schema.ts';
+import { buildCustomEndpointRequestHeaders } from './custom-endpoint-headers.ts';
 
 // ============================================================
 // Types — JSONL Protocol
@@ -439,6 +440,7 @@ function registerCustomEndpointModels(
     apiKey: resolveCustomEndpointApiKey(),
     api,
     authHeader: true,
+    headers: buildCustomEndpointRequestHeaders(),
     models: allIds.map(id => buildCustomEndpointModelDef(
       id,
       { supportsImages: initConfig?.customEndpoint?.supportsImages === true },


### PR DESCRIPTION
Closes #650

## Summary
- Add custom endpoint request headers with `User-Agent: CraftAgents/<version>`.
- Pass those headers through the `custom-endpoint` provider registration so OpenAI-compatible and Anthropic-compatible custom endpoints inherit them at SDK client construction time.
- Keep the change scoped to custom endpoints using the current `main` protocols: `openai-completions` and `anthropic-messages`.

## Validation
- `bun test packages/pi-agent-server/src/custom-endpoint-headers.test.ts`
- `git diff --cached --check`
- `bun run build` in `packages/pi-agent-server`