### PR TITLE
fix(pi-agent): resolve model contextWindow from Pi SDK catalog for non-Claude models

### DIFF
--- a/packages/shared/src/agent/claude-agent.ts
+++ b/packages/shared/src/agent/claude-agent.ts
@@ -215,7 +215,7 @@ export interface ClaudeAgentConfig {
   mcpPool?: McpClientPool;
   /** LLM connection slug for credential lookup in postInit(). */
   connectionSlug?: string;
-  /** Enable 1M context window for Opus 4.7. Default: true. Set false to use 200K and conserve usage limits. */
+  /** Toggle 1M context for Claude Opus 4.7. Other models use their native context automatically. Default: true. Set false to cap at 200K and conserve usage limits. */
   enable1MContext?: boolean;
 }
 

--- a/packages/shared/src/agent/pi-agent.ts
+++ b/packages/shared/src/agent/pi-agent.ts
@@ -33,6 +33,7 @@ import type { ThinkingLevel } from './thinking-levels.ts';
 
 // Import models from centralized registry
 import { getModelById } from '../config/models.ts';
+import { getAllPiModels } from '../config/models-pi.ts';
 
 // BaseAgent provides common functionality
 import { BaseAgent } from './base-agent.ts';
@@ -281,14 +282,23 @@ export class PiAgent extends BaseAgent {
   constructor(config: BackendConfig) {
     const resolvedModel = config.model || '';
     const modelDef = getModelById(resolvedModel);
-    super(config, resolvedModel, modelDef?.contextWindow);
+    // Fall back to Pi SDK model catalog for non-Claude models (DeepSeek, Gemini, etc.)
+    // that are not in the static MODEL_REGISTRY.
+    const contextWindow = modelDef?.contextWindow
+      ?? (() => {
+        try {
+          const bareId = resolvedModel.startsWith('pi/') ? resolvedModel.slice(3) : resolvedModel;
+          return getAllPiModels().find(m => m.id === `pi/${bareId}` || m.id === bareId)?.contextWindow;
+        } catch { return undefined; }
+      })();
+    super(config, resolvedModel, contextWindow);
 
     this._supportsBranching = true;
 
     this.piSessionId = config.session?.sdkSessionId || null;
     this.adapter = new PiEventAdapter();
-    if (modelDef?.contextWindow) {
-      this.adapter.setContextWindow(modelDef.contextWindow);
+    if (contextWindow) {
+      this.adapter.setContextWindow(contextWindow);
     }
     if (config.miniModel) {
       this.adapter.setMiniModel(config.miniModel);

--- a/packages/shared/src/i18n/locales/de.json
+++ b/packages/shared/src/i18n/locales/de.json
@@ -736,7 +736,7 @@
   "settings.ai.description": "Modell, Denken, Verbindungen",
   "settings.ai.enterConnectionName": "Verbindungsname eingeben...",
   "settings.ai.extendedContext": "Erweiterter Kontext (1M)",
-  "settings.ai.extendedContextDesc": "1M-Token-Kontextfenster für Opus 4.7 verwenden. Deaktivieren, um 200K zu nutzen und Nutzungslimits zu schonen.",
+  "settings.ai.extendedContextDesc": "1M-Token-Kontextfenster aktivieren. Bei Deaktivierung auf 200K begrenzt.",
   "settings.ai.extendedPromptCache": "Erweiterter Prompt-Cache (1 Stunde)",
   "settings.ai.extendedPromptCacheDesc": "Prompts 1 Stunde statt 5 Minuten zwischenspeichern. Gilt nur für Claude-Modelle über die Anthropic API. Reduziert Kosten bei langen Sitzungen, erhöht jedoch die Cache-Schreibkosten.",
   "settings.ai.inheritFromApp": "Von App-Einstellungen übernehmen",

--- a/packages/shared/src/i18n/locales/en.json
+++ b/packages/shared/src/i18n/locales/en.json
@@ -736,7 +736,7 @@
   "settings.ai.description": "Model, thinking, connections",
   "settings.ai.enterConnectionName": "Enter connection name...",
   "settings.ai.extendedContext": "Extended Context (1M)",
-  "settings.ai.extendedContextDesc": "Use 1M token context window for Opus 4.7. Disable to use 200K and conserve usage limits.",
+  "settings.ai.extendedContextDesc": "Enable 1M token context window. When disabled, context is capped at 200K.",
   "settings.ai.extendedPromptCache": "Extended prompt cache (1 hour)",
   "settings.ai.extendedPromptCacheDesc": "Cache prompts for 1 hour instead of 5 minutes. Only applies to Claude models via Anthropic API. Reduces cost for long sessions but increases cache write cost.",
   "settings.ai.inheritFromApp": "Inherit from app settings",

--- a/packages/shared/src/i18n/locales/es.json
+++ b/packages/shared/src/i18n/locales/es.json
@@ -736,7 +736,7 @@
   "settings.ai.description": "Modelo, razonamiento, conexiones",
   "settings.ai.enterConnectionName": "Introduce el nombre de la conexión...",
   "settings.ai.extendedContext": "Contexto extendido (1M)",
-  "settings.ai.extendedContextDesc": "Usa la ventana de contexto de 1M tokens para Opus 4.7. Desactívalo para usar 200K y conservar los límites de uso.",
+  "settings.ai.extendedContextDesc": "Activa la ventana de contexto de 1M tokens. Al desactivar, se limita a 200K.",
   "settings.ai.extendedPromptCache": "Caché de prompts extendida (1 hora)",
   "settings.ai.extendedPromptCacheDesc": "Guarda en caché los prompts durante 1 hora en lugar de 5 minutos. Solo aplica a modelos Claude a través de Anthropic API. Reduce el coste en sesiones largas, pero aumenta el coste de escritura en caché.",
   "settings.ai.inheritFromApp": "Heredar de la configuración de la app",

--- a/packages/shared/src/i18n/locales/hu.json
+++ b/packages/shared/src/i18n/locales/hu.json
@@ -736,7 +736,7 @@
   "settings.ai.description": "Modell, gondolkodás, kapcsolatok",
   "settings.ai.enterConnectionName": "Add meg a kapcsolat nevét...",
   "settings.ai.extendedContext": "Kiterjesztett kontextus (1M)",
-  "settings.ai.extendedContextDesc": "1M tokenes kontextusablak használata az Opus 4.7-hez. Letiltással 200K-ra vált, és megőrzi a használati korlátokat.",
+  "settings.ai.extendedContextDesc": "1M tokenes kontextusablak engedélyezése. Letiltva 200K-ra korlátozódik.",
   "settings.ai.extendedPromptCache": "Kiterjesztett prompt gyorsítótár (1 óra)",
   "settings.ai.extendedPromptCacheDesc": "Promptok gyorsítótárazása 1 óráig 5 perc helyett. Csak az Anthropic API-n keresztüli Claude modellekre vonatkozik. Csökkenti a hosszú munkamenetek költségét, de növeli a gyorsítótár-írás költségét.",
   "settings.ai.inheritFromApp": "Öröklés az alkalmazás beállításaiból",

--- a/packages/shared/src/i18n/locales/ja.json
+++ b/packages/shared/src/i18n/locales/ja.json
@@ -736,7 +736,7 @@
   "settings.ai.description": "モデル、思考、接続",
   "settings.ai.enterConnectionName": "接続名を入力...",
   "settings.ai.extendedContext": "拡張コンテキスト (1M)",
-  "settings.ai.extendedContextDesc": "Opus 4.7に1Mトークンのコンテキストウィンドウを使用します。無効にすると200Kを使用し、使用制限を節約できます。",
+  "settings.ai.extendedContextDesc": "1Mトークンのコンテキストウィンドウを有効にします。無効にすると200Kに制限されます。",
   "settings.ai.extendedPromptCache": "拡張プロンプトキャッシュ (1時間)",
   "settings.ai.extendedPromptCacheDesc": "プロンプトを5分ではなく1時間キャッシュします。Anthropic APIを経由するClaudeモデルにのみ適用されます。長いセッションのコストを削減しますが、キャッシュ書き込みコストが増加します。",
   "settings.ai.inheritFromApp": "アプリ設定から継承",

--- a/packages/shared/src/i18n/locales/pl.json
+++ b/packages/shared/src/i18n/locales/pl.json
@@ -736,7 +736,7 @@
   "settings.ai.description": "Model, myślenie, połączenia",
   "settings.ai.enterConnectionName": "Wprowadź nazwę połączenia...",
   "settings.ai.extendedContext": "Rozszerzony kontekst (1M)",
-  "settings.ai.extendedContextDesc": "Używaj okna kontekstu 1M tokenów dla Opus 4.7. Wyłącz, aby używać 200K i oszczędzać limity użycia.",
+  "settings.ai.extendedContextDesc": "Włącz okno kontekstu 1M tokenów. Po wyłączeniu ograniczone do 200K.",
   "settings.ai.extendedPromptCache": "Rozszerzony cache promptów (1 godzina)",
   "settings.ai.extendedPromptCacheDesc": "Buforuj prompty przez 1 godzinę zamiast 5 minut. Dotyczy tylko modeli Claude przez Anthropic API. Obniża koszty długich sesji, ale zwiększa koszt zapisu do cache.",
   "settings.ai.inheritFromApp": "Dziedzicz z ustawień aplikacji",

--- a/packages/shared/src/i18n/locales/zh-Hans.json
+++ b/packages/shared/src/i18n/locales/zh-Hans.json
@@ -736,7 +736,7 @@
   "settings.ai.description": "模型、思考、连接",
   "settings.ai.enterConnectionName": "输入连接名称...",
   "settings.ai.extendedContext": "扩展上下文 (1M)",
-  "settings.ai.extendedContextDesc": "为 Opus 4.7 使用 1M token 上下文窗口。禁用则使用 200K 以节省用量配额。",
+  "settings.ai.extendedContextDesc": "启用 1M token 上下文窗口。禁用后限制为 200K。",
   "settings.ai.extendedPromptCache": "扩展提示缓存 (1 小时)",
   "settings.ai.extendedPromptCacheDesc": "将提示缓存从 5 分钟延长到 1 小时。仅适用于通过 Anthropic API 的 Claude 模型。可降低长会话成本，但会增加缓存写入成本。",
   "settings.ai.inheritFromApp": "继承应用设置",


### PR DESCRIPTION
## Summary

Fixes an issue where Pi SDK models (DeepSeek, Gemini, etc.) never had their native context window surfaced to the agent adapter, causing usage tracking and context overflow detection to operate with `undefined` contextWindow.

### Root Cause

`pi-agent.ts` constructor calls `getModelById()` which only searches the static `MODEL_REGISTRY` (Claude models only). Pi SDK models live in a separate registry and are never found, so `contextWindow` stays `undefined`.

### Fix

When `getModelById()` returns `undefined`, fall back to `getAllPiModels()` from the Pi SDK model catalog. The Pi SDK already has correct `contextWindow` values (1,000,000 for DeepSeek V4 Pro/Flash since v0.72.1) — they just weren't being surfaced.

### Changes

| File | Change |
|------|--------|
| `packages/shared/src/agent/pi-agent.ts` | Add Pi SDK model lookup fallback for `contextWindow` (+13/-3) |
| `packages/shared/src/agent/claude-agent.ts` | Update JSDoc comment |
| `packages/shared/src/i18n/locales/*.json` | Simplify 1M context description across 7 locales |

### Before / After (UI)

| | Before | After |
|------|--------|-------|
| English | *"Use 1M token context window for Opus 4.7. Disable to use 200K..."* | *"Enable 1M token context window. When disabled, context is capped at 200K."* |
| Chinese | *"为 Opus 4.7 使用 1M token 上下文窗口..."* | *"启用 1M token 上下文窗口。禁用后限制为 200K。"* |

Co-Authored-By: Craft Agent \u003cagents-noreply@craft.do\u003e