### PR TITLE
Fix final messages not being sent over Telegram

### DIFF
--- a/packages/messaging-gateway/src/__tests__/renderer.test.ts
+++ b/packages/messaging-gateway/src/__tests__/renderer.test.ts
@@ -236,6 +236,39 @@ describe('Renderer — progress mode (default)', () => {
     expect(sends.map((s) => s.text)).toEqual(['🔧 Read…', 'The answer is 42.'])
   })
 
+  it('tool-terminated run with no non-intermediate final → falls back to last assistant text', async () => {
+    const adapter = makeAdapter()
+    const binding = makeBinding()
+    // Automation pattern: agent narrates, calls a tool to deliver its result,
+    // and never emits a clean non-intermediate final text_complete.
+    await play(renderer, binding, adapter, [
+      ev.intermediate('Sending the report now.'),
+      ev.toolStart('SendTelegram'),
+      ev.toolResult(),
+      ev.complete(),
+    ])
+
+    const edits = adapter.calls.filter((c) => c.kind === 'editMessage')
+    // Must NOT be left frozen on a status label; the last assistant text wins.
+    expect(edits.at(-1)!.text).toBe('Sending the report now.')
+    expect(edits.some((e) => e.text === '💭 thinking…')).toBe(true)
+  })
+
+  it('still leaves status in place when the run produced no assistant text at all', async () => {
+    const adapter = makeAdapter()
+    const binding = makeBinding()
+    await play(renderer, binding, adapter, [
+      ev.toolStart('Read'),
+      ev.toolResult(),
+      ev.complete(),
+    ])
+    const all = adapter.calls
+      .filter((c) => c.kind === 'sendText' || c.kind === 'editMessage')
+      .map((c) => c.text ?? '')
+    // No empty-string edit on complete (would trip Telegram "not modified").
+    expect(all.every((t) => t.length > 0)).toBe(true)
+  })
+
   it('collapses redundant status edits (same status twice = one edit total)', async () => {
     const adapter = makeAdapter()
     const binding = makeBinding()
@@ -288,6 +321,35 @@ describe('Renderer — final_only mode', () => {
     const binding = makeBinding({ responseMode: 'final_only' as ResponseMode })
     await play(renderer, binding, adapter, [ev.toolStart('Read'), ev.toolResult(), ev.complete()])
     expect(adapter.calls.length).toBe(0)
+  })
+
+  it('tool-terminated run with only intermediate text → still sends the last assistant text', async () => {
+    const adapter = makeAdapter()
+    const binding = makeBinding({ responseMode: 'final_only' as ResponseMode })
+    await play(renderer, binding, adapter, [
+      ev.intermediate('Here is the summary you asked for.'),
+      ev.toolStart('SendTelegram'),
+      ev.toolResult(),
+      ev.complete(),
+    ])
+
+    const sends = adapter.calls.filter((c) => c.kind === 'sendText')
+    expect(sends.length).toBe(1)
+    expect(sends[0]!.text).toBe('Here is the summary you asked for.')
+  })
+
+  it('non-intermediate final is preferred over earlier intermediate text', async () => {
+    const adapter = makeAdapter()
+    const binding = makeBinding({ responseMode: 'final_only' as ResponseMode })
+    await play(renderer, binding, adapter, [
+      ev.intermediate('thinking out loud'),
+      ev.final('The real answer.'),
+      ev.complete(),
+    ])
+
+    const sends = adapter.calls.filter((c) => c.kind === 'sendText')
+    expect(sends.length).toBe(1)
+    expect(sends[0]!.text).toBe('The real answer.')
   })
 
   it('treats text_complete without isIntermediate as final (backwards compat)', async () => {

--- a/packages/messaging-gateway/src/renderer.ts
+++ b/packages/messaging-gateway/src/renderer.ts
@@ -79,6 +79,14 @@ interface RenderState {
   // --- progress / final_only modes -------------------------------------
   /** Progress/final_only: non-intermediate assistant text accumulated this run. */
   finalBuffer: string
+  /**
+   * Progress/final_only: the most recent non-empty assistant text seen this
+   * run, regardless of `isIntermediate`. Used as a fallback on `complete`
+   * when the run never produced a clean non-intermediate final turn (common
+   * for automations whose last action is a tool call) so we still deliver
+   * the agent's message instead of stranding the user on "thinking…".
+   */
+  lastAssistantText: string
   /** Progress: id of the single evolving message for this run (null before first activity). */
   progressMessageId: string | null
   /** Progress: last status label written to the bubble, to avoid redundant edits. */
@@ -150,6 +158,7 @@ export class Renderer {
         lastEditedLength: 0,
         currentEditIntervalMs: DEFAULT_EDIT_INTERVAL_MS,
         finalBuffer: '',
+        lastAssistantText: '',
         progressMessageId: null,
         progressStatus: null,
       }
@@ -335,11 +344,16 @@ export class Renderer {
       case 'text_complete': {
         const isIntermediate = Boolean(event.isIntermediate)
         const text = typeof event.text === 'string' ? event.text : ''
-        if (!isIntermediate && text.trim()) {
-          // Last assistant text of the run — keep it for the final edit.
-          state.finalBuffer = appendFinal(state.finalBuffer, text)
+        if (text.trim()) {
+          if (!isIntermediate) {
+            // Last assistant text of the run — keep it for the final edit.
+            state.finalBuffer = appendFinal(state.finalBuffer, text)
+          }
+          // Always remember the latest assistant text so `complete` can fall
+          // back to it if the run never produces a non-intermediate final.
+          state.lastAssistantText = text
         }
-        // Intermediate text is dropped. Make sure the bubble exists and shows
+        // Intermediate text is dropped from the bubble. Make sure it exists and shows
         // thinking status so the user knows the run is alive.
         await this.ensureProgressBubble(state, binding, adapter, THINKING_LABEL)
         return
@@ -365,7 +379,10 @@ export class Renderer {
       }
 
       case 'complete': {
-        const finalText = state.finalBuffer.trim()
+        // Prefer the clean non-intermediate final; fall back to the last
+        // assistant text so a tool-terminated run still delivers a message
+        // instead of freezing the bubble on "thinking…".
+        const finalText = (state.finalBuffer.trim() || state.lastAssistantText.trim())
         if (state.progressMessageId && adapter.capabilities.messageEditing) {
           if (finalText) {
             await this.tryEditMessage(
@@ -376,8 +393,8 @@ export class Renderer {
               state,
             )
           }
-          // If the run ended with no final text, leave the last status in
-          // place rather than deleting/editing to an empty string — avoids
+          // If the run produced no assistant text at all, leave the last
+          // status in place rather than editing to an empty string — avoids
           // Telegram "message is not modified" errors and keeps a trace.
         } else if (finalText) {
           // Adapter can't edit (WhatsApp) — send one message at the end.
@@ -434,14 +451,21 @@ export class Renderer {
         // because it's the only thing we might ever see.
         const isIntermediate = Boolean(event.isIntermediate)
         const text = typeof event.text === 'string' ? event.text : ''
-        if (!isIntermediate && text.trim()) {
-          state.finalBuffer = appendFinal(state.finalBuffer, text)
+        if (text.trim()) {
+          if (!isIntermediate) {
+            state.finalBuffer = appendFinal(state.finalBuffer, text)
+          }
+          // Fallback for runs that never emit a non-intermediate final turn.
+          state.lastAssistantText = text
         }
         return
       }
 
       case 'complete': {
-        const finalText = state.finalBuffer.trim()
+        // Prefer the clean non-intermediate final; fall back to the last
+        // assistant text so final_only still delivers something rather than
+        // staying silent when the run ends on a tool call.
+        const finalText = (state.finalBuffer.trim() || state.lastAssistantText.trim())
         if (finalText) {
           await this.sendText(adapter, binding, finalText)
         }
@@ -657,6 +681,7 @@ Approve in the desktop app to continue.`,
     state.lastEditedLength = 0
     state.processing = false
     state.finalBuffer = ''
+    state.lastAssistantText = ''
     state.progressMessageId = null
     state.progressStatus = null
   }


### PR DESCRIPTION
Fix for bug reported here: https://craft-community.slack.com/archives/C0A3LNBFL2D/p1778337274430029

I tested and verified manually. Claude's summary below:

## Summary

Telegram automations that route to a forum topic could get stuck on `💭 thinking…` and never deliver the agent's message (and `final_only` stayed completely silent). This occurs when a run ends without a clean non-intermediate `text_complete` — e.g. automations whose last action is a tool call.

Root cause: `progress` and `final_only` modes only captured the final answer from `text_complete` events with `isIntermediate` falsy. Runs that never produce one left `finalBuffer` empty, and `complete` deliberately left the status bubble frozen / sent nothing.

Fix: track the most recent assistant text regardless of `isIntermediate` and fall back to it on `complete` when no non-intermediate final arrived. The clean non-intermediate final is still preferred when present; genuinely empty runs still leave the status label in place / send nothing (so we don't trip Telegram's "message is not modified").

Renderer-side fix only — automation bindings still default to `progress`; this makes `progress` reliably deliver.

## Test plan

- [x] `bun test` in `packages/messaging-gateway` — 228/228 pass (4 new regression tests covering tool-terminated runs in both modes)
- [x] `bun run tsc --noEmit` in `packages/messaging-gateway` — clean
- [x] Built the desktop app and confirmed the affected Telegram automation now delivers its message instead of freezing on "thinking…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)