### PR TITLE
fix(input): hide placeholder overlay and restore text visibility during IME composition

### DIFF
--- a/apps/electron/resources/release-notes/next.md
+++ b/apps/electron/resources/release-notes/next.md
@@ -8,4 +8,6 @@ This file accumulates release notes for the next unreleased version. PRs that ad
 
 ## Bug Fixes
 
+- Fixed IME composition text being invisible and placeholder hints overlaying the input during the entire composition phase. `showPlaceholder` was computed from React state (`safeValue`) which stays `''` while `onChange` is blocked during composition, making the preedit text transparent and keeping the rotating placeholder overlay visible.
+
 ## Breaking Changes

--- a/apps/electron/src/renderer/components/ui/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ui/rich-text-input.tsx
@@ -523,6 +523,10 @@ export const RichTextInput = React.forwardRef<RichTextInputHandle, RichTextInput
     const divRef = React.useRef<HTMLDivElement>(null)
     const [isFocused, setIsFocused] = React.useState(false)
     const isComposing = React.useRef(false)
+    // Mirrors isComposing.current but as React state so that toggling it triggers
+    // a re-render. Used only for showPlaceholder to hide the overlay and remove
+    // text-transparent during IME composition (refs don't cause re-renders).
+    const [isComposingState, setIsComposingState] = React.useState(false)
     const lastValueRef = React.useRef(safeValue)
     const cursorPositionRef = React.useRef(0)
     const lastMentionSignatureRef = React.useRef('')
@@ -620,10 +624,12 @@ export const RichTextInput = React.forwardRef<RichTextInputHandle, RichTextInput
     // Handle composition (IME)
     const handleCompositionStart = React.useCallback(() => {
       isComposing.current = true
+      setIsComposingState(true)
     }, [])
 
     const handleCompositionEnd = React.useCallback(() => {
       isComposing.current = false
+      setIsComposingState(false)
       handleInput()
     }, [handleInput])
 
@@ -757,8 +763,12 @@ export const RichTextInput = React.forwardRef<RichTextInputHandle, RichTextInput
       return () => document.removeEventListener('selectionchange', handleSelectionChange)
     }, [])
 
-    // Show placeholder when input is empty (regardless of focus state)
-    const showPlaceholder = !safeValue
+    // Show placeholder when input is empty AND not composing. During IME
+    // composition onChange is blocked, so safeValue stays '' the entire time;
+    // without the isComposingState guard the div would get text-transparent
+    // (making composition text invisible) and RotatingPlaceholder would overlay
+    // the active preedit text for the whole composition duration.
+    const showPlaceholder = !safeValue && !isComposingState
 
     // Normalize placeholder to array for RotatingPlaceholder
     const placeholderArray = React.useMemo(() => {


### PR DESCRIPTION
## Problem

During IME composition (e.g. Chinese Pinyin), users saw two symptoms simultaneously:

1. **Composition (preedit) text was invisible** — the `text-transparent` CSS class was applied to the contenteditable div, making the pinyin text the user was typing transparent.
2. **Rotating placeholder hints stayed visible on top** — the `RotatingPlaceholder` overlay (`absolute inset-0`) remained rendered, showing animated hint text that appeared to "pre-fill" the input and covered the invisible composition text.

## Root cause

`rich-text-input.tsx:784`

```ts
const showPlaceholder = !safeValue   // ← computed from React state only
```

`safeValue = coerceInputText(value)` is derived from the React `value` prop. During IME composition, `onChange` is intentionally blocked by the `isComposing.current` guard in `handleInput`, so `safeValue` stays `''` for the **entire composition duration**. This makes `showPlaceholder = true` the whole time, which:
- Applies `text-transparent caret-foreground` to the div → preedit text invisible
- Keeps `<RotatingPlaceholder className="absolute inset-0">" mounted → hints overlay active

## Fix

Add a React state flag `isComposingState` that mirrors the existing `isComposing` ref but triggers re-renders. Guard `showPlaceholder` with it:

```ts
const [isComposingState, setIsComposingState] = React.useState(false)

// compositionstart / compositionend toggle it
const showPlaceholder = !safeValue && !isComposingState
```

- `compositionstart` → `setIsComposingState(true)` → re-render removes `text-transparent` and unmounts `RotatingPlaceholder` → preedit text immediately visible
- `compositionend` → `setIsComposingState(false)` → normal placeholder logic resumes (by this point `onChange` has committed the composed value, so `safeValue` is already non-empty)

The existing `isComposing` ref is kept for all synchronous guards (`handleInput`, `useEffect`). The new state is used **only** for the render-time `showPlaceholder` computation.