### PR TITLE
fix: support session-relative image preview paths

### DIFF
--- a/apps/electron/resources/docs/image-preview.md
+++ b/apps/electron/resources/docs/image-preview.md
@@ -12,7 +12,7 @@ The `image-preview` block renders local image files inline in chat messages — 
 | **`pdf-preview` block** | PDF reports and documents | First page inline + full navigation |
 | **`html-preview` block** | Rich HTML content | Sandboxed iframe rendering |
 
-**Key principle:** Images are already files on disk. Reference them directly with an absolute path in `src`.
+**Key principle:** Images are already files on disk. Reference them directly with either an absolute path in `src` or, inside a session transcript, a current-session relative path under `data/` or `plans/`.
 
 ## When to Use
 
@@ -35,7 +35,7 @@ Do NOT use `image-preview` when:
 ````
 ```image-preview
 {
-  "src": "/absolute/path/to/screenshot.png",
+  "src": "data/screenshot.png",
   "title": "Settings screen"
 }
 ```
@@ -50,8 +50,8 @@ Use `items` to show related images with tab navigation.
 {
   "title": "Before / After",
   "items": [
-    { "src": "/path/to/before.png", "label": "Before" },
-    { "src": "/path/to/after.png", "label": "After" }
+    { "src": "data/before.png", "label": "Before" },
+    { "src": "data/after.png", "label": "After" }
   ]
 }
 ```
@@ -63,10 +63,10 @@ Content loads lazily on tab switch and is cached once loaded.
 
 | Field | Required | Type | Description |
 |-------|----------|------|-------------|
-| `src` | Yes* | string | Absolute path to image file (single item mode) |
+| `src` | Yes* | string | Absolute path to image file, or session-relative `data/...` / `plans/...` path (single item mode) |
 | `title` | No | string | Header title (defaults to "Image Preview") |
 | `items` | Yes* | array | Array of image items with `src` and optional `label` |
-| `items[].src` | Yes | string | Absolute path to image file |
+| `items[].src` | Yes | string | Absolute path to image file, or session-relative `data/...` / `plans/...` path |
 | `items[].label` | No | string | Tab label |
 
 *Either `src` (single) or `items` (multiple) is required. If both are present, `items` takes precedence.
@@ -95,7 +95,7 @@ Formats like HEIC/HEIF/TIFF may not render in-app. For those files, use external
 ## Troubleshooting
 
 ### "Loading..." shown indefinitely
-- Verify `src` is an **absolute path**
+- Verify `src` is an **absolute path** or a session-relative `data/...` / `plans/...` path rendered inside a session
 - Confirm the file exists and is readable
 - Check that file extension is one of the supported formats
 

--- a/apps/electron/src/renderer/components/app-shell/ChatDisplay.tsx
+++ b/apps/electron/src/renderer/components/app-shell/ChatDisplay.tsx
@@ -1608,6 +1608,7 @@ export const ChatDisplay = React.forwardRef<ChatDisplayHandle, ChatDisplayProps>
                             onOpenFile={onOpenFile}
                             onOpenUrl={onOpenUrl}
                             sessionId={session?.id}
+                            sessionFolderPath={sessionFolderPath}
                             compactMode={compactMode}
                           />
                         </div>
@@ -1631,6 +1632,7 @@ export const ChatDisplay = React.forwardRef<ChatDisplayHandle, ChatDisplayProps>
                             onOpenFile={onOpenFile}
                             onOpenUrl={onOpenUrl}
                             sessionId={session?.id}
+                            sessionFolderPath={sessionFolderPath}
                             onRetry={turn.message.role === 'error' ? () => {
                               const msgs = session?.messages
                               if (!msgs) return
@@ -1966,6 +1968,7 @@ export const ChatDisplay = React.forwardRef<ChatDisplayHandle, ChatDisplayProps>
           theme={isDark ? 'dark' : 'light'}
           onOpenUrl={onOpenUrl}
           onOpenFile={onOpenFile}
+          sessionFolderPath={sessionFolderPath}
         />
       )}
 
@@ -2013,6 +2016,7 @@ export const ChatDisplay = React.forwardRef<ChatDisplayHandle, ChatDisplayProps>
             content={activityOutputOverlayData.content}
             onOpenUrl={onOpenUrl}
             onOpenFile={onOpenFile}
+            sessionFolderPath={sessionFolderPath}
             filePath={activityOutputOverlayData.filePath}
             typeBadge={{
               icon: Info,
@@ -2028,6 +2032,7 @@ export const ChatDisplay = React.forwardRef<ChatDisplayHandle, ChatDisplayProps>
             content={activityOutputOverlayData.content}
             onOpenUrl={onOpenUrl}
             onOpenFile={onOpenFile}
+            sessionFolderPath={sessionFolderPath}
             typeBadge={{
               icon: Info,
               label: overlayState.activity.displayName || overlayState.activity.toolName || 'Activity',
@@ -2082,6 +2087,7 @@ export const ChatDisplay = React.forwardRef<ChatDisplayHandle, ChatDisplayProps>
             content={overlayState.content}
             onOpenUrl={onOpenUrl}
             onOpenFile={onOpenFile}
+            sessionFolderPath={sessionFolderPath}
           />
         )
       )}
@@ -2105,6 +2111,8 @@ interface MessageBubbleProps {
   onOpenFile: (path: string) => void
   onOpenUrl: (url: string) => void
   sessionId?: string
+  /** Absolute path to the current session folder for resolving preview src values like data/... or plans/... */
+  sessionFolderPath?: string
   /**
    * Markdown render mode for assistant messages
    * @default 'minimal'
@@ -2201,6 +2209,7 @@ function MessageBubble({
   onOpenFile,
   onOpenUrl,
   sessionId,
+  sessionFolderPath,
   renderMode = 'minimal',
   onPopOut,
   compactMode,
@@ -2247,6 +2256,7 @@ function MessageBubble({
               mode={renderMode}
               onUrlClick={onOpenUrl}
               onFileClick={onOpenFile}
+              sessionFolderPath={sessionFolderPath}
             />
           ) : (
             <CollapsibleMarkdownProvider>
@@ -2257,6 +2267,7 @@ function MessageBubble({
                 id={message.id}
                 className="text-sm"
                 collapsible
+                sessionFolderPath={sessionFolderPath}
               >
                 {message.content}
               </Markdown>
@@ -2355,6 +2366,7 @@ const MemoizedMessageBubble = React.memo(MessageBubble, (prev, next) => {
     prev.message.content === next.message.content &&
     prev.message.role === next.message.role &&
     prev.sessionId === next.sessionId &&
+    prev.sessionFolderPath === next.sessionFolderPath &&
     prev.compactMode === next.compactMode
   )
 })

--- a/apps/electron/src/renderer/components/markdown/StreamingMarkdown.tsx
+++ b/apps/electron/src/renderer/components/markdown/StreamingMarkdown.tsx
@@ -7,6 +7,7 @@ interface StreamingMarkdownProps {
   mode?: RenderMode
   onUrlClick?: (url: string) => void
   onFileClick?: (path: string) => void
+  sessionFolderPath?: string
 }
 
 interface Block {
@@ -103,20 +104,22 @@ const MemoizedBlock = React.memo(function Block({
   mode,
   onUrlClick,
   onFileClick,
+  sessionFolderPath,
 }: {
   content: string
   mode: RenderMode
   onUrlClick?: (url: string) => void
   onFileClick?: (path: string) => void
+  sessionFolderPath?: string
 }) {
   return (
-    <Markdown mode={mode} onUrlClick={onUrlClick} onFileClick={onFileClick}>
+    <Markdown mode={mode} onUrlClick={onUrlClick} onFileClick={onFileClick} sessionFolderPath={sessionFolderPath}>
       {content}
     </Markdown>
   )
 }, (prev, next) => {
   // Only re-render if content actually changed
-  return prev.content === next.content && prev.mode === next.mode
+  return prev.content === next.content && prev.mode === next.mode && prev.sessionFolderPath === next.sessionFolderPath
 })
 MemoizedBlock.displayName = 'MemoizedBlock'
 
@@ -142,6 +145,7 @@ export function StreamingMarkdown({
   mode = 'minimal',
   onUrlClick,
   onFileClick,
+  sessionFolderPath,
 }: StreamingMarkdownProps) {
   // Split into blocks - memoized to avoid recomputation
   // Must be called unconditionally to satisfy Rules of Hooks
@@ -153,7 +157,7 @@ export function StreamingMarkdown({
   // Not streaming - use simple Markdown (no block splitting needed)
   if (!isStreaming) {
     return (
-      <Markdown mode={mode} onUrlClick={onUrlClick} onFileClick={onFileClick}>
+      <Markdown mode={mode} onUrlClick={onUrlClick} onFileClick={onFileClick} sessionFolderPath={sessionFolderPath}>
         {content}
       </Markdown>
     )
@@ -177,6 +181,7 @@ export function StreamingMarkdown({
             mode={mode}
             onUrlClick={onUrlClick}
             onFileClick={onFileClick}
+            sessionFolderPath={sessionFolderPath}
           />
         )
       })}

--- a/packages/ui/src/components/chat/TurnCard.tsx
+++ b/packages/ui/src/components/chat/TurnCard.tsx
@@ -1393,6 +1393,8 @@ export interface ResponseCardProps {
   variant?: 'response' | 'plan'
   /** Parent session ID (used to reset local annotation/island UI state on session switches) */
   sessionId?: string
+  /** Session folder path for resolving preview src values like data/... or plans/... */
+  sessionFolderPath?: string
   /** Underlying message ID for annotation actions */
   messageId?: string
   /** Persisted annotations for this response */
@@ -1649,6 +1651,7 @@ export function ResponseCard({
   onPopOut,
   variant = 'response',
   sessionId,
+  sessionFolderPath,
   messageId,
   annotations,
   onAccept,
@@ -2469,6 +2472,7 @@ export function ResponseCard({
                 mode="minimal"
                 onUrlClick={onOpenUrl}
                 onFileClick={onOpenFile}
+                sessionFolderPath={sessionFolderPath}
               >
                 {text}
               </Markdown>
@@ -2554,6 +2558,7 @@ export function ResponseCard({
           onOpenUrl={onOpenUrl}
           onOpenFile={onOpenFile}
           sessionId={sessionId}
+          sessionFolderPath={sessionFolderPath}
           messageId={messageId}
           annotations={annotations}
           onAddAnnotation={onAddAnnotation}
@@ -2594,6 +2599,7 @@ export function ResponseCard({
               mode="minimal"
               onUrlClick={onOpenUrl}
               onFileClick={onOpenFile}
+              sessionFolderPath={sessionFolderPath}
             >
               {displayedText}
             </Markdown>
@@ -3087,6 +3093,7 @@ export const TurnCard = React.memo(function TurnCard({
             text={planActivity.content || ''}
             isStreaming={false}
             sessionId={sessionId}
+            sessionFolderPath={sessionFolderPath}
             onOpenFile={onOpenFile}
             onOpenUrl={onOpenUrl}
             onPopOut={onPopOut ? () => onPopOut(planActivity.content || '') : undefined}
@@ -3126,6 +3133,7 @@ export const TurnCard = React.memo(function TurnCard({
                 isStreaming={response.isStreaming}
                 streamStartTime={response.streamStartTime}
                 sessionId={sessionId}
+                sessionFolderPath={sessionFolderPath}
                 onOpenFile={onOpenFile}
                 onOpenUrl={onOpenUrl}
                 onPopOut={onPopOut ? () => onPopOut(response.text) : undefined}
@@ -3158,6 +3166,7 @@ export const TurnCard = React.memo(function TurnCard({
             isStreaming={response.isStreaming}
             streamStartTime={response.streamStartTime}
             sessionId={sessionId}
+            sessionFolderPath={sessionFolderPath}
             onOpenFile={onOpenFile}
             onOpenUrl={onOpenUrl}
             onPopOut={onPopOut ? () => onPopOut(response.text) : undefined}

--- a/packages/ui/src/components/markdown/Markdown.tsx
+++ b/packages/ui/src/components/markdown/Markdown.tsx
@@ -71,6 +71,8 @@ export interface MarkdownProps {
    * @default true
    */
   hideFirstMermaidExpand?: boolean
+  /** Absolute path to the current session folder for resolving preview src values like data/... or plans/... */
+  sessionFolderPath?: string
 }
 
 /** Context for collapsible sections */
@@ -106,7 +108,8 @@ function createComponents(
   onFileClick?: (path: string) => void,
   collapsibleContext?: CollapsibleContext | null,
   firstMermaidCodeRef?: React.RefObject<string | null>,
-  hideFirstMermaidExpand: boolean = true
+  hideFirstMermaidExpand: boolean = true,
+  sessionFolderPath?: string
 ): Partial<Components> {
   let blockIndex = 0
   const wrapBlock = (
@@ -256,7 +259,7 @@ function createComponents(
           }
           // Image preview blocks → inline image with expand to full viewer
           if (match?.[1] === 'image-preview') {
-            return wrapBlock('image-preview', code, <MarkdownImageBlock code={code} className="my-2" />, props.node?.position)
+            return wrapBlock('image-preview', code, <MarkdownImageBlock code={code} className="my-2" sessionFolderPath={sessionFolderPath} />, props.node?.position)
           }
           // LaTeX/math code blocks → KaTeX rendered display math
           if (match?.[1] === 'latex' || match?.[1] === 'math') {
@@ -385,7 +388,7 @@ function createComponents(
         }
         // Image preview blocks → inline image with expand to full viewer
         if (match?.[1] === 'image-preview') {
-          return wrapBlock('image-preview', code, <MarkdownImageBlock code={code} className="my-2" />, props.node?.position)
+          return wrapBlock('image-preview', code, <MarkdownImageBlock code={code} className="my-2" sessionFolderPath={sessionFolderPath} />, props.node?.position)
         }
         // LaTeX/math code blocks → KaTeX rendered display math
         if (match?.[1] === 'latex' || match?.[1] === 'math') {
@@ -510,6 +513,7 @@ export function Markdown({
   onFileClick,
   collapsible = false,
   hideFirstMermaidExpand = true,
+  sessionFolderPath,
 }: MarkdownProps) {
   // Get collapsible context if enabled
   const collapsibleContext = useCollapsibleMarkdown()
@@ -528,8 +532,8 @@ export function Markdown({
   }
 
   const components = React.useMemo(
-    () => wrapWithSafeProxy(createComponents(mode, onUrlClick, onFileClick, collapsible ? collapsibleContext : null, firstMermaidCodeRef, hideFirstMermaidExpand)),
-    [mode, onUrlClick, onFileClick, collapsible, collapsibleContext, hideFirstMermaidExpand]
+    () => wrapWithSafeProxy(createComponents(mode, onUrlClick, onFileClick, collapsible ? collapsibleContext : null, firstMermaidCodeRef, hideFirstMermaidExpand, sessionFolderPath)),
+    [mode, onUrlClick, onFileClick, collapsible, collapsibleContext, hideFirstMermaidExpand, sessionFolderPath]
   )
 
   // Preprocess to convert raw URLs and file paths to markdown links
@@ -581,13 +585,15 @@ export const MemoizedMarkdown = React.memo(
       return (
         prevProps.id === nextProps.id &&
         prevProps.children === nextProps.children &&
-        prevProps.mode === nextProps.mode
+        prevProps.mode === nextProps.mode &&
+        prevProps.sessionFolderPath === nextProps.sessionFolderPath
       )
     }
     // Otherwise compare content and mode
     return (
       prevProps.children === nextProps.children &&
-      prevProps.mode === nextProps.mode
+      prevProps.mode === nextProps.mode &&
+      prevProps.sessionFolderPath === nextProps.sessionFolderPath
     )
   }
 )

--- a/packages/ui/src/components/markdown/MarkdownImageBlock.tsx
+++ b/packages/ui/src/components/markdown/MarkdownImageBlock.tsx
@@ -29,6 +29,7 @@ import { ImagePreviewOverlay } from '../overlay/ImagePreviewOverlay'
 import { usePlatform } from '../../context/PlatformContext'
 import { ImageCardStack } from './ImageCardStack'
 import { useTranslation } from 'react-i18next'
+import { resolveSessionPreviewPath } from './preview-paths'
 
 interface PreviewItem {
   src: string
@@ -60,6 +61,7 @@ class ImageBlockErrorBoundary extends React.Component<
 export interface MarkdownImageBlockProps {
   code: string
   className?: string
+  sessionFolderPath?: string
   onCreateRegionAnnotation?: (region: { x: number; y: number; w: number; h: number; unit: 'pixel' | 'percent' }) => void
 }
 
@@ -78,7 +80,7 @@ function detectImageRatio(src: string): Promise<number | null> {
   })
 }
 
-export function MarkdownImageBlock({ code, className, onCreateRegionAnnotation: _onCreateRegionAnnotation }: MarkdownImageBlockProps) {
+export function MarkdownImageBlock({ code, className, sessionFolderPath, onCreateRegionAnnotation: _onCreateRegionAnnotation }: MarkdownImageBlockProps) {
   const { t } = useTranslation()
   const { onReadFileDataUrl } = usePlatform()
 
@@ -98,11 +100,20 @@ export function MarkdownImageBlock({ code, className, onCreateRegionAnnotation: 
   }, [code])
 
   const items = React.useMemo<PreviewItem[]>(() => {
-    if (!spec) return []
-    if (spec.items && spec.items.length > 0) return spec.items
-    if (spec.src) return [{ src: spec.src }]
-    return []
-  }, [spec])
+    const rawItems = (() => {
+      if (!spec) return []
+      if (spec.items && spec.items.length > 0) return spec.items
+      if (spec.src) return [{ src: spec.src }]
+      return []
+    })()
+
+    return rawItems
+      .filter((item): item is PreviewItem => !!item && typeof item.src === 'string')
+      .map((item) => ({
+        ...item,
+        src: resolveSessionPreviewPath(item.src, sessionFolderPath),
+      }))
+  }, [spec, sessionFolderPath])
 
   const [activeIndex, setActiveIndex] = React.useState(0)
   const [isFullscreen, setIsFullscreen] = React.useState(false)

--- a/packages/ui/src/components/markdown/__tests__/preview-paths.test.ts
+++ b/packages/ui/src/components/markdown/__tests__/preview-paths.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test'
+import { resolveSessionPreviewPath } from '../preview-paths'
+
+const SESSION = 'C:/Users/test/.craft-agent/workspaces/ws/sessions/260501-test'
+
+describe('resolveSessionPreviewPath', () => {
+  it('leaves absolute Windows paths unchanged', () => {
+    expect(resolveSessionPreviewPath('C:/Users/test/image.png', SESSION)).toBe('C:/Users/test/image.png')
+    expect(resolveSessionPreviewPath('C:\\Users\\test\\image.png', SESSION)).toBe('C:\\Users\\test\\image.png')
+  })
+
+  it('leaves absolute POSIX paths unchanged', () => {
+    expect(resolveSessionPreviewPath('/Users/test/image.png', SESSION)).toBe('/Users/test/image.png')
+  })
+
+  it('leaves URL-like values unchanged', () => {
+    expect(resolveSessionPreviewPath('https://example.com/image.png', SESSION)).toBe('https://example.com/image.png')
+    expect(resolveSessionPreviewPath('data:image/png;base64,abc', SESSION)).toBe('data:image/png;base64,abc')
+  })
+
+  it('resolves data and plans paths under the session folder', () => {
+    expect(resolveSessionPreviewPath('data/image.png', SESSION)).toBe(`${SESSION}/data/image.png`)
+    expect(resolveSessionPreviewPath('plans/fix.md', SESSION)).toBe(`${SESSION}/plans/fix.md`)
+  })
+
+  it('supports Windows separators for session-relative data/plans paths', () => {
+    expect(resolveSessionPreviewPath('data\\nested\\image.png', SESSION)).toBe(`${SESSION}/data/nested/image.png`)
+  })
+
+  it('does not resolve session-relative paths without a session folder', () => {
+    expect(resolveSessionPreviewPath('data/image.png')).toBe('data/image.png')
+  })
+
+  it('does not resolve traversal or malformed relative paths', () => {
+    expect(resolveSessionPreviewPath('../image.png', SESSION)).toBe('../image.png')
+    expect(resolveSessionPreviewPath('data/../../secret.txt', SESSION)).toBe('data/../../secret.txt')
+    expect(resolveSessionPreviewPath('plans/../data/file.png', SESSION)).toBe('plans/../data/file.png')
+    expect(resolveSessionPreviewPath('data//file.png', SESSION)).toBe('data//file.png')
+    expect(resolveSessionPreviewPath('data/./file.png', SESSION)).toBe('data/./file.png')
+  })
+})

--- a/packages/ui/src/components/markdown/preview-paths.ts
+++ b/packages/ui/src/components/markdown/preview-paths.ts
@@ -1,0 +1,54 @@
+const URL_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/
+const WINDOWS_DRIVE_ABSOLUTE_RE = /^[a-zA-Z]:[\\/]/
+const WINDOWS_UNC_ABSOLUTE_RE = /^(?:\\\\|\/\/)[^\\/]+[\\/][^\\/]+/
+
+function isAbsoluteLocalPath(src: string): boolean {
+  return src.startsWith('/') || WINDOWS_DRIVE_ABSOLUTE_RE.test(src) || WINDOWS_UNC_ABSOLUTE_RE.test(src)
+}
+
+function isUrlLike(src: string): boolean {
+  // Check Windows drive-letter paths before scheme detection so C:/foo is a path, not a URL.
+  return !WINDOWS_DRIVE_ABSOLUTE_RE.test(src) && URL_SCHEME_RE.test(src)
+}
+
+function normalizeSessionFolderPath(sessionFolderPath: string): string {
+  return sessionFolderPath.replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
+function getSafeSessionRelativePath(src: string): string | null {
+  const normalized = src.replace(/\\/g, '/')
+  const match = /^(data|plans)\/(.+)$/.exec(normalized)
+  if (!match) return null
+
+  const folder = match[1]
+  const relativePath = match[2]
+  if (!folder || !relativePath) return null
+  const segments = relativePath.split('/')
+
+  // Keep support deliberately narrow: no traversal, current-dir segments, empty segments,
+  // absolute subpaths, or NUL bytes. The file RPC validates again after resolution.
+  if (segments.some((segment) => !segment || segment === '.' || segment === '..' || segment.includes('\0'))) {
+    return null
+  }
+
+  return `${folder}/${segments.join('/')}`
+}
+
+/**
+ * Resolve file-backed markdown preview src values.
+ *
+ * Preview blocks still pass absolute paths to the platform read APIs. This helper adds
+ * a small session-context convenience for generated artifacts: when a preview is rendered
+ * inside a session, `data/foo.png` and `plans/foo.md` resolve under that session folder.
+ */
+export function resolveSessionPreviewPath(src: string, sessionFolderPath?: string): string {
+  const trimmed = src.trim()
+  if (!trimmed) return src
+  if (isAbsoluteLocalPath(trimmed) || isUrlLike(trimmed)) return trimmed
+  if (!sessionFolderPath) return src
+
+  const safeRelativePath = getSafeSessionRelativePath(trimmed)
+  if (!safeRelativePath) return src
+
+  return `${normalizeSessionFolderPath(sessionFolderPath)}/${safeRelativePath}`
+}

--- a/packages/ui/src/components/overlay/ActivityCardsOverlay.tsx
+++ b/packages/ui/src/components/overlay/ActivityCardsOverlay.tsx
@@ -21,6 +21,8 @@ export interface ActivityCardsOverlayProps {
   theme?: 'light' | 'dark'
   onOpenUrl?: (url: string) => void
   onOpenFile?: (path: string) => void
+  /** Absolute path to the current session folder for resolving preview src values like data/... or plans/... */
+  sessionFolderPath?: string
 }
 
 const craftAgentDarkTheme = {
@@ -65,6 +67,7 @@ export function ActivityCardsOverlay({
   theme = 'light',
   onOpenUrl,
   onOpenFile,
+  sessionFolderPath,
 }: ActivityCardsOverlayProps) {
   const jsonTheme = useMemo(() => (theme === 'dark' ? craftAgentDarkTheme : craftAgentLightTheme), [theme])
 
@@ -78,6 +81,7 @@ export function ActivityCardsOverlay({
               onUrlClick={onOpenUrl}
               onFileClick={onOpenFile}
               hideFirstMermaidExpand={false}
+              sessionFolderPath={sessionFolderPath}
             >
               {content}
             </Markdown>

--- a/packages/ui/src/components/overlay/AnnotatableMarkdownDocument.tsx
+++ b/packages/ui/src/components/overlay/AnnotatableMarkdownDocument.tsx
@@ -48,6 +48,8 @@ export interface AnnotatableMarkdownDocumentProps {
   content: string
   messageId: string
   sessionId?: string
+  /** Absolute path to the current session folder for resolving preview src values like data/... or plans/... */
+  sessionFolderPath?: string
   annotations?: AnnotationV1[]
   onAddAnnotation?: (messageId: string, annotation: AnnotationV1) => void
   onRemoveAnnotation?: (messageId: string, annotationId: string) => void
@@ -64,6 +66,7 @@ export function AnnotatableMarkdownDocument({
   content,
   messageId,
   sessionId,
+  sessionFolderPath,
   annotations,
   onAddAnnotation,
   onRemoveAnnotation,
@@ -623,7 +626,13 @@ export function AnnotatableMarkdownDocument({
         onMouseDown={handleSelectionPointerDown}
         onMouseUp={handleTextSelection}
       >
-        <Markdown mode="minimal" onUrlClick={onOpenUrl} onFileClick={onOpenFile} hideFirstMermaidExpand={false}>
+        <Markdown
+          mode="minimal"
+          onUrlClick={onOpenUrl}
+          onFileClick={onOpenFile}
+          hideFirstMermaidExpand={false}
+          sessionFolderPath={sessionFolderPath}
+        >
           {content}
         </Markdown>
 

--- a/packages/ui/src/components/overlay/DocumentFormattedMarkdownOverlay.tsx
+++ b/packages/ui/src/components/overlay/DocumentFormattedMarkdownOverlay.tsx
@@ -40,6 +40,8 @@ export interface DocumentFormattedMarkdownOverlayProps {
   error?: string
   /** Optional session id used for annotation payload source metadata */
   sessionId?: string
+  /** Absolute path to the current session folder for resolving preview src values like data/... or plans/... */
+  sessionFolderPath?: string
   /** Optional message id; when present with callbacks, overlay becomes annotatable */
   messageId?: string
   /** Persisted annotations for the message */
@@ -69,6 +71,7 @@ export function DocumentFormattedMarkdownOverlay({
   typeBadge,
   error,
   sessionId,
+  sessionFolderPath,
   messageId,
   annotations,
   onAddAnnotation,
@@ -107,6 +110,7 @@ export function DocumentFormattedMarkdownOverlay({
                 <AnnotatableMarkdownDocument
                   content={content}
                   sessionId={sessionId}
+                  sessionFolderPath={sessionFolderPath}
                   messageId={messageId}
                   annotations={annotations}
                   onAddAnnotation={onAddAnnotation}
@@ -125,6 +129,7 @@ export function DocumentFormattedMarkdownOverlay({
                   onUrlClick={onOpenUrl}
                   onFileClick={onOpenFile}
                   hideFirstMermaidExpand={false}
+                  sessionFolderPath={sessionFolderPath}
                 >
                   {content}
                 </Markdown>


### PR DESCRIPTION
## Summary
- Resolve session-relative `image-preview` sources under the active session folder.
- Allow `data/...` and `plans/...` image sources while leaving absolute paths and URLs unchanged.
- Thread the session folder path through markdown renderers and overlays so image previews work in chat, streaming, and expanded views.

Addresses the image-preview portion of #657.

## Testing
- `bun test packages/ui/src/components/markdown/__tests__/preview-paths.test.ts`
- `bun test packages/ui/src/components/markdown/__tests__`
- `cd packages/ui && bun run tsc --noEmit`
- `cd apps/electron && bun run typecheck`

## Manual Verification
- Verified `image-preview` renders `data/codex-fish.png` in the Electron dev app.