### PR TITLE
Fix: single-model compat connections block hierarchical connection switcher in empty sessions

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
+++ b/apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx
@@ -2057,64 +2057,6 @@ export function FreeFormInput({
                     {t('chat.connectionUnavailableDescription')}
                   </div>
                 </div>
-              ) : connectionDefaultModel ? (
-                (() => {
-                  // Single-model pi_compat connection: model row is disabled (you
-                  // can't switch), but vision toggle is still a separate control.
-                  const showVisionToggle =
-                    !!effectiveConnectionDetails && isCompatProvider(effectiveConnectionDetails.providerType)
-                  const visionOn = showVisionToggle && modelSupportsImages(effectiveConnectionDetails!, connectionDefaultModel)
-                  return (
-                    <StyledDropdownMenuItem
-                      disabled
-                      className="flex items-center justify-between px-2 py-2 rounded-lg"
-                    >
-                      <div className="text-left">
-                        <div className="font-medium text-sm">{stripPiPrefixForDisplay(connectionDefaultModel)}</div>
-                        <div className="text-xs text-muted-foreground">{t('chat.connectionDefault')}</div>
-                      </div>
-                      <div className="flex items-center gap-1 ml-3 shrink-0">
-                        {showVisionToggle && effectiveConnectionDetails && (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <span
-                                role="button"
-                                tabIndex={0}
-                                aria-label={visionOn
-                                  ? t('chat.modelPicker.supportsImagesOn')
-                                  : t('chat.modelPicker.supportsImagesOff')}
-                                className="inline-flex items-center justify-center p-1 rounded pointer-events-auto opacity-100 hover:bg-foreground/5 cursor-pointer"
-                                onClick={(e) => {
-                                  e.preventDefault()
-                                  e.stopPropagation()
-                                  handleToggleModelVision(effectiveConnectionDetails.slug, connectionDefaultModel, !visionOn)
-                                }}
-                                onKeyDown={(e) => {
-                                  if (e.key === 'Enter' || e.key === ' ') {
-                                    e.preventDefault()
-                                    e.stopPropagation()
-                                    handleToggleModelVision(effectiveConnectionDetails.slug, connectionDefaultModel, !visionOn)
-                                  }
-                                }}
-                              >
-                                <ImageIcon className={cn(
-                                  "h-3.5 w-3.5",
-                                  visionOn ? "text-foreground/70" : "text-foreground/30"
-                                )} />
-                              </span>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              {visionOn
-                                ? t('chat.modelPicker.supportsImagesOn')
-                                : t('chat.modelPicker.supportsImagesOff')}
-                            </TooltipContent>
-                          </Tooltip>
-                        )}
-                        <Check className="h-3 w-3 text-foreground" />
-                      </div>
-                    </StyledDropdownMenuItem>
-                  )
-                })()
               ) : isEmptySession && llmConnections.length > 1 ? (
                 /* Hierarchical view: Provider → Connection → Models (for new sessions with multiple connections) */
                 connectionsByProvider.map(([providerName, connections], index) => (
@@ -2225,6 +2167,64 @@ export function FreeFormInput({
                     )}
                   </React.Fragment>
                 ))
+              ) : connectionDefaultModel ? (
+                (() => {
+                  // Single-model pi_compat connection: model row is disabled (you
+                  // can't switch), but vision toggle is still a separate control.
+                  const showVisionToggle =
+                    !!effectiveConnectionDetails && isCompatProvider(effectiveConnectionDetails.providerType)
+                  const visionOn = showVisionToggle && modelSupportsImages(effectiveConnectionDetails!, connectionDefaultModel)
+                  return (
+                    <StyledDropdownMenuItem
+                      disabled
+                      className="flex items-center justify-between px-2 py-2 rounded-lg"
+                    >
+                      <div className="text-left">
+                        <div className="font-medium text-sm">{stripPiPrefixForDisplay(connectionDefaultModel)}</div>
+                        <div className="text-xs text-muted-foreground">{t('chat.connectionDefault')}</div>
+                      </div>
+                      <div className="flex items-center gap-1 ml-3 shrink-0">
+                        {showVisionToggle && effectiveConnectionDetails && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span
+                                role="button"
+                                tabIndex={0}
+                                aria-label={visionOn
+                                  ? t('chat.modelPicker.supportsImagesOn')
+                                  : t('chat.modelPicker.supportsImagesOff')}
+                                className="inline-flex items-center justify-center p-1 rounded pointer-events-auto opacity-100 hover:bg-foreground/5 cursor-pointer"
+                                onClick={(e) => {
+                                  e.preventDefault()
+                                  e.stopPropagation()
+                                  handleToggleModelVision(effectiveConnectionDetails.slug, connectionDefaultModel, !visionOn)
+                                }}
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault()
+                                    e.stopPropagation()
+                                    handleToggleModelVision(effectiveConnectionDetails.slug, connectionDefaultModel, !visionOn)
+                                  }
+                                }}
+                              >
+                                <ImageIcon className={cn(
+                                  "h-3.5 w-3.5",
+                                  visionOn ? "text-foreground/70" : "text-foreground/30"
+                                )} />
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              {visionOn
+                                ? t('chat.modelPicker.supportsImagesOn')
+                                : t('chat.modelPicker.supportsImagesOff')}
+                            </TooltipContent>
+                          </Tooltip>
+                        )}
+                        <Check className="h-3 w-3 text-foreground" />
+                      </div>
+                    </StyledDropdownMenuItem>
+                  )
+                })()
               ) : (
                 /* Flat model list (single connection or session started) */
                 <>


### PR DESCRIPTION
# Fix: single-model compat connections block hierarchical connection switcher in empty sessions

## Summary

When a `pi_compat` connection (e.g. Ollama local endpoint) has only a **single model**, the model/connection dropdown in a **new empty session** incorrectly renders a disabled single-model row instead of the hierarchical connection selector. This prevents users from switching to other connections before sending their first message.

## Related Issue

No existing issue found. This bug affects users with multiple LLM connections where the default connection is a single-model compat provider (common with Ollama setups).

Related discussions:
- #289 - Self-hosted LLMs (LM Studio/Ollama) show unstable behavior with Craft Agents
- #636 - Custom local endpoint with API key authentication fails with 401

## Changes

- **Swapped conditional precedence** in `FreeFormInput.tsx` model dropdown rendering
- Hierarchical connection selector (`isEmptySession && llmConnections.length > 1`) now evaluated **before** the single-model disabled row (`connectionDefaultModel`)
- This ensures users can always switch connections in empty sessions when multiple connections are configured

## Root Cause

In `FreeFormInput.tsx` the conditional rendering was:

```tsx
{connectionUnavailable ? (
  // ...
) : connectionDefaultModel ? (
  // Single-model compat provider: disabled row
) : isEmptySession && llmConnections.length > 1 ? (
  // Hierarchical connection → model selector
) : (
  // Flat model list
)}
```

`connectionDefaultModel` is non-null when the effective connection is a **compat provider with only one model**. Because this branch came **before** the hierarchical selector branch, the selector was **skipped entirely** whenever the active connection was a single-model compat provider — even in empty sessions where switching should be allowed.

## Fix

Swap the branch order:

```diff
-               ) : connectionDefaultModel ? (
-                 (() => {
-                   // Single-model pi_compat connection: model row is disabled ...
-                 })()
-               ) : isEmptySession && llmConnections.length > 1 ? (
+               ) : isEmptySession && llmConnections.length > 1 ? (
                  /* Hierarchical view: Provider → Connection → Models */
                  connectionsByProvider.map(([providerName, connections], index) => (
                    ...
                  ))
+               ) : connectionDefaultModel ? (
+                 (() => {
+                   // Single-model pi_compat connection: model row is disabled ...
+                 })()
                ) : (
                  /* Flat model list */
                  ...
                )}
```

This ensures:
- **Empty session + multiple connections** → always show hierarchical selector
- **Single-model compat connection** → show disabled row only when session already started or only one connection exists

## Files Changed

- `apps/electron/src/renderer/components/app-shell/input/FreeFormInput.tsx`

## Testing

- [x] Manual: configured `local-ollama` (1 model) + `pi-api-key` (3 models); verified hierarchical selector appears in new empty sessions
- [x] Manual: confirmed that after sending the first message, the dropdown correctly collapses to the flat model list of the locked connection
- [x] `bun run typecheck:all` passes

## Screenshots

N/A (UI behavior change — dropdown content changes based on state)

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/craft-ai-agents/craft-agents-oss/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project style
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
