### PR TITLE
fix skills discovery for symlinked directories

### DIFF
--- a/packages/shared/src/skills/__tests__/storage.test.ts
+++ b/packages/shared/src/skills/__tests__/storage.test.ts
@@ -14,7 +14,7 @@
  * baseline count and validating relative to it.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync } from 'fs';
 import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import {
@@ -309,6 +309,48 @@ describe('loadWorkspaceSkills', () => {
     expect(skills).toHaveLength(1);
     expect(skills[0]!.slug).toBe('real-skill');
   });
+
+  it('should load symlinked skill directories from workspace', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const skillsDir = join(workspaceRoot, 'skills');
+    const realSkillsDir = join(tempDir, 'real-skills');
+    mkdirSync(realSkillsDir, { recursive: true });
+    createSkill(realSkillsDir, 'shared-skill', {
+      name: 'Shared Skill',
+      description: 'Loaded through a symlink',
+    });
+
+    symlinkSync(
+      join(realSkillsDir, 'shared-skill'),
+      join(skillsDir, 'shared-skill'),
+      'dir'
+    );
+
+    const skills = loadWorkspaceSkills(workspaceRoot);
+
+    expect(skills.map(skill => skill.slug)).toContain('shared-skill');
+    const skill = skills.find(skill => skill.slug === 'shared-skill');
+    expect(skill!.metadata.name).toBe('Shared Skill');
+  });
+
+  it('should ignore broken symlinked skill directories', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const skillsDir = join(workspaceRoot, 'skills');
+    symlinkSync(
+      join(tempDir, 'missing-target'),
+      join(skillsDir, 'broken-skill'),
+      'dir'
+    );
+
+    expect(() => loadWorkspaceSkills(workspaceRoot)).not.toThrow();
+    expect(loadWorkspaceSkills(workspaceRoot)).toEqual([]);
+  });
 });
 
 // ============================================================
@@ -574,6 +616,27 @@ describe('listSkillSlugs', () => {
   it('should return empty array for non-existent workspace', () => {
     const slugs = listSkillSlugs(join(tempDir, 'nonexistent'));
     expect(slugs).toEqual([]);
+  });
+
+  it('should include symlinked skill directories in listSkillSlugs', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const skillsDir = join(workspaceRoot, 'skills');
+    const realSkillDir = join(tempDir, 'real-shared-skill');
+    mkdirSync(realSkillDir, { recursive: true });
+    writeFileSync(join(realSkillDir, 'SKILL.md'), `---
+name: "Shared Skill"
+description: "Loaded through a symlink"
+---
+Instructions
+`);
+
+    symlinkSync(realSkillDir, join(skillsDir, 'shared-skill'), 'dir');
+
+    const slugs = listSkillSlugs(workspaceRoot);
+    expect(slugs).toContain('shared-skill');
   });
 });
 

--- a/packages/shared/src/skills/storage.ts
+++ b/packages/shared/src/skills/storage.ts
@@ -12,6 +12,7 @@ import {
   rmSync,
   statSync,
 } from 'fs';
+import type { Dirent } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
 import matter from 'gray-matter';
@@ -94,6 +95,22 @@ function parseSkillFile(content: string): { metadata: SkillMetadata; body: strin
   }
 }
 
+function isDirectoryOrSymlinkToDirectory(parentDir: string, entry: Dirent): boolean {
+  if (entry.isDirectory()) {
+    return true;
+  }
+
+  if (!entry.isSymbolicLink()) {
+    return false;
+  }
+
+  try {
+    return statSync(join(parentDir, entry.name)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 // ============================================================
 // Load Operations
 // ============================================================
@@ -156,7 +173,7 @@ function loadSkillsFromDir(skillsDir: string, source: SkillSource): LoadedSkill[
   try {
     const entries = readdirSync(skillsDir, { withFileTypes: true });
     for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
+      if (!isDirectoryOrSymlinkToDirectory(skillsDir, entry)) continue;
 
       const skill = loadSkillFromDir(skillsDir, entry.name, source);
       if (skill) {
@@ -342,7 +359,7 @@ export function listSkillSlugs(workspaceRoot: string): string[] {
   try {
     return readdirSync(skillsDir, { withFileTypes: true })
       .filter((entry) => {
-        if (!entry.isDirectory()) return false;
+        if (!isDirectoryOrSymlinkToDirectory(skillsDir, entry)) return false;
         const skillFile = join(skillsDir, entry.name, 'SKILL.md');
         return existsSync(skillFile);
       })


### PR DESCRIPTION
Fixes #744

## Summary
- Treat symlinks to directories as valid skill directories during skill scanning
- Apply the same logic to workspace skill loading and slug listing
- Ignore broken symlinks safely
- Add regression tests for symlinked skill discovery

## Testing
- bun test packages/shared/src/skills/__tests__/storage.test.ts
- bun run typecheck:shared