### PR TITLE
fix: keep macOS Dock icon consistent after launch

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -415,7 +415,9 @@ app.whenReady().then(async () => {
     ].find(p => existsSync(p))
 
     if (dockIconPath) {
-      app.dock.setIcon(dockIconPath)
+      if (!app.isPackaged) {
+        app.dock.setIcon(dockIconPath)
+      }
       // Initialize badge icon for canvas-based badge overlay
       initBadgeIcon(dockIconPath)
     }


### PR DESCRIPTION
## Summary
- Keep the macOS packaged app's Dock icon managed by the bundled app icon instead of replacing it with `resources/icon.png` at runtime.
- Preserve the existing runtime Dock icon override for development builds.
- Continue initializing the badge base icon so notification badge rendering still has a source image.

## Root Cause
The packaged macOS app uses `resources/icon.icns` and, on newer macOS versions, `Assets.car` / `CFBundleIconName: AppIcon` before launch. After launch, the main process unconditionally called `app.dock.setIcon(...)` with `resources/icon.png`, which could visually differ from the packaged icon and made the Dock icon change while the app was running.

## Verification
- `git diff --check`
- `bun run electron:dist:mac`
- Confirmed the generated test app contains both `Contents/Resources/icon.icns` and `Contents/Resources/Assets.car`.

Fixes #737