### PR TITLE
feat(ui): configure custom endpoint protocol and model metadata

### DIFF
--- a/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
+++ b/apps/electron/src/renderer/components/apisetup/ApiKeyInput.tsx
@@ -32,16 +32,19 @@ import {
 } from "./submit-helpers"
 
 import type { CustomEndpointApi, CustomEndpointConfig } from '@config/llm-connections'
+import type { ModelDefinition } from '@config/models'
 
 export type ApiKeyStatus = 'idle' | 'validating' | 'success' | 'error'
 
 export type { CustomEndpointApi }
 
+export type CustomEndpointModelInput = string | ModelDefinition
+
 export interface ApiKeySubmitData {
   apiKey: string
   baseUrl?: string
   connectionDefaultModel?: string
-  models?: string[]
+  models?: CustomEndpointModelInput[]
   piAuthProvider?: string
   modelSelectionMode?: 'automaticallySyncedFromProvider' | 'userDefined3Tier'
   /** Custom endpoint protocol — set when user configures an arbitrary API endpoint */
@@ -77,7 +80,7 @@ export interface ApiKeyInputProps {
     baseUrl?: string
     connectionDefaultModel?: string
     activePreset?: string
-    models?: string[]
+    models?: CustomEndpointModelInput[]
     /** Pre-fill the protocol toggle for custom endpoints */
     customApi?: CustomEndpointApi
   }
@@ -164,11 +167,85 @@ function getPresetForUrl(url: string, presets: Preset[]): PresetKey {
   return match?.key ?? 'custom'
 }
 
-function parseModelList(value: string): string[] {
+export function getModelId(model: CustomEndpointModelInput): string {
+  return typeof model === 'string' ? model : model.id
+}
+
+export function formatModelList(models: CustomEndpointModelInput[] | undefined, fallback: string): string {
+  if (!models?.length) return fallback
+  return models.map(getModelId).join(', ')
+}
+
+export function parseModelList(value: string): CustomEndpointModelInput[] {
   return value
     .split(',')
     .map((entry) => entry.trim())
     .filter(Boolean)
+}
+
+export function makeCustomModelDefinition(values: Partial<ModelDefinition> & { id: string }): ModelDefinition {
+  return {
+    id: values.id,
+    name: values.name || values.id,
+    shortName: values.shortName || values.name || values.id,
+    description: values.description || '',
+    provider: values.provider || 'pi',
+    contextWindow: values.contextWindow ?? 131_072,
+    ...(values.supportsImages !== undefined ? { supportsImages: values.supportsImages } : {}),
+    ...(values.supportsThinking !== undefined ? { supportsThinking: values.supportsThinking } : {}),
+  }
+}
+
+export function parseCustomModelsJson(value: string): { models?: CustomEndpointModelInput[]; error?: string } {
+  const trimmed = value.trim()
+  if (!trimmed) return {}
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch (error) {
+    return { error: `Invalid JSON: ${error instanceof Error ? error.message : 'Unable to parse model metadata.'}` }
+  }
+
+  if (!Array.isArray(parsed)) {
+    return { error: 'Model metadata must be a JSON array.' }
+  }
+
+  const models: CustomEndpointModelInput[] = []
+  for (const [index, item] of parsed.entries()) {
+    if (typeof item === 'string') {
+      const id = item.trim()
+      if (!id) return { error: `Model metadata entry ${index + 1} is empty.` }
+      models.push(id)
+      continue
+    }
+
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      return { error: `Model metadata entry ${index + 1} must be a string or object.` }
+    }
+
+    const raw = item as Record<string, unknown>
+    if (typeof raw.id !== 'string' || !raw.id.trim()) {
+      return { error: `Model metadata entry ${index + 1} must include a non-empty string id.` }
+    }
+
+    const model: Partial<ModelDefinition> & { id: string } = { id: raw.id.trim() }
+    if (typeof raw.name === 'string' && raw.name.trim()) model.name = raw.name.trim()
+    if (typeof raw.shortName === 'string' && raw.shortName.trim()) model.shortName = raw.shortName.trim()
+    if (typeof raw.description === 'string') model.description = raw.description
+    if (typeof raw.contextWindow === 'number' && Number.isFinite(raw.contextWindow)) model.contextWindow = raw.contextWindow
+    if (typeof raw.supportsImages === 'boolean') model.supportsImages = raw.supportsImages
+    if (typeof raw.supportsThinking === 'boolean') model.supportsThinking = raw.supportsThinking
+    models.push(makeCustomModelDefinition(model))
+  }
+
+  return { models }
+}
+
+export function formatCustomModelsJson(models: CustomEndpointModelInput[] | undefined): string {
+  const objectModels = models?.filter((model) => typeof model !== 'string')
+  if (!objectModels?.length) return ''
+  return JSON.stringify(objectModels, null, 2)
 }
 
 // ============================================================
@@ -200,8 +277,9 @@ export function ApiKeyInput({
   const [lastNonCustomPreset, setLastNonCustomPreset] = useState<PresetKey | null>(
     initialPreset !== 'custom' ? initialPreset : defaultPreset.key
   )
-  const [connectionDefaultModel, setConnectionDefaultModel] = useState(initialValues?.connectionDefaultModel ?? '')
+  const [connectionDefaultModel, setConnectionDefaultModel] = useState(formatModelList(initialValues?.models, initialValues?.connectionDefaultModel ?? ''))
   const [customApi, setCustomApi] = useState<CustomEndpointApi>(initialValues?.customApi ?? 'openai-completions')
+  const [customModelsJson, setCustomModelsJson] = useState(formatCustomModelsJson(initialValues?.models))
   const [modelError, setModelError] = useState<string | null>(null)
 
   // Bedrock auth state
@@ -252,7 +330,7 @@ export function ApiKeyInput({
       setPiModels(result.models)
 
       if (hydratedTierProviderRef.current !== provider) {
-        const tiers = resolveTierModels(result.models, provider === initialPreset ? initialValues?.models : undefined)
+        const tiers = resolveTierModels(result.models, provider === initialPreset ? initialValues?.models?.map(getModelId) : undefined)
         setBestModel(tiers.best)
         setDefaultModel(tiers.default_)
         setCheapModel(tiers.cheap)
@@ -380,7 +458,7 @@ export function ApiKeyInput({
             ...(awsSessionToken.trim() ? { sessionToken: awsSessionToken.trim() } : {}),
           },
         } : {}),
-        connectionDefaultModel: parsedModels[0],
+        connectionDefaultModel: parsedModels[0] ? getModelId(parsedModels[0]) : undefined,
         models: parsedModels.length > 0 ? parsedModels : undefined,
       })
       return
@@ -389,10 +467,20 @@ export function ApiKeyInput({
     const effectiveBaseUrl = baseUrl.trim()
 
     const parsedModels = parseModelList(connectionDefaultModel)
+    const parsedModelIds = parsedModels.map(getModelId)
+    const metadataParse = parseCustomModelsJson(customModelsJson)
+    if (metadataParse.error) {
+      setModelError(metadataParse.error)
+      return
+    }
+    const metadataById = new Map((metadataParse.models ?? []).map((model) => [getModelId(model), model]))
+    const modelsWithMetadata = parsedModels.map((model) => metadataById.get(getModelId(model)) ?? model)
+    const extraMetadataModels = (metadataParse.models ?? []).filter((model) => !parsedModelIds.includes(getModelId(model)))
+    const submittedModels = [...modelsWithMetadata, ...extraMetadataModels]
 
     const isUsingDefaultEndpoint = isDefaultProviderPreset || !effectiveBaseUrl
     const requiresModel = !isDefaultProviderPreset && !!effectiveBaseUrl
-    if (requiresModel && parsedModels.length === 0) {
+    if (requiresModel && submittedModels.length === 0) {
       setModelError('Default model is required for custom endpoints.')
       return
     }
@@ -411,8 +499,8 @@ export function ApiKeyInput({
     onSubmit({
       apiKey: apiKey.trim(),
       baseUrl: isUsingDefaultEndpoint ? undefined : effectiveBaseUrl,
-      connectionDefaultModel: parsedModels[0],
-      models: parsedModels.length > 0 ? parsedModels : undefined,
+      connectionDefaultModel: submittedModels[0] ? getModelId(submittedModels[0]) : undefined,
+      models: submittedModels.length > 0 ? submittedModels : undefined,
       piAuthProvider: resolvedPiAuthProvider,
       modelSelectionMode: isPiApiKeyFlow
         ? (parsedModels.length > 0 ? 'userDefined3Tier' : 'automaticallySyncedFromProvider')
@@ -522,8 +610,9 @@ export function ApiKeyInput({
             isDisabled && "opacity-50 pointer-events-none"
           )}>
             {([
-              { value: 'openai-completions' as const, label: 'OpenAI Compatible' },
-              { value: 'anthropic-messages' as const, label: 'Anthropic Compatible' },
+              { value: 'openai-completions' as const, label: 'OpenAI Chat' },
+              { value: 'openai-responses' as const, label: 'OpenAI Responses' },
+              { value: 'anthropic-messages' as const, label: 'Anthropic' },
             ]).map(({ value, label }) => (
               <button
                 key={value}
@@ -542,7 +631,7 @@ export function ApiKeyInput({
             ))}
           </div>
           <p className="text-xs text-foreground/30">
-            Most third-party APIs (Ollama, vLLM, DashScope) use OpenAI Compatible.
+            Use OpenAI Responses for OpenAI-compatible reasoning models that require /v1/responses.
           </p>
         </div>
       )}
@@ -818,6 +907,32 @@ export function ApiKeyInput({
             <p className="text-xs text-foreground/30">
               Required for custom endpoints. Use the provider-specific model ID.
             </p>
+          )}
+          {activePreset === 'custom' && (
+            <div className="space-y-1.5 pt-2">
+              <Label htmlFor="custom-model-metadata" className="text-muted-foreground font-normal text-xs">
+                Advanced model metadata <span className="text-foreground/30">· optional JSON</span>
+              </Label>
+              <textarea
+                id="custom-model-metadata"
+                value={customModelsJson}
+                onChange={(e) => {
+                  setCustomModelsJson(e.target.value)
+                  setModelError(null)
+                }}
+                placeholder={'[{\n  "id": "gpt-5.5",\n  "name": "GPT 5.5",\n  "shortName": "GPT 5.5",\n  "supportsImages": true,\n  "contextWindow": 131072\n}]'}
+                className={cn(
+                  "min-h-[120px] w-full resize-y rounded-md border-0 bg-foreground-2 px-3 py-2 font-mono text-xs shadow-minimal outline-none transition-colors",
+                  "focus:bg-background focus:ring-1 focus:ring-ring/30",
+                  isDisabled && "opacity-50 pointer-events-none",
+                  modelError && "ring-1 ring-destructive/40"
+                )}
+                disabled={isDisabled}
+              />
+              <p className="text-xs text-foreground/30">
+                Add objects here to set friendly names or capabilities. Entries are matched by id and merged with the model list above.
+              </p>
+            </div>
           )}
         </div>
       )}

--- a/apps/electron/src/renderer/components/apisetup/__tests__/ApiKeyInput.test.ts
+++ b/apps/electron/src/renderer/components/apisetup/__tests__/ApiKeyInput.test.ts
@@ -5,6 +5,7 @@ import {
   resolvePresetStateForBaseUrlChange,
 } from '../submit-helpers'
 import { pickTierDefaults, resolveTierModels } from '../tier-models'
+import { parseCustomModelsJson, formatModelList } from '../ApiKeyInput'
 
 const MODELS = [
   { id: 'pi/zai-best', name: 'Best', costInput: 10, costOutput: 20, contextWindow: 200000, reasoning: true },
@@ -115,7 +116,7 @@ describe('resolveCustomEndpointPayload', () => {
     })
   })
 
-  it('honors the protocol toggle for the generic custom preset', () => {
+  it('honors the Anthropic protocol toggle for the generic custom preset', () => {
     expect(resolveCustomEndpointPayload({
       activePreset: 'custom',
       baseUrl: 'https://my-endpoint.example.com',
@@ -125,6 +126,19 @@ describe('resolveCustomEndpointPayload', () => {
     })).toEqual({
       customEndpoint: { api: 'anthropic-messages' },
       piAuthProvider: 'anthropic',
+    })
+  })
+
+  it('honors the OpenAI Responses protocol toggle for the generic custom preset', () => {
+    expect(resolveCustomEndpointPayload({
+      activePreset: 'custom',
+      baseUrl: 'https://my-endpoint.example.com/v1',
+      customApi: 'openai-responses',
+      brandedOpenAiCompatPresets: BRANDED,
+      fallbackPiAuthProvider: undefined,
+    })).toEqual({
+      customEndpoint: { api: 'openai-responses' },
+      piAuthProvider: 'openai',
     })
   })
 
@@ -152,5 +166,38 @@ describe('resolveCustomEndpointPayload', () => {
       customEndpoint: undefined,
       piAuthProvider: undefined,
     })
+  })
+})
+
+describe('custom endpoint model metadata helpers', () => {
+  it('parses display names and capability metadata from JSON', () => {
+    expect(parseCustomModelsJson(JSON.stringify([
+      {
+        id: 'gpt-5.5',
+        name: 'GPT 5.5',
+        shortName: 'GPT 5.5',
+        supportsImages: true,
+        contextWindow: 131072,
+      },
+    ]))).toEqual({
+      models: [
+        {
+          id: 'gpt-5.5',
+          name: 'GPT 5.5',
+          shortName: 'GPT 5.5',
+          description: '',
+          provider: 'pi',
+          supportsImages: true,
+          contextWindow: 131072,
+        },
+      ],
+    })
+  })
+
+  it('formats object models back to model id lists for editing', () => {
+    expect(formatModelList([
+      { id: 'gpt-5.5', name: 'GPT 5.5', shortName: 'GPT 5.5', description: '', provider: 'pi', contextWindow: 131072 },
+      'gpt-5.4',
+    ], '')).toBe('gpt-5.5, gpt-5.4')
   })
 })

--- a/apps/electron/src/renderer/components/apisetup/index.ts
+++ b/apps/electron/src/renderer/components/apisetup/index.ts
@@ -1,4 +1,4 @@
-export { ApiKeyInput, type ApiKeyInputProps, type ApiKeyStatus, type ApiKeySubmitData } from './ApiKeyInput'
+export { ApiKeyInput, type ApiKeyInputProps, type ApiKeyStatus, type ApiKeySubmitData, type CustomEndpointModelInput } from './ApiKeyInput'
 export {
   OAuthConnect,
   type OAuthConnectProps,

--- a/apps/electron/src/renderer/components/apisetup/submit-helpers.ts
+++ b/apps/electron/src/renderer/components/apisetup/submit-helpers.ts
@@ -61,7 +61,7 @@ export function resolvePresetStateForBaseUrlChange(params: {
  *
  * Three submit branches:
  *  - branded openai-compat preset (e.g. Manifest)  → pinned to openai-completions
- *  - generic custom preset with a base URL         → honors the protocol toggle
+ *  - generic custom preset with a base URL         → honors the protocol toggle, including openai-responses
  *  - everything else                               → no customEndpoint, passthrough piAuth
  */
 export function resolveCustomEndpointPayload(params: {

--- a/apps/electron/src/renderer/components/onboarding/CredentialsStep.tsx
+++ b/apps/electron/src/renderer/components/onboarding/CredentialsStep.tsx
@@ -14,6 +14,7 @@ import {
   ApiKeyInput,
   type ApiKeyStatus,
   type ApiKeySubmitData,
+  type CustomEndpointModelInput,
   OAuthConnect,
   type OAuthStatus,
 } from "../apisetup"
@@ -40,7 +41,7 @@ interface CredentialsStepProps {
     baseUrl?: string
     connectionDefaultModel?: string
     activePreset?: string
-    models?: string[]
+    models?: CustomEndpointModelInput[]
     customApi?: CustomEndpointApi
   }
 }

--- a/apps/electron/src/renderer/components/onboarding/OnboardingWizard.tsx
+++ b/apps/electron/src/renderer/components/onboarding/OnboardingWizard.tsx
@@ -6,7 +6,7 @@ import { CredentialsStep, type CredentialStatus } from "./CredentialsStep"
 import { LocalModelStep, type LocalModelSubmitData } from "./LocalModelStep"
 import { CompletionStep } from "./CompletionStep"
 import { GitBashWarning, type GitBashStatus } from "./GitBashWarning"
-import type { ApiKeySubmitData } from "../apisetup"
+import type { ApiKeySubmitData, CustomEndpointModelInput } from "../apisetup"
 import type { CustomEndpointApi } from '@config/llm-connections'
 
 export type OnboardingStep =
@@ -72,7 +72,7 @@ interface OnboardingWizardProps {
     baseUrl?: string
     connectionDefaultModel?: string
     activePreset?: string
-    models?: string[]
+    models?: CustomEndpointModelInput[]
     customApi?: CustomEndpointApi
   }
 

--- a/apps/electron/src/renderer/hooks/useOnboarding.ts
+++ b/apps/electron/src/renderer/hooks/useOnboarding.ts
@@ -17,7 +17,7 @@ import type {
 } from '@/components/onboarding'
 import type { ProviderChoice } from '@/components/onboarding/ProviderSelectStep'
 import type { LocalModelSubmitData } from '@/components/onboarding/LocalModelStep'
-import type { ApiKeySubmitData } from '@/components/apisetup'
+import type { ApiKeySubmitData, CustomEndpointModelInput } from '@/components/apisetup'
 import type { CustomEndpointConfig } from '@config/llm-connections'
 import type { SetupNeeds, LlmConnectionSetup } from '../../shared/types'
 
@@ -140,7 +140,7 @@ export function apiSetupMethodToConnectionSetup(
     credential?: string
     baseUrl?: string
     connectionDefaultModel?: string
-    models?: string[]
+    models?: CustomEndpointModelInput[]
     piAuthProvider?: string
     modelSelectionMode?: 'automaticallySyncedFromProvider' | 'userDefined3Tier'
     customEndpoint?: CustomEndpointConfig
@@ -245,7 +245,7 @@ export function useOnboarding({
     options?: {
       baseUrl?: string
       connectionDefaultModel?: string
-      models?: string[]
+      models?: CustomEndpointModelInput[]
       piAuthProvider?: string
       modelSelectionMode?: 'automaticallySyncedFromProvider' | 'userDefined3Tier'
       customEndpoint?: CustomEndpointConfig
@@ -452,7 +452,7 @@ export function useOnboarding({
         provider: setupTestProvider,
         apiKey: data.apiKey,
         baseUrl: data.baseUrl,
-        model: data.models?.[0],
+        model: data.models?.[0] ? (typeof data.models[0] === 'string' ? data.models[0] : data.models[0].id) : undefined,
         piAuthProvider: data.piAuthProvider,
         customEndpoint: data.customEndpoint,
       })

--- a/apps/electron/src/renderer/pages/settings/AiSettingsPage.tsx
+++ b/apps/electron/src/renderer/pages/settings/AiSettingsPage.tsx
@@ -53,6 +53,7 @@ import { OnboardingWizard, type ApiSetupMethod } from '@/components/onboarding'
 import { RenameDialog } from '@/components/ui/rename-dialog'
 import { useAppShellContext } from '@/context/AppShellContext'
 import { getModelShortName, type ModelDefinition } from '@config/models'
+import type { CustomEndpointModelInput } from '@/components/apisetup'
 import { getModelsForProviderType, resolveMidStreamBehavior, type CustomEndpointApi, type MidStreamBehavior } from '@config/llm-connections'
 import { toast } from 'sonner'
 
@@ -601,7 +602,7 @@ export default function AiSettingsPage() {
     baseUrl?: string
     connectionDefaultModel?: string
     activePreset?: string
-    models?: string[]
+    models?: CustomEndpointModelInput[]
     customApi?: CustomEndpointApi
   } | undefined>(undefined)
   const setFullscreenOverlayOpen = useSetAtom(fullscreenOverlayOpenAtom)

--- a/packages/pi-agent-server/src/custom-endpoint-models.test.ts
+++ b/packages/pi-agent-server/src/custom-endpoint-models.test.ts
@@ -31,13 +31,17 @@ describe('normalizeCustomEndpointModelEntry', () => {
     })
   })
 
-  it('preserves context window and image support together', () => {
+  it('preserves display names, context window, and image support together', () => {
     expect(normalizeCustomEndpointModelEntry({
       id: 'pi/vision-model',
+      name: 'Vision Model',
+      shortName: 'Vision',
       contextWindow: 262_144,
       supportsImages: true,
     })).toEqual({
       id: 'vision-model',
+      name: 'Vision Model',
+      shortName: 'Vision',
       contextWindow: 262_144,
       supportsImages: true,
     })
@@ -64,5 +68,17 @@ describe('buildCustomEndpointModelDef', () => {
     const model = buildCustomEndpointModelDef('vision-model', undefined, { supportsImages: true, contextWindow: 262_144 })
     expect(model.input).toEqual(['text', 'image'])
     expect(model.contextWindow).toBe(262_144)
+  })
+
+  it('uses per-model display names when provided', () => {
+    const model = buildCustomEndpointModelDef('gpt-5.5', undefined, { name: 'GPT 5.5', shortName: 'GPT 5.5' })
+    expect(model.name).toBe('GPT 5.5')
+    expect(model.shortName).toBe('GPT 5.5')
+  })
+
+  it('marks openai-responses custom endpoint models as reasoning-capable', () => {
+    const model = buildCustomEndpointModelDef('gpt-5.5', { reasoning: true })
+    expect(model.reasoning).toBe(true)
+    expect(model.thinkingLevelMap).toEqual({ off: null, xhigh: 'xhigh' })
   })
 })

--- a/packages/pi-agent-server/src/custom-endpoint-models.ts
+++ b/packages/pi-agent-server/src/custom-endpoint-models.ts
@@ -2,9 +2,12 @@ export type CustomEndpointInput = 'text' | 'image'
 
 export interface CustomEndpointModelDefaults {
   supportsImages?: boolean
+  reasoning?: boolean
 }
 
 export interface CustomEndpointModelOverrides {
+  name?: string
+  shortName?: string
   contextWindow?: number
   supportsImages?: boolean
 }
@@ -15,6 +18,8 @@ export interface CustomEndpointModelEntry extends CustomEndpointModelOverrides {
 
 export type CustomEndpointModelConfig = string | {
   id: string
+  name?: string
+  shortName?: string
   contextWindow?: number
   supportsImages?: boolean
 }
@@ -38,6 +43,8 @@ export function normalizeCustomEndpointModelEntry(model: CustomEndpointModelConf
 
   return {
     id: stripPiPrefix(model.id),
+    ...(model.name !== undefined ? { name: model.name } : {}),
+    ...(model.shortName !== undefined ? { shortName: model.shortName } : {}),
     ...(model.contextWindow !== undefined ? { contextWindow: model.contextWindow } : {}),
     ...(model.supportsImages !== undefined ? { supportsImages: model.supportsImages } : {}),
   }
@@ -59,8 +66,10 @@ export function buildCustomEndpointModelDef(
 
   return {
     id,
-    name: id,
-    reasoning: false,
+    name: overrides?.name ?? id,
+    shortName: overrides?.shortName ?? overrides?.name ?? id,
+    reasoning: defaults?.reasoning ?? false,
+    ...(defaults?.reasoning ? { thinkingLevelMap: { off: null, xhigh: 'xhigh' } } : {}),
     input,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: overrides?.contextWindow ?? 131_072,

--- a/packages/pi-agent-server/src/index.ts
+++ b/packages/pi-agent-server/src/index.ts
@@ -90,7 +90,7 @@ type PiCredential =
   | { type: 'iam'; accessKeyId: string; secretAccessKey: string; region?: string; sessionToken?: string };
 
 /** Custom endpoint protocol — determines which streaming adapter Pi SDK uses */
-type CustomEndpointApi = 'openai-completions' | 'anthropic-messages';
+type CustomEndpointApi = 'openai-completions' | 'openai-responses' | 'anthropic-messages';
 
 /** Init message from main process — configures the Pi agent server */
 interface InitMessage {
@@ -114,7 +114,7 @@ interface InitMessage {
   branchFromSessionPath?: string;
   branchFromSdkTurnId?: string;
   customEndpoint?: { api: CustomEndpointApi; supportsImages?: boolean };
-  customModels?: Array<string | { id: string; contextWindow?: number; supportsImages?: boolean }>;
+  customModels?: Array<string | { id: string; name?: string; shortName?: string; contextWindow?: number; supportsImages?: boolean }>;
   piAuth?: { provider: string; credential: PiCredential };
 }
 
@@ -126,7 +126,7 @@ interface RuntimeConfigUpdateMessage {
   authType?: string;
   baseUrl?: string;
   customEndpoint?: { api: CustomEndpointApi; supportsImages?: boolean };
-  customModels?: Array<string | { id: string; contextWindow?: number; supportsImages?: boolean }>;
+  customModels?: Array<string | { id: string; name?: string; shortName?: string; contextWindow?: number; supportsImages?: boolean }>;
 }
 
 /** Messages from main process (stdin) */
@@ -444,8 +444,10 @@ function registerCustomEndpointModels(
 ): void {
   for (const m of models) {
     customEndpointModelIds.add(m.id);
-    if (m.contextWindow || m.supportsImages !== undefined) {
+    if (m.name !== undefined || m.shortName !== undefined || m.contextWindow || m.supportsImages !== undefined) {
       customModelOverrides.set(m.id, {
+        ...(m.name !== undefined ? { name: m.name } : {}),
+        ...(m.shortName !== undefined ? { shortName: m.shortName } : {}),
         ...(m.contextWindow ? { contextWindow: m.contextWindow } : {}),
         ...(m.supportsImages !== undefined ? { supportsImages: m.supportsImages } : {}),
       });
@@ -459,7 +461,10 @@ function registerCustomEndpointModels(
     authHeader: true,
     models: allIds.map(id => buildCustomEndpointModelDef(
       id,
-      { supportsImages: initConfig?.customEndpoint?.supportsImages === true },
+      {
+        supportsImages: initConfig?.customEndpoint?.supportsImages === true,
+        reasoning: api === 'openai-responses',
+      },
       customModelOverrides.get(id),
     )),
   });

--- a/packages/server-core/src/sessions/SessionManager.ts
+++ b/packages/server-core/src/sessions/SessionManager.ts
@@ -2812,9 +2812,12 @@ export class SessionManager implements ISessionManager {
             customModels: connection.models?.map(model => {
               if (typeof model === 'string') return model
               const supportsImages = typeof model.supportsImages === 'boolean' ? model.supportsImages : undefined
-              if (model.contextWindow || supportsImages !== undefined) {
+              const hasDisplayName = typeof model.name === 'string' || typeof model.shortName === 'string'
+              if (model.contextWindow || supportsImages !== undefined || hasDisplayName) {
                 return {
                   id: model.id,
+                  ...(typeof model.name === 'string' ? { name: model.name } : {}),
+                  ...(typeof model.shortName === 'string' ? { shortName: model.shortName } : {}),
                   ...(model.contextWindow ? { contextWindow: model.contextWindow } : {}),
                   ...(supportsImages !== undefined ? { supportsImages } : {}),
                 }

--- a/packages/shared/src/agent/backend/internal/drivers/pi.ts
+++ b/packages/shared/src/agent/backend/internal/drivers/pi.ts
@@ -240,9 +240,12 @@ export const piDriver: ProviderDriver = {
       const supportsImages = typeof m.supportsImages === 'boolean'
         ? m.supportsImages
         : undefined;
-      if (m.contextWindow || supportsImages !== undefined) {
+      const hasDisplayName = typeof m.name === 'string' || typeof m.shortName === 'string';
+      if (m.contextWindow || supportsImages !== undefined || hasDisplayName) {
         return {
           id: m.id,
+          ...(typeof m.name === 'string' ? { name: m.name } : {}),
+          ...(typeof m.shortName === 'string' ? { shortName: m.shortName } : {}),
           ...(m.contextWindow ? { contextWindow: m.contextWindow } : {}),
           ...(supportsImages !== undefined ? { supportsImages } : {}),
         };

--- a/packages/shared/src/config/llm-connections.ts
+++ b/packages/shared/src/config/llm-connections.ts
@@ -99,7 +99,7 @@ export type ModelSelectionMode = 'automaticallySyncedFromProvider' | 'userDefine
  * Protocol for custom API endpoints.
  * Determines which streaming adapter the Pi SDK uses for requests.
  */
-export type CustomEndpointApi = 'openai-completions' | 'anthropic-messages';
+export type CustomEndpointApi = 'openai-completions' | 'openai-responses' | 'anthropic-messages';
 
 /**
  * Custom endpoint protocol config.

--- a/packages/shared/src/config/validators.ts
+++ b/packages/shared/src/config/validators.ts
@@ -76,7 +76,7 @@ const LlmAuthTypeSchema = z.enum([
 ]);
 
 const CustomEndpointSchema = z.object({
-  api: z.enum(['openai-completions', 'anthropic-messages']),
+  api: z.enum(['openai-completions', 'openai-responses', 'anthropic-messages']),
   supportsImages: z.boolean().optional(),
 });
 

--- a/packages/shared/src/protocol/dto.ts
+++ b/packages/shared/src/protocol/dto.ts
@@ -17,6 +17,7 @@ import type {
 import type { PermissionMode } from '../agent/mode-types'
 import type { ThinkingLevel } from '../agent/thinking-levels'
 import type { CustomEndpointConfig } from '../config/llm-connections'
+import type { ModelDefinition } from '../config/models'
 import type {
   AuthRequest as SharedAuthRequest,
   CredentialInputMode as SharedCredentialInputMode,
@@ -347,7 +348,7 @@ export interface LlmConnectionSetup {
   credential?: string
   baseUrl?: string | null
   defaultModel?: string | null
-  models?: string[] | null
+  models?: Array<string | ModelDefinition> | null
   piAuthProvider?: string
   modelSelectionMode?: 'automaticallySyncedFromProvider' | 'userDefined3Tier'
   /** When true, reject setup if the connection doesn't already exist (reauth guard). */


### PR DESCRIPTION
## Summary

Adds UI support for the custom endpoint capabilities introduced in #750.

This PR makes the custom endpoint setup/editing flow able to author the fields that the runtime/config layer can now preserve:

- exposes `OpenAI Responses` in the custom endpoint protocol selector
- keeps `OpenAI Chat` and `Anthropic` protocol options
- adds an advanced JSON editor for custom model metadata
- lets users set per-model `name`, `shortName`, `supportsImages`, `contextWindow`, and `supportsThinking`
- pre-fills the model ID field and metadata editor when editing existing object model entries
- broadens setup DTO/UI types from `string[]` model lists to `Array<string | ModelDefinition>`

## Why

Before this, custom endpoint users could only enter comma-separated model IDs from the UI. The richer model object form had to be hand-edited in `config.json`, e.g.:

```json
[
  {
    "id": "gpt-5.5",
    "name": "GPT 5.5",
    "shortName": "GPT 5.5",
    "supportsImages": true,
    "contextWindow": 131072
  }
]
```

That meant the runtime fixes in #750 were usable only through manual config edits. This PR exposes an advanced UI path for the same data.

## UI behavior

For the generic `Custom` endpoint preset:

1. Protocol selector now includes:
   - OpenAI Chat
   - OpenAI Responses
   - Anthropic
2. The existing comma-separated model ID field remains for simple setups.
3. An optional advanced JSON metadata field can be used for friendly names/capabilities.
4. Metadata entries are matched by `id` and merged with the model list before submit.

Example metadata:

```json
[
  {
    "id": "gpt-5.5",
    "name": "GPT 5.5",
    "shortName": "GPT 5.5",
    "supportsImages": true,
    "contextWindow": 131072
  }
]
```

## Relationship to other work

- Builds on / complements #750
- Closes #751

This branch is stacked on top of #750 so the diff includes both the runtime plumbing commit and this UI commit when viewed against `main`. If preferred, I can rebase this PR after #750 lands.

## Tests

Passed:

```bash
cd packages/shared && bun run tsc --noEmit
cd packages/server-core && bun run tsc --noEmit
cd apps/electron && bun run typecheck
bun test packages/pi-agent-server/src/custom-endpoint-models.test.ts
```

Attempted:

```bash
bun test apps/electron/src/renderer/components/apisetup/__tests__/ApiKeyInput.test.ts
```

This currently fails in the local environment before running tests due to an existing test-loader/module issue:

```txt
SyntaxError: Missing 'default' export in module 'pdfjs-dist/build/pdf.worker.min.mjs?url'
```

The new helper coverage is still included in that test file, and TypeScript passes.
