### PR TITLE
Fix session self-management tool hang in ask mode

### DIFF
--- a/packages/session-tools-core/src/handlers/set-session-status.test.ts
+++ b/packages/session-tools-core/src/handlers/set-session-status.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { SessionToolContext } from "../context.ts";
+import { TOOL_DESCRIPTIONS } from "../tool-defs.ts";
+import { handleSetSessionStatus } from "./set-session-status.ts";
+
+describe("set_session_status tool description", () => {
+  // Workspaces ship with status IDs like "todo" / "needs-review" / "done".
+  // The default template does NOT include "in_progress" — yet a previous
+  // version of this description suggested it as an example, which led the
+  // agent to call set_session_status({ status: "in_progress" }) and trip
+  // the unknown-status path on every fresh workspace.
+  //
+  // Guard against regression: the description must not advertise specific
+  // status IDs that aren't part of the canonical default config.
+  it("does not hardcode status IDs that may not exist in a workspace", () => {
+    const desc = TOOL_DESCRIPTIONS.set_session_status;
+    expect(desc).not.toContain('"in_progress"');
+    expect(desc).not.toContain("'in_progress'");
+  });
+
+  it("points the agent at a discovery path for valid IDs", () => {
+    const desc = TOOL_DESCRIPTIONS.set_session_status.toLowerCase();
+    const mentionsDiscovery =
+      desc.includes("get_session_info") ||
+      desc.includes("list_sessions") ||
+      desc.includes("available") ||
+      desc.includes("returns");
+    expect(mentionsDiscovery).toBe(true);
+  });
+});
+
+function baseCtx(): Partial<SessionToolContext> {
+  return {
+    sessionId: "sess-1",
+    workspacePath: "/tmp/ws",
+    sessionPath: "/tmp/ws/sessions/sess-1",
+  };
+}
+
+describe("handleSetSessionStatus", () => {
+  it("returns errorResponse when ctx.setSessionStatus is missing", async () => {
+    const ctx = baseCtx() as SessionToolContext;
+
+    const result = await handleSetSessionStatus(ctx, { status: "todo" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("not available");
+  });
+
+  it("rejects unknown status fast and lists available IDs", async () => {
+    const setSessionStatus = mock(async () => {});
+    const ctx = {
+      ...baseCtx(),
+      setSessionStatus,
+      resolveStatus: () => ({
+        resolved: null,
+        available: ["backlog", "todo", "needs-review", "done", "cancelled"],
+      }),
+    } as unknown as SessionToolContext;
+
+    const result = await handleSetSessionStatus(ctx, { status: "in_progress" });
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0]?.text ?? "";
+    expect(text).toContain("in_progress");
+    expect(text).toContain("backlog");
+    expect(text).toContain("needs-review");
+    expect(setSessionStatus).not.toHaveBeenCalled();
+  });
+
+  it("resolves display-name input to canonical ID before persisting", async () => {
+    const setSessionStatus = mock(async () => {});
+    const ctx = {
+      ...baseCtx(),
+      setSessionStatus,
+      resolveStatus: (s: string) =>
+        s === "Needs Review"
+          ? { resolved: "needs-review", available: ["needs-review"] }
+          : { resolved: null, available: ["needs-review"] },
+    } as unknown as SessionToolContext;
+
+    const result = await handleSetSessionStatus(ctx, {
+      status: "Needs Review",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(setSessionStatus).toHaveBeenCalledTimes(1);
+    expect(setSessionStatus.mock.calls[0]?.[1]).toBe("needs-review");
+  });
+
+  it("targets a specific session when sessionId is provided", async () => {
+    const setSessionStatus = mock(async () => {});
+    const ctx = {
+      ...baseCtx(),
+      setSessionStatus,
+      resolveStatus: () => ({ resolved: "done", available: ["done"] }),
+    } as unknown as SessionToolContext;
+
+    await handleSetSessionStatus(ctx, { sessionId: "sess-9", status: "done" });
+
+    expect(setSessionStatus).toHaveBeenCalledTimes(1);
+    expect(setSessionStatus.mock.calls[0]?.[0]).toBe("sess-9");
+    expect(setSessionStatus.mock.calls[0]?.[1]).toBe("done");
+  });
+
+  it("without resolveStatus, passes the status through (legacy fallback)", async () => {
+    const setSessionStatus = mock(async () => {});
+    const ctx = {
+      ...baseCtx(),
+      setSessionStatus,
+    } as unknown as SessionToolContext;
+
+    const result = await handleSetSessionStatus(ctx, { status: "arbitrary" });
+
+    expect(result.isError).toBeFalsy();
+    expect(setSessionStatus.mock.calls[0]?.[1]).toBe("arbitrary");
+  });
+
+  it("returns errorResponse when setSessionStatus throws", async () => {
+    const setSessionStatus = mock(async () => {
+      throw new Error("persistence failed");
+    });
+    const ctx = {
+      ...baseCtx(),
+      setSessionStatus,
+      resolveStatus: () => ({ resolved: "done", available: ["done"] }),
+    } as unknown as SessionToolContext;
+
+    const result = await handleSetSessionStatus(ctx, { status: "done" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("persistence failed");
+  });
+});

--- a/packages/session-tools-core/src/tool-defs.ts
+++ b/packages/session-tools-core/src/tool-defs.ts
@@ -456,7 +456,7 @@ Use this to share anything that would help improve the product — issues you hi
 Use this to tag sessions for filtering or to trigger label-based automations (LabelAdd/LabelRemove events).
 Pass an empty array to clear all labels. Omit sessionId to target the current session.`,
 
-  set_session_status: `Set the status of the current session or a specific session by ID (e.g., "todo", "in_progress", "done").
+  set_session_status: `Set the status of the current session or a specific session by ID. Statuses are workspace-configured — call get_session_info to see the current session's status (which is always a valid ID), or use list_sessions to spot status IDs in use. If you pass an unknown value, the tool returns the available IDs so you can retry.
 
 Use this to signal completion or trigger status-based automations (SessionStatusChange events).
 Omit sessionId to target the current session.`,

--- a/packages/shared/src/agent/core/__tests__/pre-tool-use-checks.isolated.ts
+++ b/packages/shared/src/agent/core/__tests__/pre-tool-use-checks.isolated.ts
@@ -1141,6 +1141,42 @@ describe('shouldPromptInAskMode', () => {
 
       expect(result).toBeNull();
     });
+
+    // Session self-management tools (set_session_status, set_session_labels) only
+    // mutate the current session's metadata — no external side effects. They must
+    // never prompt in ask mode, otherwise headless / webhook-dispatched sessions
+    // hang forever waiting on a UI that doesn't exist.
+    it('auto-allows mcp__session__set_session_status without prompting', () => {
+      mockShouldAllowToolInMode.mockImplementation(
+        (_tool: string, _input: Record<string, unknown>, mode: string) =>
+          mode === 'safe' ? { allowed: false, reason: 'mutation' } : { allowed: true, reason: '' }
+      );
+
+      const result = shouldPromptInAskMode(
+        'mcp__session__set_session_status',
+        { status: 'needs-review' },
+        pm,
+        { workspaceRootPath: '/test', activeSourceSlugs: [] },
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('auto-allows mcp__session__set_session_labels without prompting', () => {
+      mockShouldAllowToolInMode.mockImplementation(
+        (_tool: string, _input: Record<string, unknown>, mode: string) =>
+          mode === 'safe' ? { allowed: false, reason: 'mutation' } : { allowed: true, reason: '' }
+      );
+
+      const result = shouldPromptInAskMode(
+        'mcp__session__set_session_labels',
+        { labels: ['urgent'] },
+        pm,
+        { workspaceRootPath: '/test', activeSourceSlugs: [] },
+      );
+
+      expect(result).toBeNull();
+    });
   });
 
   // --- API mutations ---

--- a/packages/shared/src/agent/core/pre-tool-use.ts
+++ b/packages/shared/src/agent/core/pre-tool-use.ts
@@ -664,6 +664,21 @@ const BUILT_IN_MCP_SERVERS = new Set(['session', 'craft-agents-docs']);
 const FILE_WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit']);
 
 /**
+ * Session self-management tools that only mutate the current session's
+ * own metadata (status, labels). They have no external side effects and
+ * must never prompt in ask mode — otherwise headless / webhook-dispatched
+ * sessions hang indefinitely waiting for a UI approval that will never
+ * arrive.
+ *
+ * Keep this list narrow: tools with any external side effect (terminal_exec,
+ * inter-session messaging, source activation, file writes) belong elsewhere.
+ */
+const SESSION_METADATA_MUTATION_TOOLS = new Set([
+  'mcp__session__set_session_status',
+  'mcp__session__set_session_labels',
+]);
+
+/**
  * Centralized PreToolUse pipeline.
  *
  * Synchronous except for the final result — all async work (source activation,
@@ -1067,6 +1082,13 @@ export function shouldPromptInAskMode(
       toolName, input, 'safe', { plansFolderPath }
     );
     if (!safeModeResult.allowed) {
+      // Session self-management mutations only touch this session's own
+      // metadata; auto-allow so headless / webhook-dispatched sessions don't
+      // deadlock waiting on a UI prompt.
+      if (SESSION_METADATA_MUTATION_TOOLS.has(toolName)) {
+        onDebug?.(`Auto-allowing session self-management mutation "${toolName}"`);
+        return null;
+      }
       // It's a mutation — check whitelist
       if (permissionManager.isCommandWhitelisted(toolName)) {
         onDebug?.(`Auto-allowing "${toolName}" (previously approved)`);


### PR DESCRIPTION
When an agent calls `set_session_status` or `set_session_labels` in ask mode, the tool call hangs indefinitely in headless / webhook-dispatched sessions because `shouldPromptInAskMode()` routes them through the generic `mcp__*` mutation prompt path. With no UI to grant approval, the tool never resolves and the agent's turn deadlocks.

These tools only mutate the current session's own metadata — there's no external side effect to gate. This PR adds a narrow auto-allow list for them, paralleling how `mcp__session__call_llm` and `mcp__session__spawn_session` are already intercepted earlier in the pipeline.

## Also fixes the description

The `set_session_status` description previously suggested `"in_progress"` as an example status ID, but that ID is not part of the default workspace status config (`backlog` / `todo` / `needs-review` / `done` / `cancelled`). Agents reasonably trusted the example and tripped the unknown-status path on every fresh workspace. The new description points the agent at `get_session_info` / `list_sessions` for discovery and notes that the tool returns the available IDs on invalid input.

## Reproduction

In a fresh workspace with `permissionMode: "ask"`, send any agent prompt that triggers a self-status update from a headless context (e.g. an issue dispatched from a downstream webhook integration). The agent calls `set_session_status({ status: "in_progress" })`, the tool sits in `executing` state forever, the turn never completes.

## Scope

Narrow auto-allow list — only the two tools that mutate this session's own metadata. Tools with external side effects (`terminal_exec`, inter-session messaging, source activation) intentionally still go through the prompt path.

## Tests

- New `packages/session-tools-core/src/handlers/set-session-status.test.ts` covers the handler's `resolveStatus` path, the legacy fallback when `resolveStatus` is missing, the error-throw path, and adds two regression guards asserting the description does not hardcode invalid status IDs and points the agent at a discovery path.
- Two new cases in `packages/shared/src/agent/core/__tests__/pre-tool-use-checks.isolated.ts` assert that `mcp__session__set_session_status` and `mcp__session__set_session_labels` return `null` (no prompt) in ask mode even when classified as mutations by `shouldAllowToolInMode`.

All 142 tests in `session-tools-core` + `shared/src/agent/core` pass; `bun run typecheck` clean.