### PR TITLE
Fix native UI rendering with wrong color scheme on Linux/GNOME

### DIFF
--- a/apps/electron/src/renderer/index.css
+++ b/apps/electron/src/renderer/index.css
@@ -82,6 +82,11 @@
 
 /* Light Mode */
 :root {
+  /* Tells Chromium to render native UI (scrollbars, form controls, autofill,
+     default backgrounds before CSS loads) in the matching color scheme.
+     Without this, GNOME shows light scrollbars/inputs over dark backgrounds. */
+  color-scheme: light;
+
   /* === 6 BASE COLORS === */
   --background: oklch(0.98 0.003 265);
   --background-elevated: color-mix(in srgb, var(--foreground) 1.5%, var(--background));
@@ -236,6 +241,8 @@
 
 /* Dark Mode */
 .dark {
+  color-scheme: dark;
+
   /* === 6 BASE COLORS (must match DEFAULT_THEME.dark in theme.ts) === */
   --background: oklch(0.145 0.015 270);
   --background-elevated: color-mix(in srgb, var(--foreground) 1.5%, var(--background));

--- a/packages/ui/src/styles/index.css
+++ b/packages/ui/src/styles/index.css
@@ -31,6 +31,11 @@
 ============================================================================= */
 
 :root {
+  /* Tells Chromium to render native UI (scrollbars, form controls, autofill,
+     default backgrounds before CSS loads) in the matching color scheme.
+     Without this, GNOME shows light scrollbars/inputs over dark backgrounds. */
+  color-scheme: light;
+
   /* === 6 BASE COLORS === */
   --background: oklch(0.98 0.003 265);
   --foreground: oklch(0.185 0.01 270);
@@ -149,6 +154,8 @@
 ============================================================================= */
 
 .dark {
+  color-scheme: dark;
+
   /* === 6 BASE COLORS === */
   --background: oklch(0.2 0.005 270);
   --foreground: oklch(0.92 0.005 270);


### PR DESCRIPTION
## Summary
On Linux (especially GNOME), Craft Agents in dark mode renders light-colored scrollbars, form controls, autofill highlights, and default UA backgrounds on top of the dark layout. This PR adds the CSS `color-scheme` property to the theme blocks so Chromium renders native UI in the matching scheme.

The bug exists because nothing in the codebase declared `color-scheme` (the CSS property, not the `prefers-color-scheme` media query). Chromium therefore painted UA-styled UI in the *light* scheme by default, producing the visible "light over dark" mismatch — most evident on GNOME via `xdg-desktop-portal-gtk`, but the same root cause affects every Chromium build.

## Changes
- `apps/electron/src/renderer/index.css` — add `color-scheme: light` to `:root` and `color-scheme: dark` to `.dark`. Covers `apps/electron` directly and `apps/webui` (which `@import`s electron's CSS).
- `packages/ui/src/styles/index.css` — same change in the shared base theme. Covers `apps/viewer` (which `@import "@craft-agent/ui/styles"`).

`apps/viewer/src/index.css` and `apps/webui/src/index.css` need no edits — they inherit via cascade. No TypeScript, build, or runtime changes — `color-scheme` is a CSS-only Chromium hint, honored uniformly across macOS / Windows / Linux.

Diff: 2 files, 14 lines added, 0 removed.

## Testing
- Targeted typecheck of touched packages: `cd apps/electron && bun run typecheck` and `cd packages/ui && bun run tsc --noEmit` — both clean.
- `bun run lint:i18n:parity` and `bun run lint:i18n:sorted` — pass.
- `bun run electron:dev` on Arch Linux + Hyprland (Wayland, `xdg-desktop-portal-gtk`):
  - Dark mode: scrollbars, native inputs/selects, and autofill highlights render in the dark scheme.
  - Light mode: same elements render light.
  - HMR confirmed via Vite (`[vite] hmr update /index.css`).

## Notes
- `bun run typecheck:all` has pre-existing failures on `main` unrelated to this CSS-only diff (missing `tsconfig.base.json`; transitive `@types/cacheable-request` typing issues; etc.). Stashing this PR's changes and re-running reproduces the exact same errors, so they are not introduced by this change.
- No screenshot included — easier to reproduce by checking out the branch and looking at any pane with a visible scrollbar in dark mode (sessions list, chat history).

## References
- [`color-scheme` CSS — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme)
- [Scrollbar styling — Chrome for Developers](https://developer.chrome.com/docs/css-ui/scrollbar-styling)