### PR TITLE
fix: refresh model list after re-authenticating an LLM connection

### DIFF
--- a/packages/server-core/src/handlers/rpc/llm-connections.ts
+++ b/packages/server-core/src/handlers/rpc/llm-connections.ts
@@ -270,7 +270,11 @@ export function registerLlmConnectionsHandlers(server: RpcServer, deps: HandlerD
       // Awaited so the model selector shows real available models immediately.
       const pendingModels = Array.isArray(pendingConnection.models) ? pendingConnection.models : []
       const isAutoSynced = pendingConnection.modelSelectionMode === 'automaticallySyncedFromProvider'
-      if (!pendingModels.length || isAutoSynced) {
+      // Re-auth with a new credential may point at a different account whose
+      // model entitlements differ — force a refresh instead of trusting the
+      // cached models from the prior credential.
+      const isReauthWithNewCredential = setup.updateOnly === true && !!setup.credential && !isMasked
+      if (!pendingModels.length || isAutoSynced || isReauthWithNewCredential) {
         try {
           await getModelRefreshService().refreshNow(setup.slug)
         } catch (err) {
@@ -671,6 +675,16 @@ export function registerLlmConnectionsHandlers(server: RpcServer, deps: HandlerD
       })
 
       pendingChatGptFlows.delete(state)
+
+      // Refresh the model list with the new credentials — the previously
+      // cached models reflect the old account's entitlements and would be
+      // stale (e.g. a new account may have access to newer GPT models).
+      try {
+        await getModelRefreshService().refreshNow(flow.connectionSlug)
+      } catch (err) {
+        deps.platform.logger?.warn(`Model refresh after ChatGPT OAuth failed for ${flow.connectionSlug}: ${err instanceof Error ? err.message : err}`)
+      }
+
       deps.platform.logger?.info(`[ChatGPT OAuth] Flow complete for ${flow.connectionSlug}`)
       return { success: true }
     } catch (error) {
@@ -794,6 +808,15 @@ export function registerLlmConnectionsHandlers(server: RpcServer, deps: HandlerD
         refreshToken: credentials.refresh,
         expiresAt: credentials.expires,
       })
+
+      // Refresh the model list with the new credentials — Copilot's available
+      // models depend on the GitHub account's subscription policy, which can
+      // differ between the previous and newly authenticated account.
+      try {
+        await getModelRefreshService().refreshNow(connectionSlug)
+      } catch (err) {
+        deps.platform.logger?.warn(`Model refresh after Copilot OAuth failed for ${connectionSlug}: ${err instanceof Error ? err.message : err}`)
+      }
 
       deps.platform.logger?.info('GitHub Copilot OAuth completed successfully')
       return { success: true }


### PR DESCRIPTION
## Summary

Fixes #820. Re-authenticating an existing LLM connection now refreshes the cached model list, so switching to a different account (e.g. one with newer model access) no longer requires deleting and re-adding the connection.

- `chatgpt.COMPLETE_OAUTH`: call `refreshNow()` after storing tokens
- `copilot.START_OAUTH`: call `refreshNow()` after storing tokens
- `SETUP_LLM_CONNECTION`: also refresh on `updateOnly` re-auth when a new credential is supplied (covers API-key re-auth pointing at a different account)

Refresh errors are logged but don't fail the auth return — the periodic refresh / `REFRESH_MODELS` paths recover.

## Test plan

- [ ] Sign in to a Codex account with limited models, re-authenticate with a different account that has additional models, verify the list updates without delete + re-add
- [ ] Same flow for GitHub Copilot
- [ ] API-key re-auth: swap the key for a different account, verify model list refreshes
- [ ] Refresh failure path: disconnect network during re-auth, verify auth still succeeds and a warning is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)