### PR TITLE
fix(pi): support reasoning and display names for custom endpoints

### DIFF
--- a/packages/pi-agent-server/src/custom-endpoint-models.test.ts
+++ b/packages/pi-agent-server/src/custom-endpoint-models.test.ts
@@ -31,13 +31,17 @@ describe('normalizeCustomEndpointModelEntry', () => {
     })
   })
 
-  it('preserves context window and image support together', () => {
+  it('preserves display names, context window, and image support together', () => {
     expect(normalizeCustomEndpointModelEntry({
       id: 'pi/vision-model',
+      name: 'Vision Model',
+      shortName: 'Vision',
       contextWindow: 262_144,
       supportsImages: true,
     })).toEqual({
       id: 'vision-model',
+      name: 'Vision Model',
+      shortName: 'Vision',
       contextWindow: 262_144,
       supportsImages: true,
     })
@@ -64,5 +68,17 @@ describe('buildCustomEndpointModelDef', () => {
     const model = buildCustomEndpointModelDef('vision-model', undefined, { supportsImages: true, contextWindow: 262_144 })
     expect(model.input).toEqual(['text', 'image'])
     expect(model.contextWindow).toBe(262_144)
+  })
+
+  it('uses per-model display names when provided', () => {
+    const model = buildCustomEndpointModelDef('gpt-5.5', undefined, { name: 'GPT 5.5', shortName: 'GPT 5.5' })
+    expect(model.name).toBe('GPT 5.5')
+    expect(model.shortName).toBe('GPT 5.5')
+  })
+
+  it('marks openai-responses custom endpoint models as reasoning-capable', () => {
+    const model = buildCustomEndpointModelDef('gpt-5.5', { reasoning: true })
+    expect(model.reasoning).toBe(true)
+    expect(model.thinkingLevelMap).toEqual({ off: null, xhigh: 'xhigh' })
   })
 })

--- a/packages/pi-agent-server/src/custom-endpoint-models.ts
+++ b/packages/pi-agent-server/src/custom-endpoint-models.ts
@@ -2,9 +2,12 @@ export type CustomEndpointInput = 'text' | 'image'
 
 export interface CustomEndpointModelDefaults {
   supportsImages?: boolean
+  reasoning?: boolean
 }
 
 export interface CustomEndpointModelOverrides {
+  name?: string
+  shortName?: string
   contextWindow?: number
   supportsImages?: boolean
 }
@@ -15,6 +18,8 @@ export interface CustomEndpointModelEntry extends CustomEndpointModelOverrides {
 
 export type CustomEndpointModelConfig = string | {
   id: string
+  name?: string
+  shortName?: string
   contextWindow?: number
   supportsImages?: boolean
 }
@@ -38,6 +43,8 @@ export function normalizeCustomEndpointModelEntry(model: CustomEndpointModelConf
 
   return {
     id: stripPiPrefix(model.id),
+    ...(model.name !== undefined ? { name: model.name } : {}),
+    ...(model.shortName !== undefined ? { shortName: model.shortName } : {}),
     ...(model.contextWindow !== undefined ? { contextWindow: model.contextWindow } : {}),
     ...(model.supportsImages !== undefined ? { supportsImages: model.supportsImages } : {}),
   }
@@ -59,8 +66,10 @@ export function buildCustomEndpointModelDef(
 
   return {
     id,
-    name: id,
-    reasoning: false,
+    name: overrides?.name ?? id,
+    shortName: overrides?.shortName ?? overrides?.name ?? id,
+    reasoning: defaults?.reasoning ?? false,
+    ...(defaults?.reasoning ? { thinkingLevelMap: { off: null, xhigh: 'xhigh' } } : {}),
     input,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: overrides?.contextWindow ?? 131_072,

--- a/packages/pi-agent-server/src/index.ts
+++ b/packages/pi-agent-server/src/index.ts
@@ -90,7 +90,7 @@ type PiCredential =
   | { type: 'iam'; accessKeyId: string; secretAccessKey: string; region?: string; sessionToken?: string };
 
 /** Custom endpoint protocol — determines which streaming adapter Pi SDK uses */
-type CustomEndpointApi = 'openai-completions' | 'anthropic-messages';
+type CustomEndpointApi = 'openai-completions' | 'openai-responses' | 'anthropic-messages';
 
 /** Init message from main process — configures the Pi agent server */
 interface InitMessage {
@@ -114,7 +114,7 @@ interface InitMessage {
   branchFromSessionPath?: string;
   branchFromSdkTurnId?: string;
   customEndpoint?: { api: CustomEndpointApi; supportsImages?: boolean };
-  customModels?: Array<string | { id: string; contextWindow?: number; supportsImages?: boolean }>;
+  customModels?: Array<string | { id: string; name?: string; shortName?: string; contextWindow?: number; supportsImages?: boolean }>;
   piAuth?: { provider: string; credential: PiCredential };
 }
 
@@ -126,7 +126,7 @@ interface RuntimeConfigUpdateMessage {
   authType?: string;
   baseUrl?: string;
   customEndpoint?: { api: CustomEndpointApi; supportsImages?: boolean };
-  customModels?: Array<string | { id: string; contextWindow?: number; supportsImages?: boolean }>;
+  customModels?: Array<string | { id: string; name?: string; shortName?: string; contextWindow?: number; supportsImages?: boolean }>;
 }
 
 /** Messages from main process (stdin) */
@@ -444,8 +444,10 @@ function registerCustomEndpointModels(
 ): void {
   for (const m of models) {
     customEndpointModelIds.add(m.id);
-    if (m.contextWindow || m.supportsImages !== undefined) {
+    if (m.name !== undefined || m.shortName !== undefined || m.contextWindow || m.supportsImages !== undefined) {
       customModelOverrides.set(m.id, {
+        ...(m.name !== undefined ? { name: m.name } : {}),
+        ...(m.shortName !== undefined ? { shortName: m.shortName } : {}),
         ...(m.contextWindow ? { contextWindow: m.contextWindow } : {}),
         ...(m.supportsImages !== undefined ? { supportsImages: m.supportsImages } : {}),
       });
@@ -459,7 +461,10 @@ function registerCustomEndpointModels(
     authHeader: true,
     models: allIds.map(id => buildCustomEndpointModelDef(
       id,
-      { supportsImages: initConfig?.customEndpoint?.supportsImages === true },
+      {
+        supportsImages: initConfig?.customEndpoint?.supportsImages === true,
+        reasoning: api === 'openai-responses',
+      },
       customModelOverrides.get(id),
     )),
   });

--- a/packages/server-core/src/sessions/SessionManager.ts
+++ b/packages/server-core/src/sessions/SessionManager.ts
@@ -2812,9 +2812,12 @@ export class SessionManager implements ISessionManager {
             customModels: connection.models?.map(model => {
               if (typeof model === 'string') return model
               const supportsImages = typeof model.supportsImages === 'boolean' ? model.supportsImages : undefined
-              if (model.contextWindow || supportsImages !== undefined) {
+              const hasDisplayName = typeof model.name === 'string' || typeof model.shortName === 'string'
+              if (model.contextWindow || supportsImages !== undefined || hasDisplayName) {
                 return {
                   id: model.id,
+                  ...(typeof model.name === 'string' ? { name: model.name } : {}),
+                  ...(typeof model.shortName === 'string' ? { shortName: model.shortName } : {}),
                   ...(model.contextWindow ? { contextWindow: model.contextWindow } : {}),
                   ...(supportsImages !== undefined ? { supportsImages } : {}),
                 }

--- a/packages/shared/src/agent/backend/internal/drivers/pi.ts
+++ b/packages/shared/src/agent/backend/internal/drivers/pi.ts
@@ -240,9 +240,12 @@ export const piDriver: ProviderDriver = {
       const supportsImages = typeof m.supportsImages === 'boolean'
         ? m.supportsImages
         : undefined;
-      if (m.contextWindow || supportsImages !== undefined) {
+      const hasDisplayName = typeof m.name === 'string' || typeof m.shortName === 'string';
+      if (m.contextWindow || supportsImages !== undefined || hasDisplayName) {
         return {
           id: m.id,
+          ...(typeof m.name === 'string' ? { name: m.name } : {}),
+          ...(typeof m.shortName === 'string' ? { shortName: m.shortName } : {}),
           ...(m.contextWindow ? { contextWindow: m.contextWindow } : {}),
           ...(supportsImages !== undefined ? { supportsImages } : {}),
         };

--- a/packages/shared/src/config/llm-connections.ts
+++ b/packages/shared/src/config/llm-connections.ts
@@ -99,7 +99,7 @@ export type ModelSelectionMode = 'automaticallySyncedFromProvider' | 'userDefine
  * Protocol for custom API endpoints.
  * Determines which streaming adapter the Pi SDK uses for requests.
  */
-export type CustomEndpointApi = 'openai-completions' | 'anthropic-messages';
+export type CustomEndpointApi = 'openai-completions' | 'openai-responses' | 'anthropic-messages';
 
 /**
  * Custom endpoint protocol config.

--- a/packages/shared/src/config/validators.ts
+++ b/packages/shared/src/config/validators.ts
@@ -76,7 +76,7 @@ const LlmAuthTypeSchema = z.enum([
 ]);
 
 const CustomEndpointSchema = z.object({
-  api: z.enum(['openai-completions', 'anthropic-messages']),
+  api: z.enum(['openai-completions', 'openai-responses', 'anthropic-messages']),
   supportsImages: z.boolean().optional(),
 });
 


### PR DESCRIPTION
## Summary

Fixes `pi_compat` custom endpoints that need the OpenAI Responses API path and model reasoning support.

This adds first-class support for `customEndpoint.api: 'openai-responses'` and ensures custom endpoint model metadata is preserved through Pi runtime registration:

- allow `openai-responses` in the shared config schema/type and pi-agent-server runtime protocol
- mark synthetic custom endpoint models as reasoning-capable when the endpoint API is `openai-responses`
- preserve configured per-model `name` / `shortName` along with existing `contextWindow` / `supportsImages`
- keep runtime refresh mapping consistent so display metadata is not dropped after session refresh
- add regression tests for display-name preservation and reasoning-capable Responses custom endpoint models

## Problem

For OpenAI-compatible providers that expose reasoning models via `/v1/responses`, users can configure models such as `gpt-5.5`, but current custom endpoint plumbing has two limitations:

1. Config validation rejects `customEndpoint.api: 'openai-responses'`, even though the unified network interceptor already has an `openai-responses` adapter and Pi API hint resolution for it.
2. Custom endpoint synthetic model definitions are always built with `reasoning: false`, so thinking/reasoning effort is omitted for reasoning-capable Responses models.
3. Per-model display metadata from config (`name`, `shortName`) is dropped before Pi model registration, causing custom/friendly names to be lost in parts of the runtime/model picker flow.

This has been reproducible locally with a `pi_compat` OpenAI-compatible endpoint configured like:

```json
{
  "providerType": "pi_compat",
  "authType": "api_key_with_endpoint",
  "baseUrl": "http://127.0.0.1:8090/v1",
  "customEndpoint": { "api": "openai-responses" },
  "models": [
    {
      "id": "gpt-5.5",
      "name": "GPT 5.5",
      "shortName": "GPT 5.5",
      "supportsImages": true
    }
  ],
  "defaultModel": "gpt-5.5"
}
```

Expected behavior:

- config validates
- requests use `/v1/responses`
- thinking level is passed as reasoning effort for reasoning-capable custom endpoint models
- friendly model names survive runtime registration

## Tests

```bash
bun test packages/pi-agent-server/src/custom-endpoint-models.test.ts
```

Passed locally: 10 tests.

Attempted package typechecks, but this clone does not have dependencies installed, so `tsc` was not available in the local environment.
