### PR TITLE
feat(apisetup): add Manifest as a default API-key provider preset

### DIFF
--- a/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
+++ b/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
@@ -111,8 +111,16 @@ const ANTHROPIC_PRESETS: Preset[] = [
   { key: 'minimax-cn', label: 'Minimax CN', url: 'https://api.minimaxi.com/anthropic', placeholder: 'Paste your key here...' },
   { key: 'kimi-coding', label: 'Kimi (Coding)', url: 'https://api.kimi.com/coding', placeholder: 'sk-kimi-...' },
   { key: 'vercel-ai-gateway', label: 'Vercel AI Gateway', url: 'https://ai-gateway.vercel.sh', placeholder: 'Paste your key here...' },
+  { key: 'manifest', label: 'Manifest', url: 'https://app.manifest.build/v1', placeholder: 'mnfst_...' },
   { key: 'custom', label: 'Custom', url: '', placeholder: 'Paste your key here...' },
 ]
+
+/**
+ * Presets without a Pi SDK provider entry that nonetheless expose a known
+ * OpenAI-compatible protocol. They behave like 'custom' on submit (customEndpoint
+ * gets pinned to openai-completions) but stay branded in the dropdown.
+ */
+const OPENAI_COMPAT_CUSTOM_URL_PRESETS: ReadonlySet<string> = new Set(['manifest'])
 
 // OpenAI provider presets - for Codex backend
 // Only direct OpenAI is supported; 3PP providers (OpenRouter, Vercel, Ollama) should be
