### PR TITLE
fix: suppress success notifications for failed agent turns (#664)

### DIFF
--- a/apps/electron/src/renderer/App.tsx
+++ b/apps/electron/src/renderer/App.tsx
@@ -969,17 +969,28 @@ export default function App() {
           newMetaMap.set(sessionId, extractSessionMeta(updatedSession))
           store.set(sessionMetaMapAtom, newMetaMap)
 
-          // Show notification on complete (when window is not focused)
-          // Skip hidden sessions (mini-agent sessions) - they shouldn't trigger notifications
+          // Show notification on complete (when window is not focused).
+          // Skip hidden sessions (mini-agent sessions) - they shouldn't trigger notifications.
+          // Gate on reason + didReceiveNewFinalMessage so error/interrupt cleanup
+          // events don't fire success-style notifications previewing stale or
+          // never-persisted content (#664). Both fields are optional — when
+          // absent (older backends) treat as success to preserve prior behavior.
           if (event.type === 'complete' && !updatedSession.hidden) {
-            // Get the last assistant/plan message as preview
-            const lastMessage = updatedSession.messages.findLast(
-              m => (m.role === 'assistant' || m.role === 'plan') && !m.isIntermediate
-            )
-            // Strip markdown so OS notifications display clean plain text
-            const rawPreview = lastMessage?.content?.substring(0, 200) || undefined
-            const preview = rawPreview ? stripMarkdown(rawPreview).substring(0, 100) || undefined : undefined
-            showSessionNotification(updatedSession, preview)
+            const completeEvent = event as { reason?: string; didReceiveNewFinalMessage?: boolean }
+            const isSuccessfulCompletion =
+              (completeEvent.reason === undefined || completeEvent.reason === 'complete') &&
+              completeEvent.didReceiveNewFinalMessage !== false
+
+            if (isSuccessfulCompletion) {
+              // Get the last assistant/plan message as preview
+              const lastMessage = updatedSession.messages.findLast(
+                m => (m.role === 'assistant' || m.role === 'plan') && !m.isIntermediate
+              )
+              // Strip markdown so OS notifications display clean plain text
+              const rawPreview = lastMessage?.content?.substring(0, 200) || undefined
+              const preview = rawPreview ? stripMarkdown(rawPreview).substring(0, 100) || undefined : undefined
+              showSessionNotification(updatedSession, preview)
+            }
           }
         }
 

--- a/apps/electron/src/renderer/event-processor/handlers/__tests__/error-drops-streaming.test.ts
+++ b/apps/electron/src/renderer/event-processor/handlers/__tests__/error-drops-streaming.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'bun:test'
+import { handleError, handleTypedError } from '../session'
+import type { SessionState, ErrorEvent, TypedErrorEvent } from '../../types'
+
+function makeState(messages: any[]): SessionState {
+  return {
+    session: {
+      id: 'session-1',
+      messages,
+      lastMessageAt: Date.now(),
+      isProcessing: true,
+    } as any,
+    streaming: { content: 'partial', turnId: 'turn-1' },
+  }
+}
+
+describe('handleError drops in-flight streaming assistant messages (#664)', () => {
+  it('removes role=assistant messages with isStreaming: true', () => {
+    const state = makeState([
+      { id: 'msg-final', role: 'assistant', content: 'previous answer', isStreaming: false },
+      { id: 'msg-streaming', role: 'assistant', content: 'partial answ', isStreaming: true, isPending: true, turnId: 'turn-1' },
+    ])
+
+    const event: ErrorEvent = {
+      type: 'error',
+      sessionId: 'session-1',
+      error: 'context_length_exceeded',
+    }
+
+    const next = handleError(state, event)
+    const ids = next.state.session.messages.map(m => m.id)
+
+    expect(ids).not.toContain('msg-streaming')
+    expect(ids).toContain('msg-final')
+  })
+
+  it('still appends the error message and clears processing state', () => {
+    const state = makeState([
+      { id: 'msg-streaming', role: 'assistant', content: 'partial', isStreaming: true },
+    ])
+
+    const event: ErrorEvent = {
+      type: 'error',
+      sessionId: 'session-1',
+      error: 'something failed',
+      timestamp: 1234,
+    }
+
+    const next = handleError(state, event)
+    const errorMsg = next.state.session.messages.find(m => m.role === 'error')
+
+    expect(errorMsg).toBeDefined()
+    expect(errorMsg!.content).toBe('something failed')
+    expect(next.state.session.isProcessing).toBe(false)
+    expect(next.state.streaming).toBeNull()
+  })
+
+  it('keeps non-streaming assistant messages untouched', () => {
+    const state = makeState([
+      { id: 'msg-final', role: 'assistant', content: 'final', isStreaming: false },
+    ])
+
+    const event: ErrorEvent = {
+      type: 'error',
+      sessionId: 'session-1',
+      error: 'oops',
+    }
+
+    const next = handleError(state, event)
+    expect(next.state.session.messages.find(m => m.id === 'msg-final')).toBeDefined()
+  })
+
+  it('still marks running tools as failed', () => {
+    const state = makeState([
+      { id: 'tool-1', role: 'tool', toolStatus: 'executing', toolResult: undefined },
+      { id: 'msg-streaming', role: 'assistant', content: 'partial', isStreaming: true },
+    ])
+
+    const event: ErrorEvent = {
+      type: 'error',
+      sessionId: 'session-1',
+      error: 'failed',
+    }
+
+    const next = handleError(state, event)
+    const tool = next.state.session.messages.find(m => m.id === 'tool-1')
+
+    expect(tool?.toolStatus).toBe('error')
+    expect(tool?.isError).toBe(true)
+  })
+})
+
+describe('handleTypedError drops in-flight streaming assistant messages (#664)', () => {
+  it('removes role=assistant messages with isStreaming: true', () => {
+    const state = makeState([
+      { id: 'msg-final', role: 'assistant', content: 'previous answer', isStreaming: false },
+      { id: 'msg-streaming', role: 'assistant', content: 'partial', isStreaming: true, isPending: true, turnId: 'turn-1' },
+    ])
+
+    const event: TypedErrorEvent = {
+      type: 'typed_error',
+      sessionId: 'session-1',
+      error: {
+        code: 'unknown_error',
+        title: 'Context limit',
+        message: 'Too long',
+        actions: [],
+        canRetry: false,
+      },
+    }
+
+    const next = handleTypedError(state, event)
+    const ids = next.state.session.messages.map(m => m.id)
+
+    expect(ids).not.toContain('msg-streaming')
+    expect(ids).toContain('msg-final')
+  })
+
+  it('still appends the typed error message and clears processing state', () => {
+    const state = makeState([
+      { id: 'msg-streaming', role: 'assistant', content: 'partial', isStreaming: true },
+    ])
+
+    const event: TypedErrorEvent = {
+      type: 'typed_error',
+      sessionId: 'session-1',
+      error: {
+        code: 'unknown_error',
+        title: 'Context limit',
+        message: 'Too long',
+        actions: [],
+        canRetry: false,
+      },
+    }
+
+    const next = handleTypedError(state, event)
+    const errorMsg = next.state.session.messages.find(m => m.role === 'error')
+
+    expect(errorMsg).toBeDefined()
+    expect(errorMsg!.errorCode).toBe('unknown_error')
+    expect(next.state.session.isProcessing).toBe(false)
+    expect(next.state.streaming).toBeNull()
+  })
+})

--- a/apps/electron/src/renderer/event-processor/handlers/session.ts
+++ b/apps/electron/src/renderer/event-processor/handlers/session.ts
@@ -122,12 +122,18 @@ export function handleError(
 ): ProcessResult {
   const { session } = state
 
+  // Drop in-flight streaming assistant messages (#664). These were assembled
+  // from text_delta events on the renderer side and were never persisted to
+  // session.jsonl, so leaving them would create a state that disappears on
+  // reload and would also leak into completion-notification previews.
   // Fail-safe: Mark any running tools as failed
-  const messagesWithFailedTools = session.messages.map(m =>
-    m.role === 'tool' && m.toolResult === undefined && m.toolStatus !== 'completed' && m.toolStatus !== 'error'
-      ? { ...m, toolStatus: 'error' as const, toolResult: 'Error occurred', isError: true }
-      : m
-  )
+  const messagesWithFailedTools = session.messages
+    .filter(m => !(m.role === 'assistant' && m.isStreaming === true))
+    .map(m =>
+      m.role === 'tool' && m.toolResult === undefined && m.toolStatus !== 'completed' && m.toolStatus !== 'error'
+        ? { ...m, toolStatus: 'error' as const, toolResult: 'Error occurred', isError: true }
+        : m
+    )
 
   const errorMessage: Message = {
     id: generateMessageId(),
@@ -159,12 +165,15 @@ export function handleTypedError(
 ): ProcessResult {
   const { session } = state
 
+  // Drop in-flight streaming assistant messages (#664). See handleError above.
   // Fail-safe: Mark any running tools as failed
-  const messagesWithFailedTools = session.messages.map(m =>
-    m.role === 'tool' && m.toolResult === undefined && m.toolStatus !== 'completed' && m.toolStatus !== 'error'
-      ? { ...m, toolStatus: 'error' as const, toolResult: 'Error occurred', isError: true }
-      : m
-  )
+  const messagesWithFailedTools = session.messages
+    .filter(m => !(m.role === 'assistant' && m.isStreaming === true))
+    .map(m =>
+      m.role === 'tool' && m.toolResult === undefined && m.toolStatus !== 'completed' && m.toolStatus !== 'error'
+        ? { ...m, toolStatus: 'error' as const, toolResult: 'Error occurred', isError: true }
+        : m
+    )
 
   const errorMessage: Message = {
     id: generateMessageId(),

--- a/apps/electron/src/renderer/event-processor/types.ts
+++ b/apps/electron/src/renderer/event-processor/types.ts
@@ -95,6 +95,10 @@ export interface CompleteEvent {
   tokenUsage?: Session['tokenUsage']
   /** Explicit unread flag - set by main process based on viewing state */
   hasUnread?: boolean
+  /** Why processing stopped. Set by SessionManager.onProcessingStopped (#664). */
+  reason?: 'complete' | 'interrupted' | 'error' | 'timeout'
+  /** True iff this turn produced a NEW final assistant message. Used to gate completion notifications (#664). */
+  didReceiveNewFinalMessage?: boolean
 }
 
 /**

--- a/packages/server-core/src/sessions/SessionManager.ts
+++ b/packages/server-core/src/sessions/SessionManager.ts
@@ -5627,12 +5627,16 @@ export class SessionManager implements ISessionManager {
         this.browserPaneManager.unbindAllForSession(sessionId)
       }
 
-      // No queue - emit complete to UI (include tokenUsage and hasUnread for state updates)
+      // No queue - emit complete to UI (include tokenUsage and hasUnread for state updates).
+      // reason + didReceiveNewFinalMessage let the renderer distinguish a real
+      // completion from an error/interrupt cleanup so it can gate notifications (#664).
       this.sendEvent({
         type: 'complete',
         sessionId,
         tokenUsage: managed.tokenUsage,
         hasUnread: managed.hasUnread,  // Propagate unread state to renderer
+        reason,
+        didReceiveNewFinalMessage,
       }, managed.workspace.id)
     }
 

--- a/packages/shared/src/protocol/dto.ts
+++ b/packages/shared/src/protocol/dto.ts
@@ -171,7 +171,7 @@ export type SessionEvent =
   | { type: 'tool_result'; sessionId: string; toolUseId: string; toolName: string; result: string; turnId?: string; parentToolUseId?: string; isError?: boolean; timestamp?: number }
   | { type: 'error'; sessionId: string; error: string; timestamp?: number }
   | { type: 'typed_error'; sessionId: string; error: TypedError; timestamp?: number }
-  | { type: 'complete'; sessionId: string; tokenUsage?: Session['tokenUsage']; hasUnread?: boolean }
+  | { type: 'complete'; sessionId: string; tokenUsage?: Session['tokenUsage']; hasUnread?: boolean; reason?: 'complete' | 'interrupted' | 'error' | 'timeout'; didReceiveNewFinalMessage?: boolean }
   | { type: 'interrupted'; sessionId: string; message?: Message; queuedMessages?: string[] }
   | { type: 'status'; sessionId: string; message: string; statusType?: 'compacting' }
   | { type: 'info'; sessionId: string; message: string; statusType?: 'compaction_complete'; level?: 'info' | 'warning' | 'error' | 'success'; timestamp?: number }


### PR DESCRIPTION
## Summary

Fixes #664. When an agent turn fails (e.g. `context_length_exceeded`), the
backend emits an `error` / `typed_error` event followed by a generic `complete`
event. The renderer currently treats every `complete` as a successful
completion notification and previews the last non-intermediate
assistant/plan message, so failed turns produce misleading OS notifications
that look like real answers — either showing the previous turn's answer or a
streaming partial that was never persisted.

This PR makes failed/interrupted turns skip the completion notification, and
keeps live UI state consistent with what was actually persisted to
`session.jsonl`.

## Changes

- **Wire + renderer types**: `SessionEvent.complete` (and renderer-side
  `CompleteEvent`) gain optional `reason` and `didReceiveNewFinalMessage`
  fields. Both are optional so older backends remain compatible; the renderer
  treats absent fields as success to preserve prior behavior during a partial
  rollout.
- **Backend**: `SessionManager.onProcessingStopped` now propagates `reason`
  and the already-computed `didReceiveNewFinalMessage` flag (it was being
  computed locally for `hasUnread` gating but never sent to the renderer).
- **Notification gate**: `App.tsx` only fires `showSessionNotification` when
  `reason === 'complete'` and `didReceiveNewFinalMessage !== false`.
- **Streaming cleanup**: `handleError` / `handleTypedError` drop in-flight
  streaming assistant messages (`role: 'assistant' && isStreaming: true`).
  These were assembled from `text_delta` events on the renderer side and were
  never persisted to `session.jsonl`, so dropping them keeps live UI state
  consistent with what a reload would show. Issue #664 listed two acceptable
  approaches (drop, or persist as interrupted) — drop is the smaller change
  and matches what's actually persisted; persisting partials is left as a
  potential follow-up.
- **Tests**: 6 new handler tests covering both `handleError` and
  `handleTypedError` — drop behavior plus existing invariants (error message
  appended, running tools marked failed, streaming state cleared).

## Test plan

- [x] `bun test apps/electron/src/renderer/event-processor/handlers/__tests__/` — 15 pass / 0 fail
- [x] `cd packages/shared && bun run tsc --noEmit` — clean
- [x] `cd packages/core && bun run tsc --noEmit` — clean
- [x] `cd packages/server-core && bun run tsc --noEmit` — clean
- [x] `cd apps/electron && bun run typecheck` — clean
- [x] `cd packages/messaging-gateway && bun test` — 133 pass / 0 fail (verifies wire-type widening doesn't break existing call sites)
- [ ] Manual: trigger a `context_length_exceeded` turn and confirm no completion notification fires; confirm live UI no longer shows a partial assistant bubble after the error message appears

## Notes

- The renderer-side gate accepts absent fields as "success" so a renderer
  running against a backend without these fields keeps current behavior.
- Two other `sendEvent({ type: 'complete', ... })` call sites in
  `SessionManager.ts` (L3353, L3408 — plan submission and auth request handoff)
  were intentionally not modified: those are paused-execution handoffs, not
  the queue-drained completion path that #664 is about. They could be
  revisited in a follow-up if their notification semantics also need
  tightening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)