### PR TITLE
fix(renderer): dedupe model dropdown when tier slots collide

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
+++ b/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
@@ -98,6 +98,18 @@ function stripPiPrefixForDisplay(value: string): string {
   return value.startsWith('pi/') ? value.slice(3) : value
 }
 
+function dedupModelsById<T extends string | ModelDefinition>(models: T[]): T[] {
+  const seen = new Set<string>()
+  const result: T[] = []
+  for (const m of models) {
+    const id = typeof m === 'string' ? m : m.id
+    if (seen.has(id)) continue
+    seen.add(id)
+    result.push(m)
+  }
+  return result
+}
+
 function formatFollowUpChipText(text: string, fallback: string, maxLength = 50): string {
   const normalized = text.replace(/\s+/g, ' ').trim()
   if (!normalized) return fallback
@@ -337,7 +349,7 @@ export function FreeFormInput({
       return ANTHROPIC_MODELS // Safety net — shouldn't happen
     }
 
-    return connection.models || ANTHROPIC_MODELS
+    return dedupModelsById(connection.models || ANTHROPIC_MODELS)
   }, [llmConnections, currentConnection, workspaceDefaultConnection, connectionUnavailable])
 
   const availableThinkingLevels = THINKING_LEVELS
@@ -2041,7 +2053,7 @@ export function FreeFormInput({
                           {isAuthenticated && (
                             <StyledDropdownMenuSubContent className="min-w-[220px]">
                               {/* Show models for this connection - use provider-specific models as fallback */}
-                              {(conn.models || ANTHROPIC_MODELS).map((model) => {
+                              {dedupModelsById(conn.models || ANTHROPIC_MODELS).map((model) => {
                                 const modelId = typeof model === 'string' ? model : model.id
                                 const modelName = typeof model === 'string' ? stripPiPrefixForDisplay(getModelShortName(model)) : model.name
                                 const isSelectedModel = isCurrentConnection && currentModel === modelId


### PR DESCRIPTION
## Summary

The 3-tier model picker (`userDefined3Tier`, used by the Pi API-key flow) can store the same model id in multiple tier slots when the catalog has fewer entries than tiers. With DeepSeek (only 2 models), the saved `connection.models` becomes:

```json
["pi/deepseek-v4-pro", "pi/deepseek-v4-pro", "pi/deepseek-v4-flash"]
```

because `pickTierDefaults` lands Best and Default on the same id. The model dropdown then renders both rows with a checkmark.

## Repro

1. Add a "Craft Agents Backend (API Key)" connection with the **DeepSeek** preset
2. Open the model dropdown — `deepseek-v4-pro` appears twice, both with ✓

## Fix

Defensive render-layer dedup in `FreeFormInput.tsx`:

- Added a small `dedupModelsById` helper (handles both `string` and `ModelDefinition` items, preserves first-occurrence order so the "Best" tier semantics are kept).
- Applied it in the `availableModels` `useMemo` (flat dropdown) and in the per-connection submenu (`conn.models || ANTHROPIC_MODELS`).

This leaves the underlying tier storage and selection logic untouched — the existing test in `apps/electron/src/renderer/components/apisetup/__tests__/ApiKeyInput.test.ts` ("preserves duplicate tiers when saved models are valid") still passes.

## Test plan

- [x] `bun run typecheck` (apps/electron) — clean
- [x] `bun run lint` — no new errors/warnings
- [x] Visual: with a connection storing duplicate tier ids, dropdown now shows each model exactly once
- [ ] Verify with multiple-model providers (Anthropic, OpenAI) that nothing changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)