### PR TITLE
fix(input): resolve Chinese IME / English auto-capitalise conflict

### DIFF
--- a/apps/electron/resources/release-notes/next.md
+++ b/apps/electron/resources/release-notes/next.md
@@ -8,4 +8,6 @@ This file accumulates release notes for the next unreleased version. PRs that ad
 
 ## Bug Fixes
 
+- Fixed Chinese IME first-character input conflicting with English auto-capitalisation. On some macOS/Electron builds the native `input` event fires before `compositionstart`, causing the auto-capitalise logic to capitalise the first pinyin letter and corrupt the IME composition session.
+
 ## Breaking Changes

--- a/apps/electron/src/renderer/components/ui/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ui/rich-text-input.tsx
@@ -627,6 +627,23 @@ export const RichTextInput = React.forwardRef<RichTextInputHandle, RichTextInput
       handleInput()
     }, [handleInput])
 
+    // Wrapper for the div's onInput event. Adds a second composition guard that
+    // checks the native event's isComposing flag in addition to the ref. This
+    // handles the edge-case on some macOS/Electron builds where the native
+    // `input` event fires *before* `compositionstart`, leaving
+    // isComposing.current=false even though composition is already in progress.
+    // Without this check the auto-capitalise logic in FreeFormInput can fire on
+    // the first pinyin letter (a Latin character) and corrupt the IME session.
+    // (handleCompositionEnd calls handleInput() directly, bypassing this wrapper
+    // intentionally — at that point isComposing.current is already false.)
+    const handleInputEvent = React.useCallback(
+      (e: React.FormEvent<HTMLDivElement>) => {
+        if ((e.nativeEvent as InputEvent).isComposing) return
+        handleInput()
+      },
+      [handleInput]
+    )
+
     const handleKeyDownInternal = React.useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
       if (isEscapeDuringComposition(e, isComposing.current)) {
         e.stopPropagation()
@@ -685,6 +702,12 @@ export const RichTextInput = React.forwardRef<RichTextInputHandle, RichTextInput
       if (!divRef.current) return
       if (isInternalUpdate.current) return
       if (lastValueRef.current === safeValue) return
+      // Don't overwrite the div while IME composition is active. The div
+      // content during composition belongs to the browser/IME; replacing
+      // innerHTML would destroy the composition session. When composition
+      // ends, handleCompositionEnd → handleInput() will sync the final
+      // composed value back into React state through the normal onChange path.
+      if (isComposing.current) return
 
       // External value change - update content
       lastValueRef.current = safeValue
@@ -789,7 +812,7 @@ export const RichTextInput = React.forwardRef<RichTextInputHandle, RichTextInput
           )}
           // Use inline style for line-height to override text-sm's built-in line-height
           style={{ lineHeight: 1.25 }}
-          onInput={handleInput}
+          onInput={handleInputEvent}
           onKeyDown={handleKeyDownInternal}
           onFocus={handleFocus}
           onBlur={handleBlur}


### PR DESCRIPTION
## Problem

On some macOS/Electron builds, the native `input` event fires **before** `compositionstart` for the first IME keystroke. This created a timing window where:

1. `handleInput` ran with `isComposing.current = false` (the ref hadn't been set yet)
2. The first pinyin letter (a Latin character like `n`, `w`, etc.) was passed to `handleRichInput`
3. The **auto-capitalise** logic fired and updated React state (e.g. `'n' → 'N'`)
4. That state change triggered the value-sync `useEffect`, which overwrote `divRef.current.innerHTML` **while IME composition was active**, destroying the composition session

Result: users saw the pinyin letter capitalised and the IME composition broken — intermittent because it depends on the exact macOS/Electron/IME timing.

## Root cause (file + line)

`apps/electron/src/renderer/components/ui/rich-text-input.tsx` — two missing guards:
- **`handleInput` (L593)** — only checked `isComposing.current` ref, not `event.nativeEvent.isComposing`
- **value-sync `useEffect` (L684)** — no composition check; could overwrite div content mid-composition

## Fix

**Defence-in-depth, two changes, one file:**

### 1. `handleInputEvent` wrapper (replaces bare `onInput={handleInput}`)
Checks `e.nativeEvent.isComposing` in addition to the existing ref guard, closing the race at the source.

### 2. `useEffect` composition guard
Adds `if (isComposing.current) return` so that auto-capitalise React-state updates can never overwrite the div while the browser owns the composition.

The dual-check mirrors `isEscapeDuringComposition` (L37-42) which already uses both the ref and event flags.

## Regression check

- Chinese Pinyin (Simplified/Traditional) IME in empty input → first character no longer corrupted/capitalised
- English first-letter auto-capitalise still works (unchanged path)
- `handleCompositionEnd → handleInput()` direct call path (no event arg) unaffected