### PR TITLE
fix: classify context overflow errors and tag overflow rejections (#666)

### DIFF
--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -467,6 +467,7 @@ export type ErrorCode =
   | 'image_too_large'        // Image exceeds API dimension/size limits
   | 'provider_error'         // AI provider experiencing issues (overloaded, unavailable)
   | 'queued_message_replay_failed'  // A message queued during an active turn could not be auto-replayed (#616)
+  | 'context_overflow'       // Provider rejected request because input/context exceeded the model's window (#666)
   | 'unknown_error';
 
 /**

--- a/packages/pi-agent-server/src/index.ts
+++ b/packages/pi-agent-server/src/index.ts
@@ -68,6 +68,7 @@ import {
 
 // Direct source imports from shared (bundled by bun build)
 import { handleLargeResponse, estimateTokens, TOKEN_LIMIT } from '../../shared/src/utils/large-response.ts';
+import { isContextOverflowMessage } from '../../shared/src/agent/errors.ts';
 import { getSessionPlansPath, getSessionPath } from '../../shared/src/sessions/storage.ts';
 import { buildCallLlmRequest, withTimeout, LLM_QUERY_TIMEOUT_MS } from '../../shared/src/agent/llm-tool.ts';
 import type { LLMQueryRequest, LLMQueryResult } from '../../shared/src/agent/llm-tool.ts';
@@ -1098,6 +1099,14 @@ function handleSessionEvent(event: AgentSessionEvent): void {
     const msg = event.message as { role?: string; stopReason?: string; errorMessage?: string } | undefined;
     if (msg?.stopReason === 'error') {
       debugLog(`API error in message_end: ${msg.errorMessage || 'unknown'}`);
+      // TODO(#666): when errorMessage is a context overflow, this is the place
+      // to trigger compact + replay (mirroring the synchronous-throw recovery
+      // at handlePrompt's catch block). Deferred from this change because
+      // mid-stream recovery needs to align with the renderer's UI cleanup
+      // semantics for the partial assistant message that's already on screen.
+      // For now the parent's parseError will at least classify the surfaced
+      // error as 'context_overflow' so the user gets an actionable message
+      // instead of a raw provider error string.
     }
 
     if (msg?.role === 'assistant' && piSession) {
@@ -1213,16 +1222,9 @@ async function handleInit(msg: Extract<InboundMessage, { type: 'init' }>): Promi
   });
 }
 
-function isContextOverflowErrorMessage(message: string): boolean {
-  const normalized = message.toLowerCase();
-  return (
-    normalized.includes('context_length_exceeded') ||
-    normalized.includes('exceeds the context window') ||
-    normalized.includes('context window') && normalized.includes('exceed') ||
-    normalized.includes('too many tokens') ||
-    normalized.includes('token limit exceeded')
-  );
-}
+// Context-overflow detection lives in @craft-agent/shared (errors.ts) so the
+// subprocess and the parent's parseError stay in sync (#666).
+const isContextOverflowErrorMessage = isContextOverflowMessage;
 
 /**
  * Wait for any in-flight compaction to finish before sending a prompt.
@@ -1689,7 +1691,12 @@ function main(): void {
     const msg = reason instanceof Error ? reason.message : String(reason);
     debugLog(`Unhandled rejection: ${msg}`);
     try {
-      send({ type: 'error', message: `Unhandled rejection: ${msg}`, code: 'unhandled_rejection' });
+      // Tag overflow rejections so the parent's parseError can classify them
+      // as context_overflow rather than generic unhandled_rejection (#666).
+      const code = isContextOverflowErrorMessage(msg)
+        ? 'context_overflow_unhandled'
+        : 'unhandled_rejection';
+      send({ type: 'error', message: `Unhandled rejection: ${msg}`, code });
     } catch {
       // stdout may be broken — swallow to avoid re-triggering
     }

--- a/packages/shared/src/agent/__tests__/errors.test.ts
+++ b/packages/shared/src/agent/__tests__/errors.test.ts
@@ -35,3 +35,42 @@ describe('parseError proxy interception handling', () => {
     expect(parsed.code).toBe('invalid_api_key')
   })
 })
+
+describe('parseError context overflow detection (#666)', () => {
+  it('maps context_length_exceeded error to context_overflow', () => {
+    const parsed = parseError(new Error('Error: context_length_exceeded - this turn would exceed the model context window'))
+    expect(parsed.code).toBe('context_overflow')
+  })
+
+  it('maps "exceeds the context window" message to context_overflow', () => {
+    const parsed = parseError(new Error('The request exceeds the context window of 200000 tokens'))
+    expect(parsed.code).toBe('context_overflow')
+  })
+
+  it('maps "too many tokens" message to context_overflow', () => {
+    const parsed = parseError(new Error('Request rejected: too many tokens for this model'))
+    expect(parsed.code).toBe('context_overflow')
+  })
+
+  it('maps "token limit exceeded" message to context_overflow', () => {
+    const parsed = parseError(new Error('Token limit exceeded'))
+    expect(parsed.code).toBe('context_overflow')
+  })
+
+  it('returns a typed error definition with title and retry action', () => {
+    const parsed = parseError(new Error('context_length_exceeded'))
+    expect(parsed.title).toBeTruthy()
+    expect(parsed.message).toBeTruthy()
+    expect(parsed.canRetry).toBe(true)
+  })
+
+  it('does not misclassify image-too-large errors as context_overflow', () => {
+    const parsed = parseError(new Error('Image dimensions exceed the 8000px limit'))
+    expect(parsed.code).toBe('image_too_large')
+  })
+
+  it('does not misclassify unrelated errors as context_overflow', () => {
+    const parsed = parseError(new Error('500 Internal Server Error'))
+    expect(parsed.code).toBe('service_error')
+  })
+})

--- a/packages/shared/src/agent/errors.ts
+++ b/packages/shared/src/agent/errors.ts
@@ -27,6 +27,7 @@ export type ErrorCode =
   | 'image_too_large'        // Image exceeds API dimension/size limits
   | 'provider_error'         // AI provider experiencing issues (overloaded, unavailable)
   | 'queued_message_replay_failed'  // A message queued during an active turn could not be auto-replayed (#616)
+  | 'context_overflow'       // Provider rejected request because input/context exceeded the model's window (#666)
   | 'unknown_error';
 
 /** Provider info attached to errors for user-facing context */
@@ -235,6 +236,15 @@ const ERROR_DEFINITIONS: Record<ErrorCode, Omit<AgentError, 'code' | 'originalEr
     ],
     canRetry: true,
   },