@@ -233,7 +241,7 @@ export function ApiKeyInput({
   // Fetch Pi SDK models when a provider is selected in pi_api_key flow.
   // Returns all models sorted by cost (expensive-first) for the searchable tier dropdowns.
   const loadPiModels = useCallback(async (provider: string) => {
-    if (!isPiApiKeyFlow || !provider || provider === 'custom' || DEFAULT_ENDPOINT_PROVIDERS.has(provider)) {
+    if (!isPiApiKeyFlow || !provider || provider === 'custom' || DEFAULT_ENDPOINT_PROVIDERS.has(provider) || OPENAI_COMPAT_CUSTOM_URL_PRESETS.has(provider)) {
       setPiModels([])
       return
     }
@@ -285,7 +293,9 @@ export function ApiKeyInput({
       setConnectionDefaultModel(COMPAT_MINIMAX_DEFAULTS)
     } else if (preset.key === 'kimi-coding') {
       setConnectionDefaultModel(COMPAT_KIMI_DEFAULTS)
-    } else if (preset.key === 'custom') {
+    } else if (preset.key === 'manifest') {
+      setConnectionDefaultModel('auto')
+    } else if (preset.key === 'custom' || OPENAI_COMPAT_CUSTOM_URL_PRESETS.has(preset.key)) {
       setConnectionDefaultModel(providerType === 'openai' ? COMPAT_OPENAI_DEFAULTS : COMPAT_ANTHROPIC_DEFAULTS)
     } else {
       setConnectionDefaultModel('')
@@ -384,11 +394,15 @@ export function ApiKeyInput({
       return
     }
 
-    // Include custom endpoint protocol when user configured a custom base URL
-    const isCustomEndpoint = activePreset === 'custom' && !!effectiveBaseUrl
-    const customEndpoint = isCustomEndpoint ? { api: customApi } : undefined
+    // Include custom endpoint protocol when user configured a custom base URL.
+    // Branded openai-compat presets (e.g. Manifest) are pinned to openai-completions
+    // and routed via the Pi SDK's openai adapter.
+    const isBrandedOpenAiCompat = OPENAI_COMPAT_CUSTOM_URL_PRESETS.has(activePreset) && !!effectiveBaseUrl
+    const isCustomEndpoint = (activePreset === 'custom' && !!effectiveBaseUrl) || isBrandedOpenAiCompat
+    const effectiveCustomApi: CustomEndpointApi = isBrandedOpenAiCompat ? 'openai-completions' : customApi
+    const customEndpoint = isCustomEndpoint ? { api: effectiveCustomApi } : undefined
     const resolvedPiAuthProvider = isCustomEndpoint
-      ? (customApi === 'anthropic-messages' ? 'anthropic' : 'openai')
+      ? (effectiveCustomApi === 'anthropic-messages' ? 'anthropic' : 'openai')
       : effectivePiAuthProvider
 
     onSubmit({

--- a/apps/electron/src/renderer/lib/provider-icons.ts
+++ b/apps/electron/src/renderer/lib/provider-icons.ts
@@ -70,6 +70,7 @@ export function getProviderDisplayName(providerType: string, baseUrl?: string | 
     if (url.includes('kimi.com')) return 'Kimi'
     if (url.includes('minimax.io') || url.includes('minimaxi.com')) return 'Minimax'
     if (url.includes('v0.dev') || url.includes('vercel')) return 'Vercel'
+    if (url.includes('manifest.build')) return 'Manifest'
   }
   return providerDisplayNames[providerType] || providerType
 }
@@ -166,6 +167,10 @@ export function getProviderIcon(
     const detectedProvider = detectProviderFromUrl(baseUrl)
     if (detectedProvider) {
       return providerIcons[detectedProvider]
+    }
+    // Manifest has no bundled SVG — fall back to Google Favicon V2 (same trick used for groq/xai elsewhere).
+    if (baseUrl.toLowerCase().includes('manifest.build')) {
+      return 'https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&size=128&url=https://app.manifest.build'
     }
   }
 

--- a/apps/electron/src/renderer/pages/settings/AiSettingsPage.tsx
+++ b/apps/electron/src/renderer/pages/settings/AiSettingsPage.tsx
@@ -233,7 +233,11 @@ function ConnectionRow({ connection, isLastConnection, onRenameClick, onDelete, 
         parts.push(piLabel ?? 'Craft Agents Backend')
         break
       }
-      case 'pi_compat': parts.push('Craft Agents Backend Compatible'); break
+      case 'pi_compat':
+        parts.push(connection.baseUrl?.toLowerCase().includes('manifest.build')
+          ? 'Manifest'
+          : 'Craft Agents Backend Compatible')
+        break
       default: parts.push(provider || 'Unknown')
     }
 
@@ -970,7 +974,7 @@ export default function AiSettingsPage() {
                       label: conn.name,
                       description: conn.providerType === 'anthropic' ? 'Anthropic API' :
                                    conn.providerType === 'pi' ? 'Craft Agents Backend' :
-                                   conn.providerType === 'pi_compat' ? 'Craft Agents Backend Compatible' :
+                                   conn.providerType === 'pi_compat' ? (conn.baseUrl?.toLowerCase().includes('manifest.build') ? 'Manifest' : 'Craft Agents Backend Compatible') :
                                    conn.providerType || 'Unknown',
                     }))}
                   />

--- a/packages/server-core/src/handlers/rpc/llm-connections.ts
+++ b/packages/server-core/src/handlers/rpc/llm-connections.ts
@@ -116,6 +116,11 @@ export function registerLlmConnectionsHandlers(server: RpcServer, deps: HandlerD
         updates.authType = branch.authType
         if (branch.name !== undefined) updates.name = branch.name
         if (branch.piAuthProvider !== undefined) updates.piAuthProvider = branch.piAuthProvider
+
+        // Brand-name override on first setup only (user-renamed connections aren't clobbered on re-save).
+        if (isNewConnection && !updates.name && setup.baseUrl?.toLowerCase().includes('manifest.build')) {
+          updates.name = 'Manifest'
+        }
       } else if (setup.baseUrl !== undefined) {
         // Base URL was explicitly updated without custom protocol config.
         // Treat this as non-custom mode and clear stale custom endpoint metadata.


### PR DESCRIPTION
## Summary

Add [Manifest](https://github.com/mnfst/manifest) to the default providers list in the API-key connection flow.

Manifest exposes an OpenAI-compatible endpoint authenticated by an API key, so it slots into the existing flow alongside HuggingFace, Vercel AI Gateway, and the other OpenAI-compat presets — no OAuth needed.

## Motivation

Manifest is a self-hostable AI workbench that fronts multiple model providers behind a single OpenAI-compatible URL. Without a preset, users have to know to pick "Custom", remember to set the protocol toggle to OpenAI Compatible, and paste the URL by hand. Adding the preset makes it a one-click choice.

## Changes

### Preset entry — `apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx`

- New entry in `ANTHROPIC_PRESETS` (used by both Claude API-key and Pi API-key flows):
  ```ts
  { key: 'manifest', label: 'Manifest', url: 'https://app.manifest.build/v1', placeholder: 'mnfst_...' }
  ```
- New `OPENAI_COMPAT_CUSTOM_URL_PRESETS` set for branded presets that aren't Pi SDK providers but speak OpenAI-compat. On submit they're treated as custom endpoints (`customEndpoint.api = 'openai-completions'`, `piAuthProvider = 'openai'`); Pi-SDK model discovery is skipped for them.
- Default-model field seeded with `auto` (Manifest's auto-routing model).

### Branding (name, subtitle, icon)

Without brand info on the connection, Manifest connections rendered as "Craft Agents Backend (API Key)" with a generic OpenAI logo and "Craft Agents Backend Compatible" subtitle, because the `customEndpoint` code path doesn't carry brand metadata.

Three inline hostname checks fix it, matching the existing pattern in `provider-icons.ts` (which already does the same for OpenRouter, Ollama, Kimi, Minimax, Vercel):

- **`provider-icons.ts`** — `getProviderDisplayName` recognizes `manifest.build`; `getProviderIcon` falls back to a Google Favicon V2 URL for the `manifest.build` domain (same trick already used for Groq/xAI/Cerebras — no bundled SVG needed).
- **`AiSettingsPage.tsx`** — `pi_compat` subtitle shows "Manifest" when the `baseUrl` points there.
- **`server-core/.../llm-connections.ts`** — stamps the connection name "Manifest" on first setup only, so user-renamed connections are never overwritten on re-save.

## Testing

- `bun test apps/electron/src/renderer/components/apisetup/__tests__/ApiKeyInput.test.ts` — 9 pass.
- `bun run tsc --noEmit` — clean across `apps/electron`, `packages/shared`, `packages/server-core`.
- Manual: Settings → AI → Add Connection → API Key → Endpoint dropdown → **Manifest**. URL prefilled to `https://app.manifest.build/v1`, placeholder `mnfst_...`, default model `auto`. Saved connection renders with name "Manifest", subtitle "Manifest · app.manifest.build", and the Manifest favicon. End-to-end chat against the hosted endpoint works.

## Notes

- Preset is appended near the bottom of the dropdown (next to Vercel AI Gateway, before Custom). Happy to reorder.
- Self-hosted Manifest URLs continue to work via the existing Custom preset; the brand checks key on the `manifest.build` hostname so cloud users get the polish automatically.