### PR TITLE
fix(electron): restore spellcheck context menu

### DIFF
--- a/apps/electron/resources/release-notes/next.md
+++ b/apps/electron/resources/release-notes/next.md
@@ -8,4 +8,6 @@ This file accumulates release notes for the next unreleased version. PRs that ad
 
 ## Bug Fixes
 
+- Fix packaged desktop spellcheck context menus so misspelled chat text now shows spelling suggestions and dictionary actions on right-click. ([#476](https://github.com/craft-ai-agents/craft-agents-oss/issues/476))
+
 ## Breaking Changes

--- a/apps/electron/src/main/__tests__/window-manager-spellcheck.isolated.ts
+++ b/apps/electron/src/main/__tests__/window-manager-spellcheck.isolated.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+const createdOptions: any[] = []
+const createdWindows: any[] = []
+let lastMenuTemplate: any[] | null = null
+let lastPopupArgs: any = null
+const addWordToSpellCheckerDictionary = mock((_word: string) => {})
+const replaceMisspelling = mock((_word: string) => {})
+const cut = mock(() => {})
+const copy = mock(() => {})
+const paste = mock(() => {})
+const selectAll = mock(() => {})
+
+function createMockWebContents() {
+  const listeners: Record<string, Function[]> = {}
+
+  return {
+    id: createdWindows.length + 1,
+    mainFrame: {},
+    session: {
+      addWordToSpellCheckerDictionary,
+    },
+    replaceMisspelling,
+    cut,
+    copy,
+    paste,
+    selectAll,
+    setWindowOpenHandler: mock((_handler: unknown) => {}),
+    on: (event: string, cb: Function) => {
+      if (!listeners[event]) listeners[event] = []
+      listeners[event].push(cb)
+    },
+    send: mock((_channel: string, ..._args: unknown[]) => {}),
+    isDestroyed: mock(() => false),
+    _listeners: listeners,
+  }
+}
+
+function createMockWindow(options?: any) {
+  const listeners: Record<string, Function[]> = {}
+  const win = {
+    webContents: createMockWebContents(),
+    on: (event: string, cb: Function) => {
+      if (!listeners[event]) listeners[event] = []
+      listeners[event].push(cb)
+    },
+    once: (event: string, cb: Function) => {
+      if (!listeners[event]) listeners[event] = []
+      listeners[event].push(cb)
+    },
+    loadFile: mock(async (_path: string, _options?: unknown) => {}),
+    loadURL: mock(async (_url: string) => {}),
+    show: mock(() => {}),
+    isDestroyed: mock(() => false),
+    isMinimized: mock(() => false),
+    restore: mock(() => {}),
+    focus: mock(() => {}),
+    destroy: mock(() => {}),
+    setWindowButtonVisibility: mock((_visible: boolean) => {}),
+    _listeners: listeners,
+    _options: options,
+  }
+
+  createdWindows.push(win)
+  return win
+}
+
+mock.module('electron', () => ({
+  BrowserWindow: class MockBrowserWindow {
+    constructor(options?: any) {
+      createdOptions.push(options)
+      Object.assign(this, createMockWindow(options))
+    }
+  },
+  Menu: {
+    buildFromTemplate: mock((template: any[]) => {
+      lastMenuTemplate = template
+      return {
+        popup: mock((args?: unknown) => {
+          lastPopupArgs = args
+        }),
+      }
+    }),
+  },
+  nativeTheme: {
+    shouldUseDarkColors: false,
+    on: mock((_event: string, _cb: Function) => {}),
+    removeListener: mock((_event: string, _cb: Function) => {}),
+  },
+  shell: {
+    openExternal: mock(async (_url: string) => {}),
+  },
+}))
+
+describe('WindowManager spellcheck context menu', () => {
+  beforeEach(() => {
+    createdOptions.length = 0
+    createdWindows.length = 0
+    lastMenuTemplate = null
+    lastPopupArgs = null
+    addWordToSpellCheckerDictionary.mockClear()
+    replaceMisspelling.mockClear()
+    cut.mockClear()
+    copy.mockClear()
+    paste.mockClear()
+    selectAll.mockClear()
+    delete process.env.VITE_DEV_SERVER_URL
+  })
+
+  it('enables Electron spellcheck for app windows', async () => {
+    const { WindowManager } = await import('../window-manager')
+
+    new WindowManager().createWindow({ workspaceId: 'ws-1' })
+
+    expect(createdOptions[0]?.webPreferences?.spellcheck).toBe(true)
+  })
+
+  it('shows a focused spelling and edit menu without dev-only items', async () => {
+    const { WindowManager } = await import('../window-manager')
+
+    new WindowManager().createWindow({ workspaceId: 'ws-1' })
+    const win = createdWindows[0]
+    const contextMenuHandler = win.webContents._listeners['context-menu'][0]
+
+    contextMenuHandler({}, {
+      x: 12,
+      y: 24,
+      misspelledWord: 'teh',
+      dictionarySuggestions: ['the', 'tech'],
+      editFlags: {
+        canCut: true,
+        canCopy: true,
+        canPaste: false,
+        canSelectAll: true,
+      },
+    })
+
+    expect(lastMenuTemplate?.some(item => item.label === 'Inspect Element')).toBe(false)
+    expect(lastMenuTemplate?.some(item => item.label === 'No spelling suggestions')).toBe(false)
+    expect(lastMenuTemplate?.some(item => item.label === 'Paste')).toBe(false)
+    expect(lastMenuTemplate?.map(item => item.label ?? item.type)).toEqual([
+      'the',
+      'tech',
+      'separator',
+      'Learn Spelling',
+      'separator',
+      'Cut',
+      'Copy',
+      'Select All',
+    ])
+    expect(lastPopupArgs).toEqual({ window: win })
+
+    const suggestionItem = lastMenuTemplate?.find(item => item.label === 'the')
+    suggestionItem.click()
+    expect(replaceMisspelling).toHaveBeenCalledWith('the')
+
+    const dictionaryItem = lastMenuTemplate?.find(item => item.label === 'Learn Spelling')
+    dictionaryItem.click()
+    expect(addWordToSpellCheckerDictionary).toHaveBeenCalledWith('teh')
+
+    const copyItem = lastMenuTemplate?.find(item => item.label === 'Copy')
+    copyItem.click()
+    expect(copy).toHaveBeenCalled()
+  })
+
+  it('omits spelling-only rows when no misspelling is present', async () => {
+    const { WindowManager } = await import('../window-manager')
+
+    new WindowManager().createWindow({ workspaceId: 'ws-1' })
+    const win = createdWindows[0]
+    const contextMenuHandler = win.webContents._listeners['context-menu'][0]
+
+    contextMenuHandler({}, {
+      x: 12,
+      y: 24,
+      misspelledWord: '',
+      dictionarySuggestions: [],
+      editFlags: {
+        canCut: false,
+        canCopy: true,
+        canPaste: true,
+        canSelectAll: true,
+      },
+    })
+
+    expect(lastMenuTemplate?.map(item => item.label ?? item.type)).toEqual([
+      'Copy',
+      'Paste',
+      'Select All',
+    ])
+  })
+})

--- a/apps/electron/src/main/window-manager.ts
+++ b/apps/electron/src/main/window-manager.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, shell, nativeTheme, Menu, app } from 'electron'
+import { BrowserWindow, shell, nativeTheme, Menu } from 'electron'
 import { windowLog } from './logger'
 import { join } from 'path'
 import { existsSync } from 'fs'
@@ -31,6 +31,51 @@ function getWindowsBackgroundMaterial(): 'mica' | 'acrylic' | undefined {
 
   windowLog.info('Older Windows detected (build ' + buildNumber + '), no transparency')
   return undefined
+}
+
+function buildContextMenuTemplate(window: BrowserWindow, params: Electron.ContextMenuParams): Electron.MenuItemConstructorOptions[] {
+  const template: Electron.MenuItemConstructorOptions[] = []
+  const misspelledWord = params.misspelledWord?.trim()
+
+  if (misspelledWord) {
+    for (const suggestion of params.dictionarySuggestions ?? []) {
+      template.push({
+        label: suggestion,
+        click: () => window.webContents.replaceMisspelling(suggestion),
+      })
+    }
+
+    if (template.length > 0) {
+      template.push({ type: 'separator' })
+    }
+
+    template.push({
+      label: 'Learn Spelling',
+      click: () => window.webContents.session.addWordToSpellCheckerDictionary(misspelledWord),
+    })
+  }
+
+  const editItems: Electron.MenuItemConstructorOptions[] = []
+  if (params.editFlags.canCut) {
+    editItems.push({ label: 'Cut', accelerator: 'CommandOrControl+X', click: () => window.webContents.cut() })
+  }
+  if (params.editFlags.canCopy) {
+    editItems.push({ label: 'Copy', accelerator: 'CommandOrControl+C', click: () => window.webContents.copy() })
+  }
+  if (params.editFlags.canPaste) {
+    editItems.push({ label: 'Paste', accelerator: 'CommandOrControl+V', click: () => window.webContents.paste() })
+  }
+  if (params.editFlags.canSelectAll) {
+    editItems.push({ label: 'Select All', accelerator: 'CommandOrControl+A', click: () => window.webContents.selectAll() })
+  }
+
+  if (template.length > 0 && editItems.length > 0) {
+    template.push({ type: 'separator' })
+  }
+
+  template.push(...editItems)
+
+  return template
 }
 
 
@@ -167,7 +212,8 @@ export class WindowManager {
         contextIsolation: true,
         nodeIntegration: false,
         sandbox: false,
-        webviewTag: false // Browser integration uses WebContentsView, not <webview>
+        webviewTag: false, // Browser integration uses WebContentsView, not <webview>
+        spellcheck: true,
       }
     })
 
