### PR TITLE
Add optional workspace icon rail

### DIFF
--- a/apps/electron/src/renderer/App.tsx
+++ b/apps/electron/src/renderer/App.tsx
@@ -11,6 +11,8 @@ import { generateMessageId } from '../shared/types'
 import { useEventProcessor } from './event-processor'
 import type { AgentEvent, Effect } from './event-processor'
 import { AppShell } from '@/components/app-shell/AppShell'
+import { WorkspaceIconRail } from '@/components/app-shell/WorkspaceIconRail'
+import { getTopBarLeftInset, shouldShowWorkspaceIconRail, WORKSPACE_SELECTOR_RAIL_CHANGED_EVENT } from '@/components/app-shell/workspace-rail'
 import type { AppShellContextType } from '@/context/AppShellContext'
 import { OnboardingWizard, ReauthScreen } from '@/components/onboarding'
 import { WorkspacePicker } from '@/components/workspace'
@@ -26,6 +28,7 @@ import { useNotifications } from '@/hooks/useNotifications'
 import { useSession } from '@/hooks/useSession'
 import { useUpdateChecker } from '@/hooks/useUpdateChecker'
 import { NavigationProvider } from '@/contexts/NavigationContext'
+import * as storage from '@/lib/local-storage'
 import { navigate, routes } from './lib/navigate'
 import { attachmentFromContentRef, toDraftRef } from './lib/drafts'
 import { stripMarkdown } from './utils/text'
@@ -262,6 +265,26 @@ export default function App() {
   }, [updateSessionDirect])
 
   const [workspaces, setWorkspaces] = useState<Workspace[]>([])
+  const [workspaceSelectorRail, setWorkspaceSelectorRail] = useState(() =>
+    storage.get(storage.KEYS.workspaceSelectorRail, false)
+  )
+
+  useEffect(() => {
+    const handleWorkspaceSelectorRailChanged = (event: Event) => {
+      const customEvent = event as CustomEvent<boolean>
+      setWorkspaceSelectorRail(
+        typeof customEvent.detail === 'boolean'
+          ? customEvent.detail
+          : storage.get(storage.KEYS.workspaceSelectorRail, false)
+      )
+    }
+
+    window.addEventListener(WORKSPACE_SELECTOR_RAIL_CHANGED_EVENT, handleWorkspaceSelectorRailChanged)
+    return () => {
+      window.removeEventListener(WORKSPACE_SELECTOR_RAIL_CHANGED_EVENT, handleWorkspaceSelectorRailChanged)
+    }
+  }, [])
+
   // Window's workspace ID — shared atom so Root/ThemeProvider stays in sync on switch
   const [windowWorkspaceId, setWindowWorkspaceId] = useAtom(windowWorkspaceIdAtom)
 
@@ -1648,13 +1671,20 @@ export default function App() {
 
   const connectionState = useTransportConnectionState()
   const showTransportConnectionBanner = shouldShowTransportConnectionBanner(connectionState)
+  const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth)
+  useEffect(() => {
+    const handleResize = () => setViewportWidth(window.innerWidth)
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+  const showWorkspaceIconRail = shouldShowWorkspaceIconRail(workspaceSelectorRail, viewportWidth)
 
   const handleReconnectTransport = useCallback(() => {
     void window.electronAPI.reconnectTransport().catch((error) => {
       const message = error instanceof Error ? error.message : 'Unknown error'
       toast.error(t('toast.reconnectFailed'), { description: message })
     })
-  }, [])
+  }, [t])
 
   const handleOpenFile = linkInterceptor.handleOpenFile
   const handleOpenUrl = linkInterceptor.handleOpenUrl
@@ -2005,33 +2035,45 @@ export default function App() {
           )}
 
           {/* Main UI - always rendered, splash fades away to reveal it */}