+  context_overflow: {
+    title: 'Context Window Full',
+    message: 'The conversation has grown larger than the model can handle in one turn. Compact the session to summarize older messages, then retry.',
+    actions: [
+      { key: 'c', label: 'Compact session', command: '/compact' },
+      { key: 'r', label: 'Retry', action: 'retry' },
+    ],
+    canRetry: true,
+  },
   unknown_error: {
     title: 'Error',
     message: 'Something went wrong. If this persists, check the provider status page or retry.',
@@ -351,6 +361,22 @@ function buildProxyErrorMessage(errorMessage: string, fullErrorText: string): st
 }
 
 /**
+ * Detect whether an error message indicates a provider-side context window
+ * overflow (e.g. `context_length_exceeded`). Exported so subprocess code paths
+ * can apply the same recovery / classification logic (#666).
+ */
+export function isContextOverflowMessage(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes('context_length_exceeded') ||
+    normalized.includes('exceeds the context window') ||
+    (normalized.includes('context window') && normalized.includes('exceed')) ||
+    normalized.includes('too many tokens') ||
+    normalized.includes('token limit exceeded')
+  );
+}
+
+/**
  * Parse an error and return a typed AgentError with user-friendly info
  */
 export function parseError(
@@ -390,6 +416,11 @@ export function parseError(
   // page would otherwise be misclassified as service_error or invalid_api_key.
   } else if (isLikelyProxyInterception(lowerMessage)) {
     code = 'proxy_error';
+  // Context-window overflow from the provider (#666). Must be checked BEFORE
+  // image_too_large (which also matches "exceed") and any generic 4xx checks
+  // so the user gets an actionable "compact and retry" message.
+  } else if (isContextOverflowMessage(lowerMessage)) {
+    code = 'context_overflow';
   // Check for specific HTTP status codes or patterns
   } else if (lowerMessage.includes('402') || lowerMessage.includes('payment required')) {
     code = 'billing_error';


### PR DESCRIPTION
## Summary

Partial fix for #666 (orchestration-layer Gap 3). Provider-side
context-overflow errors (e.g. `context_length_exceeded`) currently fall
through `parseError` as generic `unknown_error`, so the renderer surfaces a
raw provider error string with no actionable next step. This PR adds
classification so the user sees a typed "Context Window Full" error with
compact + retry actions instead.

The synchronous-throw recovery at `handlePrompt`'s catch block
(`pi-agent-server/src/index.ts` L1287-1315) is unchanged and still handles
the most common overflow path automatically. This PR addresses the paths
that escape that catch.

## Changes

- **`packages/core/src/types/message.ts`**: add `'context_overflow'` to
  `ErrorCode`.
- **`packages/shared/src/agent/errors.ts`**:
  - add `'context_overflow'` to the local `ErrorCode` union (kept in sync
    with core),
  - add `ERROR_DEFINITIONS['context_overflow']` with title, message, and
    actions (`compact session` + `retry`),
  - export `isContextOverflowMessage(message: string): boolean` so the
    subprocess can share the same patterns,
  - add a `parseError` branch that runs **before** `image_too_large` (which
    also matches "exceed") so overflow strings don't get misclassified.
- **`packages/pi-agent-server/src/index.ts`**:
  - alias the shared `isContextOverflowMessage` instead of keeping the local
    copy of the string patterns — single source of truth,
  - tag subprocess `unhandledRejection` with code
    `'context_overflow_unhandled'` when the rejection text matches, so the
    parent's `parseError` picks it up via the same overflow branch instead
    of as generic `'unhandled_rejection'`,
  - add a `TODO(#666)` comment at the `handleSessionEvent` `message_end
    stopReason==='error'` path pointing at the deferred mid-stream
    auto-recovery (see Notes).

## Tests

- 7 new `parseError` tests in
  `packages/shared/src/agent/__tests__/errors.test.ts` covering several
  overflow message formats (`context_length_exceeded`, `exceeds the context
  window`, `too many tokens`, `token limit exceeded`).
- Negative tests asserting `image_too_large` stays classified as
  `image_too_large` and `500 Internal Server Error` stays as `service_error`.

## Test plan

- [x] `cd packages/shared && bun test src/agent/__tests__/errors.test.ts`
  — 10 pass / 0 fail
- [x] `cd packages/core && bun run tsc --noEmit` — clean
- [x] `cd packages/shared && bun run tsc --noEmit` — clean
- [x] `cd packages/server-core && bun run tsc --noEmit` — clean
- [x] `cd apps/electron && bun run typecheck` — clean
- [x] `cd packages/pi-agent-server && bun run typecheck` — same pre-existing
  errors as `main`; this PR introduces no new errors there.
- [ ] Manual: trigger a `context_length_exceeded` failure and confirm the
  renderer shows a typed "Context Window Full" error with `Compact session`
  and `Retry` actions instead of a bare error string.

## Out of scope (deferred)

Mid-stream `message_end`-overflow **auto-recovery** (have the subprocess
detect overflow surfaced via SDK stream events, run `session.compact()`, and
replay the prompt) is deferred from this PR. That recovery interacts with
renderer-side partial-streaming-message cleanup (#664 / PR #665) and needs
maintainer alignment on UI semantics during the brief retry window — what
should the user see when their partial answer disappears and is replaced by
a retry mid-stream? Once we agree on the desired behaviour I'll open a
follow-up.

After this PR lands, every overflow path at minimum has a clean classified
error; auto-recovery is an additive future change on top.

The other gaps in #666 (cumulative tool-result budget, preflight context
check) remain open and are tracked separately on that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)