### PR TITLE
fix: include custom MCP headers in GET_MCP_TOOLS handler

### DIFF
--- a/packages/server-core/src/handlers/rpc/sources.ts
+++ b/packages/server-core/src/handlers/rpc/sources.ts
@@ -200,10 +200,14 @@ export function registerSourcesHandlers(server: RpcServer, deps: HandlerDeps): v
         }
 
         log.info(`Fetching MCP tools from ${source.config.mcp.url}`)
+        const headers: Record<string, string> = {
+          ...(source.config.mcp.headers || {}),
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        }
         client = new CraftMcpClient({
           transport: 'http',
           url: source.config.mcp.url,
-          headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
+          headers: Object.keys(headers).length > 0 ? headers : undefined,
         })
       }
 


### PR DESCRIPTION
## Summary

- Fixes a bug where the `GET_MCP_TOOLS` RPC handler was not forwarding static custom headers from MCP source config when displaying tool lists in the UI
- This caused MCP sources using `authType: "none"` with custom auth headers (e.g., `X-Otto-Token`) to show "Authentication failed" in the tools panel, even though the connection test passed and actual tool calls worked fine

## Root Cause

The `GET_MCP_TOOLS` handler in `sources.ts` only set `headers` to `{ Authorization: Bearer <token> }` for bearer/oauth sources, and passed `undefined` for sources with `authType: "none"`. It never included `source.config.mcp.headers` — the static custom headers defined in the source config.

Other code paths (`buildMcpServer`, `source_test`, `validateMcpConnection`) correctly merge static headers with the Authorization header.

## Fix

Merge static headers from `source.config.mcp.headers` with the Authorization header (if present) before passing to `CraftMcpClient`, matching the behavior of all other MCP connection paths.

## Test Plan

- [ ] Create an MCP source with `authType: "none"` and a custom header (e.g., `X-Otto-Token`)
- [ ] Verify the source connects successfully via `source_test`
- [ ] Verify the tools list in the UI loads correctly instead of showing "Authentication failed"
- [ ] Verify bearer/oauth MCP sources still work correctly
- [ ] Verify MCP tools can be called successfully in conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)