### PR TITLE
fix: editing a connection no longer sends masked API key to the backend

### DIFF
--- a/packages/server-core/src/handlers/rpc/llm-connections.ts
+++ b/packages/server-core/src/handlers/rpc/llm-connections.ts
@@ -410,16 +410,11 @@ export function registerLlmConnectionsHandlers(server: RpcServer, deps: HandlerD
     return getLlmConnection(slug)
   })
 
-  // Get stored API key for an LLM connection (masked — for edit form display only)
+  // Get stored API key for an LLM connection (real key — UI masks via type="password")
   server.handle(RPC_CHANNELS.llmConnections.GET_API_KEY, async (_ctx, slug: string): Promise<string | null> => {
     const manager = getCredentialManager()
     const key = await manager.getLlmApiKey(slug)
-    if (!key) return null
-    // Show provider prefix (first 7 chars) + last 4 chars, mask the middle
-    if (key.length > 15) {
-      return key.slice(0, 7) + '••••••••' + key.slice(-4)
-    }
-    return '••••••••'
+    return key ?? null
   })
 
   // Save (create or update) an LLM connection


### PR DESCRIPTION
## Problem

Closes #445, closes #540.

When editing a saved AI provider connection (Settings → AI → Connections → Edit), changing **any** field — such as the model name — and clicking **Continue** triggers a connection test that fails with:

```
Cannot convert argument to a ByteString because the character at index 7
has a value of 8226 which is greater than 255.
```

The root cause: the `GET_API_KEY` RPC handler returned a **server-side masked** API key (`sk-1234••••••••abcd`) instead of the real credential. This masked value was loaded into the form's `useState` as the actual `apiKey` field. When the user edited only the model and submitted without re-typing the key, the masked string — containing Unicode bullet `•` (U+2026) characters — was passed all the way to the `fetch` call's `x-api-key` header, which must be ISO-8859-1. The non-ASCII bullets caused the ByteString conversion error.

## Reproduction

1. Go to **Settings → AI → Connections**
2. Add a connection with a valid API key and save it
3. Click **⋯ → Edit** on that connection
4. Change the model name (leave the API key field untouched)
5. Click **Continue**

**Before:** ByteString error — the masked key is sent as the real credential.
**After:** Connection test succeeds — the real key is used.

## Fix

The `GET_API_KEY` handler previously masked the key on the server side before returning it:

```ts
return key.slice(0, 7) + '••••••••' + key.slice(-4)
```

This was unnecessary masking — the frontend's `<Input type="password">` already renders the value as dots natively. The eye-icon toggle (`type="text"`) correctly reveals the real value.

The fix simply returns the real key from the credential store. The UI-level masking (password input) is preserved, and the form now holds a valid credential for submission.

## Why this is safe

- The Electron renderer process is the same trust boundary as the main process; there is no cross-origin exposure risk.
- The existing `<Input type="password">` in `ApiKeyInput.tsx` already provides the visual masking that users expect.
- The eye-icon reveal behavior now works as intended: clicking it shows the real key, not a truncated server-side mask with a different length than the actual credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)