### PR TITLE
fix: sync i18n language before title generation

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -871,7 +871,7 @@ app.whenReady().then(async () => {
 
       // Language change: sync from renderer to main process and rebuild native menu
       ipcMain.handle('i18n:changeLanguage', async (_event, lang: string) => {
-        i18n.changeLanguage(lang)
+        await i18n.changeLanguage(lang)
         const { rebuildMenu } = await import('./menu')
         await rebuildMenu()
       })

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -14,7 +14,11 @@ import LanguageDetector from 'i18next-browser-languagedetector'
 import './index.css'
 
 // Initialize i18n before any React rendering
-setupI18n([LanguageDetector, initReactI18next])
+const i18n = setupI18n([LanguageDetector, initReactI18next])
+const initialLanguageSync = window.electronAPI?.changeLanguage?.(i18n.resolvedLanguage ?? i18n.language)
+void initialLanguageSync?.catch((error) => {
+  console.error('Failed to sync initial language to main process:', error)
+})
 
 // Known-harmless console messages that should NOT be sent to Sentry.
 // These are dev-mode noise or expected warnings that aren't actionable.

--- a/apps/electron/src/renderer/pages/settings/AppearanceSettingsPage.tsx
+++ b/apps/electron/src/renderer/pages/settings/AppearanceSettingsPage.tsx
@@ -135,6 +135,16 @@ export default function AppearanceSettingsPage() {
     setShowConnectionIcons(checked)
     storage.set(storage.KEYS.showConnectionIcons, checked)
   }, [])
+  const handleLanguageChange = useCallback((value: string) => {
+    void (async () => {
+      try {
+        await i18n.changeLanguage(value)
+        await window.electronAPI?.changeLanguage?.(value)
+      } catch (error) {
+        console.error('Failed to change language:', error)
+      }
+    })()
+  }, [i18n])
 
   // Rich tool descriptions toggle (persisted in config.json, read by SDK subprocess)
   const [richToolDescriptions, setRichToolDescriptions] = useState(true)
@@ -283,10 +293,7 @@ export default function AppearanceSettingsPage() {
                   <SettingsRow label={t("settings.appearance.language")}>
                     <SettingsMenuSelect
                       value={(i18n.resolvedLanguage ?? i18n.language) as LanguageCode}
-                      onValueChange={(value) => {
-                        i18n.changeLanguage(value)
-                        window.electronAPI?.changeLanguage?.(value)
-                      }}
+                      onValueChange={handleLanguageChange}
                       options={Object.entries(LANGUAGES).map(([code, config]) => ({
                         value: code,
                         label: config.nativeName,


### PR DESCRIPTION
## Summary
Fixes #644 by ensuring the Electron main process finishes applying i18n language changes before locale-dependent features read `i18n.resolvedLanguage`.

## Changes
- Await `i18n.changeLanguage()` in the main-process `i18n:changeLanguage` IPC handler before rebuilding native menus.
- Sync the renderer-detected startup language to the main process after i18n initialization.
- Serialize language changes from the Appearance settings page and log sync failures.

## Testing
- `npx --yes bun run typecheck:electron`
- `git diff --check`

Fixes #644