@@ -194,18 +240,10 @@ export class WindowManager {
       }
     })
 
-    // Enable right-click context menu in development
-    if (!app.isPackaged) {
-      window.webContents.on('context-menu', (_event, params) => {
-        Menu.buildFromTemplate([
-          { label: 'Inspect Element', click: () => window.webContents.inspectElement(params.x, params.y) },
-          { type: 'separator' },
-          { label: 'Cut', role: 'cut', enabled: params.editFlags.canCut },
-          { label: 'Copy', role: 'copy', enabled: params.editFlags.canCopy },
-          { label: 'Paste', role: 'paste', enabled: params.editFlags.canPaste },
-        ]).popup()
-      })
-    }
+    // Enable right-click edit and spellcheck context menu in all builds.
+    window.webContents.on('context-menu', (_event, params) => {
+      Menu.buildFromTemplate(buildContextMenuTemplate(window, params)).popup({ window })
+    })
 
     // Store the window mapping BEFORE loadURL — bootstrap preload uses
     // __get-workspace-id (via sendSync) which reads this map during eval.


### PR DESCRIPTION
## Summary

Restores the packaged desktop right-click spellcheck menu for Craft Agent chat text.

## Changes

- Enable Electron spellcheck for Craft Agent app windows.
- Register the right-click text context menu in packaged builds.
- Keep the menu focused on spelling suggestions, **Learn Spelling**, and available edit actions only.
- Remove nonessential/dev-only entries such as **Inspect Element** and unavailable disabled actions.

## Screenshots

Verified locally with the simplified spellcheck menu: suggestions, **Learn Spelling**, Cut/Copy/Paste/Select All — no **Inspect Element**.

<img width="464" height="337" alt="Spellcheck context menu without Inspect Element" src="https://github.com/user-attachments/assets/537d5eec-fb87-4c26-b9c2-855399e1575c" />

## Testing

- `bun test ./apps/electron/src/main/__tests__/window-manager-spellcheck.isolated.ts`
- `bun run typecheck:electron`
- `cd apps/electron && bun run eslint src/main/window-manager.ts src/main/__tests__/window-manager-spellcheck.isolated.ts`

## Validation note

- `bun run typecheck:all` was attempted for the CONTRIBUTING.md checklist, but currently fails outside this PR in untouched packages (`packages/session-tools-core` / dependency type errors such as missing `tsconfig.base.json` and `@types/cacheable-request`/target issues). The changed Electron files pass targeted tests, Electron typecheck, and targeted lint.

Closes #476