-          <div className="h-full flex flex-col pt-[48px] text-foreground">
-            {showTransportConnectionBanner && connectionState && (
-              <TransportConnectionBanner
-                state={connectionState}
-                onRetry={handleReconnectTransport}
+          <div className="flex h-full text-foreground">
+            {showWorkspaceIconRail && !sessionLoadError && (
+              <WorkspaceIconRail
+                workspaces={workspaces}
+                activeWorkspaceId={windowWorkspaceId}
+                onSelect={handleSelectWorkspace}
+                onWorkspaceCreated={handleRefreshWorkspaces}
               />
             )}
-            <div className="flex-1 min-h-0">
-              {sessionLoadError ? (
-                <SessionLoadErrorScreen
-                  message={sessionLoadError}
-                  onRetry={() => { void loadSessionsFromServer() }}
-                />
-              ) : (
-                <AppShell
-                  contextValue={appShellContextValue}
-                  defaultLayout={[20, 32, 48]}
-                  menuNewChatTrigger={menuNewChatTrigger}
-                  isFocusedMode={isFocusedMode}
+            <div className="flex min-w-0 flex-1 flex-col pt-[48px]">
+              {showTransportConnectionBanner && connectionState && (
+                <TransportConnectionBanner
+                  state={connectionState}
+                  onRetry={handleReconnectTransport}
                 />
               )}
+              <div className="min-h-0 flex-1">
+                {sessionLoadError ? (
+                  <SessionLoadErrorScreen
+                    message={sessionLoadError}
+                    onRetry={() => { void loadSessionsFromServer() }}
+                  />
+                ) : (
+                  <AppShell
+                    contextValue={appShellContextValue}
+                    defaultLayout={[20, 32, 48]}
+                    menuNewChatTrigger={menuNewChatTrigger}
+                    isFocusedMode={isFocusedMode}
+                    showTopBarWorkspaceSelector={!showWorkspaceIconRail}
+                    topBarLeftInset={getTopBarLeftInset(showWorkspaceIconRail)}
+                  />
+                )}
+              </div>
+              <ResetConfirmationDialog
+                open={showResetDialog}
+                onConfirm={executeReset}
+                onCancel={() => setShowResetDialog(false)}
+              />
             </div>
-            <ResetConfirmationDialog
-              open={showResetDialog}
-              onConfirm={executeReset}
-              onCancel={() => setShowResetDialog(false)}
-            />
           </div>
 
           {/* File preview overlay — rendered by the link interceptor when a previewable file is clicked */}

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -160,6 +160,10 @@ interface AppShellProps {
   menuNewChatTrigger?: number
   /** Focused mode - hides sidebars, shows only the chat content */
   isFocusedMode?: boolean
+  /** When false, workspace selection is rendered outside the top bar. */
+  showTopBarWorkspaceSelector?: boolean
+  /** Left offset for a full-height rail rendered outside the top bar. */
+  topBarLeftInset?: number
 }
 
 /** Filter mode for tri-state filtering: include shows only matching, exclude hides matching */
@@ -497,6 +501,8 @@ function AppShellContent({
   defaultCollapsed = false,
   menuNewChatTrigger,
   isFocusedMode = false,
+  showTopBarWorkspaceSelector = true,
+  topBarLeftInset = 0,
 }: AppShellProps) {
   // Destructure commonly used values from context
   // Note: sessions is NOT destructured here - we use sessionMetaMapAtom instead
@@ -2196,6 +2202,8 @@ function AppShellContent({
           onAddSessionPanel={() => handleNewChat(true)}
           onAddBrowserPanel={() => { void handleNewBrowserWindow() }}
           isCompact={isAutoCompact}
+          showWorkspaceSelector={showTopBarWorkspaceSelector || isAutoCompact}
+          leftInset={topBarLeftInset}
         />
 
       {/* === OUTER LAYOUT: Unified Panel Stack | Right Sidebar === */}

--- a/apps/electron/src/renderer/components/app-shell/TopBar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/TopBar.tsx
@@ -162,6 +162,10 @@ interface TopBarProps {
   onAddBrowserPanel: () => void
   /** When true, hides controls that don't apply in compact/mobile layout */
   isCompact?: boolean
+  /** When false, workspace selection is rendered elsewhere (for example, the left icon rail). */
+  showWorkspaceSelector?: boolean
+  /** Left offset for a full-height rail rendered outside the top bar. */
+  leftInset?: number
 }
 
 export function TopBar({
@@ -187,6 +191,8 @@ export function TopBar({
   onAddSessionPanel,
   onAddBrowserPanel,
   isCompact,
+  showWorkspaceSelector = true,
+  leftInset = 0,
 }: TopBarProps) {
   const { t } = useTranslation()
   const [isDebugMode, setIsDebugMode] = useState(false)
@@ -246,7 +252,8 @@ export function TopBar({
 
   return (
     <div
-      className="fixed top-0 left-0 right-0 h-[48px] z-panel titlebar-drag-region"
+      className="fixed top-0 right-0 h-[48px] z-panel titlebar-drag-region"
+      style={{ left: leftInset }}
     >
       <div className="flex h-full w-full items-center justify-between gap-2">
       {/* === LEFT: Sidebar + Menu + Navigation + Workspace === */}
@@ -397,17 +404,19 @@ export function TopBar({
             <TooltipContent side="bottom">{t("common.forward")} {goForwardHotkey}</TooltipContent>
           </Tooltip>
 
-          <div className="min-w-0 flex-1">
-            <WorkspaceSwitcher
-              variant="topbar"
-              workspaces={workspaces}
-              activeWorkspaceId={activeWorkspaceId}
-              onSelect={onSelectWorkspace}
-              onWorkspaceCreated={onWorkspaceCreated}
-              onWorkspaceRemoved={onWorkspaceRemoved}
-              workspaceUnreadMap={workspaceUnreadMap}
-            />
-          </div>
+          {showWorkspaceSelector && (
+            <div className="min-w-0 flex-1">
+              <WorkspaceSwitcher
+                variant="topbar"
+                workspaces={workspaces}
+                activeWorkspaceId={activeWorkspaceId}
+                onSelect={onSelectWorkspace}
+                onWorkspaceCreated={onWorkspaceCreated}
+                onWorkspaceRemoved={onWorkspaceRemoved}
+                workspaceUnreadMap={workspaceUnreadMap}
+              />
+            </div>
+          )}
         </div>
       </div>
 

--- a/apps/electron/src/renderer/components/app-shell/WorkspaceIconRail.tsx
+++ b/apps/electron/src/renderer/components/app-shell/WorkspaceIconRail.tsx
@@ -1,0 +1,316 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { Cloud, CloudOff, FolderPlus } from "lucide-react";
+import { AnimatePresence } from "motion/react";
+import { useSetAtom } from "jotai";
+import { toast } from "sonner";
+
+import { cn } from "@/lib/utils";
+import { fullscreenOverlayOpenAtom } from "@/atoms/overlay";
+import { CrossfadeAvatar } from "@/components/ui/avatar";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@craft-agent/ui";
+import { WorkspaceCreationScreen } from "@/components/workspace";
+import { waitForTransportConnected } from "@/lib/transport-wait";
+import { useTransportConnectionState } from "@/hooks/useTransportConnectionState";
+import { useWorkspaceIcons } from "@/hooks/useWorkspaceIcon";
+import type { Workspace } from "../../../shared/types";
+
+interface WorkspaceIconRailProps {
+	workspaces: Workspace[];
+	activeWorkspaceId: string | null;
+	onSelect: (
+		workspaceId: string,
+		openInNewWindow?: boolean,
+	) => void | Promise<void>;
+	onWorkspaceCreated?: (workspace: Workspace) => void;
+	/** workspaceId -> has unread */
+	workspaceUnreadMap?: Record<string, boolean>;
+	className?: string;
+}
+
+/**
+ * WorkspaceIconRail - Discord-style vertical workspace selector.
+ *
+ * Renders one icon per workspace on the far left of the app, with a tooltip
+ * for the workspace name and a selected background for the active workspace.
+ */
+export function WorkspaceIconRail({
+	workspaces,
+	activeWorkspaceId,
+	onSelect,
+	onWorkspaceCreated,
+	workspaceUnreadMap,
+	className,
+}: WorkspaceIconRailProps) {
+	const { t } = useTranslation();
+	const [showCreationScreen, setShowCreationScreen] = React.useState(false);
+	const [reconnectTarget, setReconnectTarget] =
+		React.useState<Workspace | null>(null);
+	const setFullscreenOverlayOpen = useSetAtom(fullscreenOverlayOpenAtom);
+	const workspaceIconMap = useWorkspaceIcons(workspaces);
+	const connectionState = useTransportConnectionState();
+	const isRemote = connectionState?.mode === "remote";
+
+	const [remoteHealthMap, setRemoteHealthMap] = React.useState<
+		Map<string, "ok" | "error" | "checking">
+	>(new Map());
+	const healthCheckAbort = React.useRef<AbortController | null>(null);
+
+	const isRemoteDisconnected = React.useCallback(
+		(workspaceId: string) => {
+			const workspace = workspaces.find((w) => w.id === workspaceId);
+			if (!workspace?.remoteServer) return false;
+
+			if (workspaceId === activeWorkspaceId) {
+				return (
+					isRemote &&
+					connectionState?.status !== "connected" &&
+					connectionState?.status !== "connecting" &&
+					connectionState?.status !== "idle"
+				);
+			}
+
+			return remoteHealthMap.get(workspaceId) === "error";
+		},
+		[
+			activeWorkspaceId,
+			connectionState?.status,
+			isRemote,
+			remoteHealthMap,
+			workspaces,
+		],
+	);
+
+	const checkRemoteHealth = React.useCallback(() => {
+		healthCheckAbort.current?.abort();
+		const abort = new AbortController();
+		healthCheckAbort.current = abort;
+
+		const remoteWorkspaces = workspaces.filter(
+			(w) => w.remoteServer && w.id !== activeWorkspaceId,
+		);
+		if (remoteWorkspaces.length === 0) return;
+
+		setRemoteHealthMap((prev) => {
+			const next = new Map(prev);
+			for (const ws of remoteWorkspaces) next.set(ws.id, "checking");
+			return next;
+		});
+
+		for (const ws of remoteWorkspaces) {
+			window.electronAPI
+				.testRemoteConnection(ws.remoteServer!.url, ws.remoteServer!.token)
+				.then((result) => {
+					if (abort.signal.aborted) return;
+					setRemoteHealthMap((prev) =>
+						new Map(prev).set(ws.id, result.ok ? "ok" : "error"),
+					);
+				})
+				.catch(() => {
+					if (abort.signal.aborted) return;
+					setRemoteHealthMap((prev) => new Map(prev).set(ws.id, "error"));
+				});
+		}
+	}, [activeWorkspaceId, workspaces]);
+
+	React.useEffect(() => {
+		checkRemoteHealth();
+		return () => healthCheckAbort.current?.abort();
+	}, [checkRemoteHealth]);
+
+	const getDisconnectTooltip = React.useCallback(
+		(workspaceId: string) => {
+			if (workspaceId === activeWorkspaceId && connectionState?.lastError) {
+				const { kind } = connectionState.lastError;
+				if (kind === "auth") return t("toast.authenticationFailed");
+				if (kind === "timeout") return t("toast.serverUnreachable");
+				if (kind === "network") return t("toast.serverUnreachable");
+			}
+			return t("toast.disconnected");
+		},
+		[activeWorkspaceId, connectionState?.lastError, t],
+	);
+
+	const handleNewWorkspace = React.useCallback(() => {
+		setShowCreationScreen(true);
+		setFullscreenOverlayOpen(true);
+	}, [setFullscreenOverlayOpen]);
+
+	const handleWorkspaceCreated = React.useCallback(
+		(workspace: Workspace) => {
+			toast.success(t("toast.createdWorkspace", { name: workspace.name }));
+			onWorkspaceCreated?.(workspace);
+			onSelect(workspace.id);
+		},
+		[onSelect, onWorkspaceCreated, t],
+	);
+
+	const handleCloseCreationScreen = React.useCallback(() => {
+		setShowCreationScreen(false);
+		setReconnectTarget(null);
+		setFullscreenOverlayOpen(false);
+	}, [setFullscreenOverlayOpen]);
+
+	const handleReconnectWorkspace = React.useCallback(
+		async (
+			workspaceId: string,
+			remoteServer: { url: string; token: string; remoteWorkspaceId: string },
+		) => {
+			await window.electronAPI.updateWorkspaceRemoteServer(
+				workspaceId,
+				remoteServer,
+			);
+
+			if (workspaceId === activeWorkspaceId) {
+				await window.electronAPI.reconnectTransport();
+				await waitForTransportConnected(window.electronAPI);
+			} else {
+				await Promise.resolve(onSelect(workspaceId));
+				await waitForTransportConnected(window.electronAPI);
+			}
+
+			handleCloseCreationScreen();
+			toast.success(t("toast.workspaceReconnected"));
+		},
+		[activeWorkspaceId, handleCloseCreationScreen, onSelect, t],
+	);
+
+	const handleWorkspaceClick = React.useCallback(
+		(workspace: Workspace, event: React.MouseEvent<HTMLButtonElement>) => {
+			if (workspace.id === activeWorkspaceId) return;
+
+			const disconnected = isRemoteDisconnected(workspace.id);
+
+			if (disconnected && workspace.remoteServer) {
+				setReconnectTarget(workspace);
+				setShowCreationScreen(true);
+				setFullscreenOverlayOpen(true);
+				return;
+			}
+
+			if (disconnected) return;
+
+			const openInNewWindow = event.metaKey || event.ctrlKey;
+			onSelect(workspace.id, openInNewWindow);
+		},
+		[
+			activeWorkspaceId,
+			isRemoteDisconnected,
+			onSelect,
+			setFullscreenOverlayOpen,
+		],
+	);
+
+	return (
+		<>
+			<AnimatePresence>
+				{showCreationScreen && (
+					<WorkspaceCreationScreen
+						onWorkspaceCreated={handleWorkspaceCreated}
+						onClose={handleCloseCreationScreen}
+						reconnectWorkspace={reconnectTarget ?? undefined}
+						onReconnectWorkspace={handleReconnectWorkspace}
+					/>
+				)}
+			</AnimatePresence>
+
+			<aside
+				className={cn(
+					"h-full w-[58px] shrink-0 border-r border-border/40 bg-background/40 titlebar-no-drag",
+					"flex flex-col items-center overflow-y-auto overflow-x-hidden px-2 pb-2",
+					className,
+				)}
+				aria-label={t("settings.appearance.workspaceIconRail")}
+			>
+				<div className="flex w-full flex-col items-center gap-2 pt-2">
+					{workspaces.map((workspace) => {
+						const selected = workspace.id === activeWorkspaceId;
+						const disconnected = isRemoteDisconnected(workspace.id);
+						const title = disconnected
+							? `${workspace.name} — ${getDisconnectTooltip(workspace.id)}`
+							: workspace.name;
+
+						return (
+							<Tooltip key={workspace.id}>
+								<TooltipTrigger asChild>
+									<button
+										type="button"
+										aria-label={workspace.name}
+										aria-current={selected ? "page" : undefined}
+										onMouseEnter={() => {
+											if (
+												workspace.remoteServer &&
+												workspace.id !== activeWorkspaceId
+											)
+												checkRemoteHealth();
+										}}
+										onClick={(event) => handleWorkspaceClick(workspace, event)}
+										className={cn(
+											"group relative flex h-11 w-11 items-center justify-center rounded-[14px] transition-colors duration-150",
+											"focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+											selected ? "bg-foreground/12" : "hover:bg-foreground/7",
+											disconnected && "opacity-60",
+										)}
+									>
+										<span
+											className={cn(
+												"absolute left-[-8px] top-1/2 h-5 w-1 -translate-y-1/2 rounded-r-full bg-accent transition-opacity duration-150",
+												selected
+													? "opacity-100"
+													: "opacity-0 group-hover:opacity-40",
+											)}
+											aria-hidden="true"
+										/>
+										<CrossfadeAvatar
+											src={workspaceIconMap.get(workspace.id)}
+											alt={workspace.name}
+											className={cn(
+												"h-8 w-8 rounded-full ring-1 ring-border/60 transition-transform duration-150",
+												selected && "ring-2 ring-accent/55",
+											)}
+											fallbackClassName="bg-muted text-xs font-medium rounded-full"
+											fallback={workspace.name.charAt(0)}
+										/>
+										{workspace.remoteServer &&
+											(disconnected ? (
+												<CloudOff className="absolute bottom-1 right-1 h-3.5 w-3.5 rounded-full bg-background p-0.5 text-destructive" />
+											) : (
+												<Cloud className="absolute bottom-1 right-1 h-3.5 w-3.5 rounded-full bg-background p-0.5 text-muted-foreground" />
+											))}
+										{workspaceUnreadMap?.[workspace.id] && !selected && (
+											<span
+												className="absolute right-1 top-1 h-2.5 w-2.5 rounded-full border-2 border-background bg-accent"
+												aria-hidden="true"
+											/>
+										)}
+									</button>
+								</TooltipTrigger>
+								<TooltipContent side="right" sideOffset={8}>
+									{title}
+								</TooltipContent>
+							</Tooltip>
+						);
+					})}
+				</div>
+
+				<div className="mt-1 h-px w-8 shrink-0 bg-border/60" />
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<button
+							type="button"
+							aria-label={t("workspace.addWorkspace")}
+							onClick={handleNewWorkspace}
+							className="flex h-11 w-11 items-center justify-center rounded-[14px] text-muted-foreground transition-colors duration-150 hover:bg-foreground/7 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+						>
+							<FolderPlus className="h-5 w-5" />
+						</button>
+					</TooltipTrigger>
+					<TooltipContent side="right" sideOffset={8}>
+						{t("workspace.addWorkspace")}
+					</TooltipContent>
+				</Tooltip>
+			</aside>
+		</>
+	);
+}

--- a/apps/electron/src/renderer/components/app-shell/__tests__/workspace-rail.test.ts
+++ b/apps/electron/src/renderer/components/app-shell/__tests__/workspace-rail.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  COMPACT_VIEWPORT_WIDTH,
+  WORKSPACE_ICON_RAIL_WIDTH,
+  WORKSPACE_SELECTOR_RAIL_CHANGED_EVENT,
+  getTopBarLeftInset,
+  shouldShowWorkspaceIconRail,
+} from '../workspace-rail'
+
+describe('shouldShowWorkspaceIconRail', () => {
+  it('is hidden when the setting is disabled', () => {
+    expect(shouldShowWorkspaceIconRail(false, 1200)).toBe(false)
+  })
+
+  it('is hidden below the compact viewport breakpoint', () => {
+    expect(shouldShowWorkspaceIconRail(true, COMPACT_VIEWPORT_WIDTH - 1)).toBe(
+      false,
+    )
+  })
+
+  it('is shown at and above the compact viewport breakpoint', () => {
+    expect(shouldShowWorkspaceIconRail(true, COMPACT_VIEWPORT_WIDTH)).toBe(
+      true,
+    )
+    expect(shouldShowWorkspaceIconRail(true, 1200)).toBe(true)
+  })
+})
+
+describe('getTopBarLeftInset', () => {
+  it('insets the top bar by the rail width only when the rail is visible', () => {
+    expect(getTopBarLeftInset(false)).toBe(0)
+    expect(getTopBarLeftInset(true)).toBe(WORKSPACE_ICON_RAIL_WIDTH)
+  })
+})
+
+describe('workspace selector rail event', () => {
+  it('exports the shared event name used by settings and App', () => {
+    expect(WORKSPACE_SELECTOR_RAIL_CHANGED_EVENT).toBe(
+      'craft-workspace-selector-rail-changed',
+    )
+  })
+})

--- a/apps/electron/src/renderer/components/app-shell/workspace-rail.ts
+++ b/apps/electron/src/renderer/components/app-shell/workspace-rail.ts
@@ -1,0 +1,17 @@
+export const COMPACT_VIEWPORT_WIDTH = 768
+export const WORKSPACE_ICON_RAIL_WIDTH = 58
+export const WORKSPACE_SELECTOR_RAIL_CHANGED_EVENT =
+  'craft-workspace-selector-rail-changed'
+
+export function shouldShowWorkspaceIconRail(
+  workspaceSelectorRailEnabled: boolean,
+  viewportWidth: number,
+): boolean {
+  return (
+    workspaceSelectorRailEnabled && viewportWidth >= COMPACT_VIEWPORT_WIDTH
+  )
+}
+
+export function getTopBarLeftInset(showWorkspaceIconRail: boolean): number {
+  return showWorkspaceIconRail ? WORKSPACE_ICON_RAIL_WIDTH : 0
+}

--- a/apps/electron/src/renderer/lib/local-storage.ts
+++ b/apps/electron/src/renderer/lib/local-storage.ts
@@ -52,6 +52,7 @@ export const KEYS = {
 
   // Appearance
   showConnectionIcons: 'show-connection-icons',
+  workspaceSelectorRail: 'workspace-selector-rail',
 
   // What's New
   whatsNewLastSeenVersion: 'whats-new-last-seen-version',

--- a/apps/electron/src/renderer/pages/settings/AppearanceSettingsPage.tsx
+++ b/apps/electron/src/renderer/pages/settings/AppearanceSettingsPage.tsx
@@ -29,6 +29,7 @@ import {
   SettingsToggle,
 } from '@/components/settings'
 import * as storage from '@/lib/local-storage'
+import { WORKSPACE_SELECTOR_RAIL_CHANGED_EVENT } from '@/components/app-shell/workspace-rail'
 import { useWorkspaceIcons } from '@/hooks/useWorkspaceIcon'
 import { Info_DataTable, SortableHeader } from '@/components/info/Info_DataTable'
 import { Info_Badge } from '@/components/info/Info_Badge'
@@ -134,6 +135,16 @@ export default function AppearanceSettingsPage() {
   const handleConnectionIconsChange = useCallback((checked: boolean) => {
     setShowConnectionIcons(checked)
     storage.set(storage.KEYS.showConnectionIcons, checked)
+  }, [])
+
+  // Workspace selector placement toggle
+  const [workspaceSelectorRail, setWorkspaceSelectorRail] = useState(() =>
+    storage.get(storage.KEYS.workspaceSelectorRail, false)
+  )
+  const handleWorkspaceSelectorRailChange = useCallback((checked: boolean) => {
+    setWorkspaceSelectorRail(checked)
+    storage.set(storage.KEYS.workspaceSelectorRail, checked)
+    window.dispatchEvent(new CustomEvent(WORKSPACE_SELECTOR_RAIL_CHANGED_EVENT, { detail: checked }))
   }, [])
 
   // Rich tool descriptions toggle (persisted in config.json, read by SDK subprocess)
@@ -357,6 +368,12 @@ export default function AppearanceSettingsPage() {
                     description={t("settings.appearance.connectionIconsDesc")}
                     checked={showConnectionIcons}
                     onCheckedChange={handleConnectionIconsChange}
+                  />
+                  <SettingsToggle
+                    label={t("settings.appearance.workspaceIconRail")}
+                    description={t("settings.appearance.workspaceIconRailDesc")}
+                    checked={workspaceSelectorRail}
+                    onCheckedChange={handleWorkspaceSelectorRailChange}
                   />
                   <SettingsToggle
                     label={t("settings.appearance.richToolDescriptions")}

--- a/bun.lock
+++ b/bun.lock
@@ -115,7 +115,7 @@
     },
     "apps/cli": {
       "name": "@craft-agent/cli",
-      "version": "0.8.13",
+      "version": "0.9.0",
       "bin": {
         "craft-cli": "src/index.ts",
       },
@@ -131,7 +131,7 @@
     },
     "apps/electron": {
       "name": "@craft-agent/electron",
-      "version": "0.8.13",
+      "version": "0.9.0",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/messaging-gateway": "workspace:*",
@@ -178,32 +178,9 @@
         "@types/ws": "^8.18.1",
       },
     },
-    "apps/marketing": {
-      "name": "@craft-agent/marketing",
-      "version": "0.8.13",
-      "dependencies": {
-        "@craft-agent/ui": "workspace:*",
-        "@paper-design/shaders-react": "^0.0.70",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-router-dom": "^7.13.0",
-        "shiki": "^3.21.0",
-        "three": "^0.170.0",
-      },
-      "devDependencies": {
-        "@tailwindcss/vite": "^4.1.18",
-        "@types/react": "^18.3.0",
-        "@types/react-dom": "^18.3.0",
-        "@types/three": "^0.170.0",
-        "@vitejs/plugin-react": "^5.1.2",
-        "tailwindcss": "^4.1.18",
-        "typescript": "^5.0.0",
-        "vite": "^6.2.4",
-      },
-    },
     "apps/viewer": {
       "name": "@craft-agent/viewer",
-      "version": "0.8.13",
+      "version": "0.9.0",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/ui": "workspace:*",
@@ -231,7 +208,7 @@
     },
     "apps/webui": {
       "name": "@craft-agent/webui",
-      "version": "0.8.13",
+      "version": "0.9.0",
       "dependencies": {
         "@craft-agent/shared": "workspace:*",
         "@craft-agent/ui": "workspace:*",
@@ -246,7 +223,7 @@
     },
     "packages/core": {
       "name": "@craft-agent/core",
-      "version": "0.8.13",
+      "version": "0.9.0",
       "devDependencies": {
         "@types/uuid": "^11.0.0",
       },
@@ -255,32 +232,9 @@
         "@modelcontextprotocol/sdk": ">=1.0.0",
       },
     },
-    "packages/craft-agents-commands": {
-      "name": "@craft-agent/craft-agents-commands",
-      "version": "0.8.13",
-      "dependencies": {
-        "@craft-agent/shared": "workspace:*",
-      },
-      "devDependencies": {
-        "@types/bun": "latest",
-        "@types/node": "^25.0.8",
-      },
-    },
-    "packages/craft-cli": {
-      "name": "@craft-agent/craft-cli",
-      "version": "0.8.13",
-      "dependencies": {
-        "@craft-agent/craft-agents-commands": "workspace:*",
-        "@craft-agent/shared": "workspace:*",
-      },
-      "devDependencies": {
-        "@types/bun": "latest",
-        "@types/node": "^25.0.8",
-      },
-    },
     "packages/messaging-gateway": {
       "name": "@craft-agent/messaging-gateway",
-      "version": "0.8.13",
+      "version": "0.9.0",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/messaging-whatsapp-worker": "workspace:*",
@@ -296,7 +250,7 @@
     },
     "packages/messaging-whatsapp-worker": {
       "name": "@craft-agent/messaging-whatsapp-worker",
-      "version": "0.8.13",
+      "version": "0.9.0",
       "dependencies": {
         "@whiskeysockets/baileys": "^6.7.0",
       },
@@ -307,7 +261,7 @@
     },
     "packages/pi-agent-server": {
       "name": "@craft-agent/pi-agent-server",
-      "version": "0.8.13",
+      "version": "0.9.0",
       "bin": {
         "pi-agent-server": "./dist/index.js",
       },
@@ -327,7 +281,7 @@
     },
     "packages/server": {
       "name": "@craft-agent/server",
-      "version": "0.8.13",
+      "version": "0.9.0",
       "bin": {
         "craft-server": "src/index.ts",
       },
@@ -345,7 +299,7 @@
     },
     "packages/server-core": {
       "name": "@craft-agent/server-core",
-      "version": "0.8.13",
+      "version": "0.9.0",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/shared": "workspace:*",
@@ -361,7 +315,7 @@
     },
     "packages/session-mcp-server": {
       "name": "@craft-agent/session-mcp-server",
-      "version": "0.8.13",
+      "version": "0.9.0",
       "bin": {
         "session-mcp-server": "./dist/index.js",
       },
@@ -377,7 +331,7 @@
     },
     "packages/session-tools-core": {
       "name": "@craft-agent/session-tools-core",
-      "version": "0.8.13",
+      "version": "0.9.0",
       "dependencies": {
         "beautiful-mermaid": "*",
         "gray-matter": "^4.0.3",
@@ -390,7 +344,7 @@
     },
     "packages/shared": {
       "name": "@craft-agent/shared",
-      "version": "0.8.13",
+      "version": "0.9.0",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/session-tools-core": "workspace:*",
@@ -420,7 +374,7 @@
     },
     "packages/ui": {
       "name": "@craft-agent/ui",
-      "version": "0.8.13",
+      "version": "0.9.0",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/shared": "workspace:*",
@@ -680,13 +634,7 @@
 
     "@craft-agent/core": ["@craft-agent/core@workspace:packages/core"],
 
-    "@craft-agent/craft-agents-commands": ["@craft-agent/craft-agents-commands@workspace:packages/craft-agents-commands"],
-
-    "@craft-agent/craft-cli": ["@craft-agent/craft-cli@workspace:packages/craft-cli"],
-
     "@craft-agent/electron": ["@craft-agent/electron@workspace:apps/electron"],
-
-    "@craft-agent/marketing": ["@craft-agent/marketing@workspace:apps/marketing"],
 
     "@craft-agent/messaging-gateway": ["@craft-agent/messaging-gateway@workspace:packages/messaging-gateway"],
 
@@ -1560,8 +1508,6 @@
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
-    "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
-
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -1636,11 +1582,7 @@
 
     "@types/shell-quote": ["@types/shell-quote@1.7.5", "", {}, "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw=="],
 
-    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
-
     "@types/tedious": ["@types/tedious@4.0.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
-
-    "@types/three": ["@types/three@0.170.0", "", { "dependencies": { "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": "*", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~0.18.1" } }, "sha512-CUm2uckq+zkCY7ZbFpviRttY+6f9fvwm6YqSqPfA5K22s9w7R4VnA3rzJse8kHVvuzLcTx+CjNCs2NYe0QFAyg=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -1649,8 +1591,6 @@
     "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
     "@types/verror": ["@types/verror@1.10.11", "", {}, "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg=="],
-
-    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -1693,8 +1633,6 @@
     "@wasm-audio-decoders/ogg-vorbis": ["@wasm-audio-decoders/ogg-vorbis@0.1.20", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7", "codec-parser": "2.5.0" } }, "sha512-zaQPasU5usRjUDXtXOHYED5tfkR4QMXd+EH3Nrz1+4+M5pCsdD+s9YxJqb0oqnTyRu/KUujOmu5Z/m/NT47vwg=="],
 
     "@wasm-audio-decoders/opus-ml": ["@wasm-audio-decoders/opus-ml@0.0.2", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-58rWEqDGg+CKCyEeKm2KoxxSwTWtHh/NLTW9ObR4K8CGF6VwuuGudEI1CtniS/oSRmL1nJq/eh8MKARiluw4DQ=="],
-
-    "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
 
     "@whiskeysockets/baileys": ["@whiskeysockets/baileys@6.17.16", "", { "dependencies": { "@adiwajshing/keyed-db": "^0.2.4", "@cacheable/node-cache": "^1.4.0", "@hapi/boom": "^9.1.3", "@whiskeysockets/eslint-config": "github:whiskeysockets/eslint-config", "async-lock": "^1.4.1", "audio-decode": "^2.1.3", "axios": "^1.6.0", "cache-manager": "^5.7.6", "libphonenumber-js": "^1.10.20", "libsignal": "github:WhiskeySockets/libsignal-node", "lodash": "^4.17.21", "music-metadata": "^7.12.3", "pino": "^9.6", "protobufjs": "^7.2.4", "uuid": "^10.0.0", "ws": "^8.13.0" }, "peerDependencies": { "jimp": "^0.16.1", "link-preview-js": "^3.0.0", "qrcode-terminal": "^0.12.0", "sharp": "^0.32.6" }, "optionalPeers": ["jimp", "link-preview-js", "qrcode-terminal", "sharp"] }, "sha512-cZoUaKpO4fsDUNiCtyZfbjkW0Bjl/IudzHLCvpqfqtq5TACQzNynYsYdKPJz1I8Cu/SSEvmewk0RorIs0zDWyw=="],
 
@@ -2782,8 +2720,6 @@
 
     "merge-refs": ["merge-refs@2.0.0", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg=="],
 
-    "meshoptimizer": ["meshoptimizer@0.18.1", "", {}, "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw=="],
-
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
@@ -3206,10 +3142,6 @@
 
     "react-resizable-panels": ["react-resizable-panels@3.0.6", "", { "peerDependencies": { "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew=="],
 
-    "react-router": ["react-router@7.13.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw=="],
-
-    "react-router-dom": ["react-router-dom@7.13.0", "", { "dependencies": { "react-router": "7.13.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g=="],
-
     "react-simple-code-editor": ["react-simple-code-editor@0.14.1", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-BR5DtNRy+AswWJECyA17qhUDvrrCZ6zXOCfkQY5zSmb96BVUbpVAv03WpcjcwtCwiLbIANx3gebHOcXYn1EHow=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
@@ -3321,8 +3253,6 @@
     "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -3473,8 +3403,6 @@
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
     "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
-
-    "three": ["three@0.170.0", "", {}, "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ=="],
 
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
 
@@ -3874,12 +3802,6 @@
 
     "@craft-agent/cli/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
 
-    "@craft-agent/craft-agents-commands/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
-
-    "@craft-agent/craft-cli/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
-
-    "@craft-agent/marketing/@paper-design/shaders-react": ["@paper-design/shaders-react@0.0.70", "", { "dependencies": { "@paper-design/shaders": "0.0.70" }, "peerDependencies": { "@types/react": "^18 || ^19", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-9DkZXcyehorsZzyWnYV3OOO1i7rF7a5CkasjKJ1h1tLlY3JJLUEX9W+gZz7JgWHyvCimUu0OSq1sbHTb2OntRw=="],
-
     "@craft-agent/messaging-gateway/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
 
     "@craft-agent/messaging-whatsapp-worker/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
@@ -4242,8 +4164,6 @@
 
     "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
-    "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
-
     "read-pkg-up/find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "^2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
 
     "readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
@@ -4495,12 +4415,6 @@
     "@craft-agent/cli/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "@craft-agent/cli/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
-
-    "@craft-agent/craft-agents-commands/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
-
-    "@craft-agent/craft-cli/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
-
-    "@craft-agent/marketing/@paper-design/shaders-react/@paper-design/shaders": ["@paper-design/shaders@0.0.70", "", {}, "sha512-d9LQcmPoEm3+Y6Vuz7cvsnSelfTM5QD63yQ3ddLM7QGYfoSjbQiU38kzjA4O3oCQ6zv23o/IGvGA8k9S/L+kZw=="],
 
     "@craft-agent/messaging-gateway/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/packages/shared/src/i18n/locales/de.json
+++ b/packages/shared/src/i18n/locales/de.json
@@ -752,6 +752,8 @@
   "settings.appearance.commandsHeader": "Befehle",
   "settings.appearance.connectionIcons": "Verbindungssymbole",
   "settings.appearance.connectionIconsDesc": "Anbietersymbole in der Sitzungsliste und Modellauswahl anzeigen",
+  "settings.appearance.workspaceIconRail": "Arbeitsbereich-Symbolleiste",
+  "settings.appearance.workspaceIconRailDesc": "Arbeitsbereichsymbole in einer linken Leiste statt im Dropdown-Menü der oberen Leiste anzeigen",
   "settings.appearance.dark": "Dunkel",
   "settings.appearance.defaultTheme": "Standarddesign",
   "settings.appearance.description": "Design, Schrift, Werkzeugsymbole",

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -752,6 +752,8 @@
   "settings.appearance.commandsHeader": "Commands",
   "settings.appearance.connectionIcons": "Connection icons",
   "settings.appearance.connectionIconsDesc": "Show provider icons in the session list and model selector",
+  "settings.appearance.workspaceIconRail": "Workspace icon rail",
+  "settings.appearance.workspaceIconRailDesc": "Show workspace icons in a left-side rail instead of the top-bar dropdown",
   "settings.appearance.dark": "Dark",
   "settings.appearance.defaultTheme": "Default Theme",
   "settings.appearance.description": "Theme, font, tool icons",

--- a/packages/shared/src/i18n/locales/es.json
+++ b/packages/shared/src/i18n/locales/es.json
@@ -752,6 +752,8 @@
   "settings.appearance.commandsHeader": "Comandos",
   "settings.appearance.connectionIcons": "Iconos de conexión",
   "settings.appearance.connectionIconsDesc": "Muestra los iconos del proveedor en la lista de sesiones y el selector de modelos",
+  "settings.appearance.workspaceIconRail": "Barra lateral de espacios de trabajo",
+  "settings.appearance.workspaceIconRailDesc": "Muestra los iconos de los espacios de trabajo en una barra lateral izquierda en lugar del menú desplegable de la barra superior",
   "settings.appearance.dark": "Oscuro",
   "settings.appearance.defaultTheme": "Tema predeterminado",
   "settings.appearance.description": "Tema, fuente, iconos de herramientas",

--- a/packages/shared/src/i18n/locales/hu.json
+++ b/packages/shared/src/i18n/locales/hu.json
@@ -752,6 +752,8 @@
   "settings.appearance.commandsHeader": "Parancsok",
   "settings.appearance.connectionIcons": "Kapcsolat ikonok",
   "settings.appearance.connectionIconsDesc": "Szolgáltatói ikonok megjelenítése a munkamenetek listájában és a modellválasztóban",
+  "settings.appearance.workspaceIconRail": "Munkaterület-ikonsáv",
+  "settings.appearance.workspaceIconRailDesc": "A munkaterületek ikonjainak megjelenítése egy bal oldali sávban a felső sáv lenyíló menüje helyett",
   "settings.appearance.dark": "Sötét",
   "settings.appearance.defaultTheme": "Alapértelmezett téma",
   "settings.appearance.description": "Téma, betűtípus, eszközikonok",

--- a/packages/shared/src/i18n/locales/ja.json
+++ b/packages/shared/src/i18n/locales/ja.json
@@ -752,6 +752,8 @@
   "settings.appearance.commandsHeader": "コマンド",
   "settings.appearance.connectionIcons": "接続アイコン",
   "settings.appearance.connectionIconsDesc": "セッションリストとモデルセレクターにプロバイダーアイコンを表示します",
+  "settings.appearance.workspaceIconRail": "ワークスペースのアイコンレール",
+  "settings.appearance.workspaceIconRailDesc": "上部バーのドロップダウンの代わりに、左側のレールにワークスペースのアイコンを表示します",
   "settings.appearance.dark": "ダーク",
   "settings.appearance.defaultTheme": "デフォルトテーマ",
   "settings.appearance.description": "テーマ、フォント、ツールアイコン",

--- a/packages/shared/src/i18n/locales/pl.json
+++ b/packages/shared/src/i18n/locales/pl.json
@@ -752,6 +752,8 @@
   "settings.appearance.commandsHeader": "Polecenia",
   "settings.appearance.connectionIcons": "Ikony połączeń",
   "settings.appearance.connectionIconsDesc": "Pokaż ikony dostawców na liście sesji i w selektorze modeli",
+  "settings.appearance.workspaceIconRail": "Pasek ikon obszarów roboczych",
+  "settings.appearance.workspaceIconRailDesc": "Pokazuj ikony obszarów roboczych na lewym pasku zamiast w menu rozwijanym na górnym pasku",
   "settings.appearance.dark": "Ciemny",
   "settings.appearance.defaultTheme": "Domyślny motyw",
   "settings.appearance.description": "Motyw, czcionka, ikony narzędzi",

--- a/packages/shared/src/i18n/locales/zh-Hans.json
+++ b/packages/shared/src/i18n/locales/zh-Hans.json
@@ -752,6 +752,8 @@
   "settings.appearance.commandsHeader": "命令",
   "settings.appearance.connectionIcons": "连接图标",
   "settings.appearance.connectionIconsDesc": "在会话列表和模型选择器中显示提供商图标",
+  "settings.appearance.workspaceIconRail": "工作区图标栏",
+  "settings.appearance.workspaceIconRailDesc": "在左侧栏中显示工作区图标，而不是使用顶部栏的下拉菜单",
   "settings.appearance.dark": "深色",
   "settings.appearance.defaultTheme": "默认主题",
   "settings.appearance.description": "主题、字体、工具图标",


### PR DESCRIPTION
## Summary
I like to switch between workspaces a lot, but the current workspace selector makes it cumbersome. This PR adds an optional Discord-style workspace icon rail for switching workspaces, replacing the top-bar workspace dropdown.

## Changes
- Adds a persisted Appearance setting to enable the workspace icon rail.
- Renders workspace icons in a full-height left rail with active, unread, and remote-disconnected states.
- Insets the top bar when the rail is visible so top-bar controls do not overlap the rail.
- Keeps the top-bar workspace selector for compact viewports and when the rail setting is disabled.
- Adds i18n strings for the new setting across supported locales.
- Adds unit coverage for the rail visibility and top-bar inset logic.

## Testing
- `bun test apps/electron/src/renderer/components/app-shell/__tests__/workspace-rail.test.ts`
- `cd apps/electron && bun run typecheck`
- `cd packages/shared && bun run tsc --noEmit`
- Manually tested electron app (Linux), web server, web gui.

Note: `bun run typecheck:all` currently fails before reaching this change because `packages/core` cannot read `tsconfig.base.json` and dependency type errors are emitted from `@types/cacheable-request`/`keyv`.

## Screenshots
<img width="1706" height="1065" alt="Screenshot 2026-04-30 at 22-54-14 Craft Agents" src="https://github.com/user-attachments/assets/64bd668b-5bf3-46d7-ad75-b818161d3ae9" />

<img width="1706" height="1065" alt="Screenshot 2026-04-30 at 22-55-24 Craft Agents" src="https://github.com/user-attachments/assets/bb722420-802d-48af-a49e-02964759a0fa" />

<img width="548" height="1220" alt="Screenshot 2026-04-30 at 22-57-02 Craft Agents" src="https://github.com/user-attachments/assets/0a8a9299-043d-42b5-8397-9e106e3134ab" />

<img width="1708" height="1068" alt="Screenshot From 2026-04-30 22-56-00" src="https://github.com/user-attachments/assets/714b846c-ff49-4feb-9209-655e914cb146" />

