### PR TITLE
feat(cli+server): hang-proof `ask` command, idempotent sends, heartbeat

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1148,11 +1148,6 @@ function flattenLabelTree(labels: Array<{ id: string; name?: string; children?: 
   return out
 }
 
-/** Default LLM connection slug for a model: opus → claude-max, else pi-api-key (gpt-5.5). */
-function defaultConnectionForModel(model: string): string {
-  return /opus/i.test(model) ? 'claude-max' : 'pi-api-key'
-}
-
 /**
  * Resolve (or create) a stable MAX-tier reviewer session carrying a label.
  *
@@ -1166,9 +1161,13 @@ function defaultConnectionForModel(model: string): string {
  * if the tier is wrong — never silently returns a downgraded session.
  */
 async function cmdEnsureReviewer(client: CliRpcClient, args: CliArgs): Promise<void> {
-  const labelName = args.label ?? 'cc-reviewer-max'
-  const model = args.model || 'gpt-5.5'
-  const connection = args.connection || defaultConnectionForModel(model)
+  const labelName = args.label
+  const model = args.model
+  const connection = args.connection
+  if (!labelName || !model || !connection) {
+    err('ensure-reviewer requires --label <name>, --model <id>, and --connection <slug>')
+    process.exit(2)
+  }
 
   await client.connect()
   const workspaceId = await resolveWorkspace(client, args.workspace)
@@ -2402,11 +2401,11 @@ Commands:
                                                 a same-id retry short-circuits the send.
                          --json prints { control: {correlationId, sessionId, messageId,
                          complete, timedOut, success}, payload: <reply> }
-  ensure-reviewer        Resolve or create a MAX-tier reviewer session by label,
-                         asserting the tier on read-back (fail-closed). Prints the sessionId.
-                         --label <name>      Label to resolve/create (default: cc-reviewer-max)
-                         --model <id>        Model (default: gpt-5.5)
-                         --connection <slug> LLM connection (default: pi-api-key, or claude-max for opus)
+  ensure-reviewer        Resolve or create a MAX-tier session by label, asserting the
+                         tier on read-back (fail-closed). Prints the sessionId.
+                         --label <name>      (required) label to resolve/create
+                         --model <id>        (required) model id
+                         --connection <slug> (required) LLM connection slug
   cancel <id>            Cancel in-progress processing
   invoke <channel> [...] Raw RPC call with JSON args
   listen <channel>       Subscribe to push events (Ctrl+C to stop)

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -731,6 +731,33 @@ async function cmdAsk(client: CliRpcClient, args: CliArgs): Promise<void> {
     args.correlationId ? { idempotencyKey: args.correlationId } : undefined
   )) as { accepted: true; messageId: string; deduped?: boolean }
 
+  // Server-enforced idempotency: a same-key resend returns synchronously with the
+  // prior messageId and starts NO new turn, so no `complete` push will ever arrive.
+  // Skip the wait loop entirely and resolve the prior final reply via a durable read.
+  if (sendResult.deduped) {
+    unsub()
+    const after = (await client.invoke('sessions:getMessages', sessionId)) as AskSession
+    const final = resolveFinalMessage(after)
+    const result: AskResult = {
+      control: {
+        correlationId: args.correlationId,
+        sessionId,
+        messageId: sendResult.messageId,
+        complete: true,
+        timedOut: false,
+        success: true,
+        deduped: true,
+      },
+      payload: textOf(final),
+    }
+    if (args.dedupeDir && args.correlationId) {
+      await writeDedupe(args.dedupeDir, args.correlationId, result)
+    }
+    emitAskResult(result, args.json)
+    client.destroy()
+    process.exit(0)
+  }
+
   // Bounded wait — ALWAYS exits at the deadline, never an unbounded await.
   const deadline = Date.now() + args.askTimeout
   while (!completed && Date.now() < deadline) {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -22,6 +22,7 @@ export interface CliArgs {
   json: boolean
   tlsCa?: string
   sendTimeout: number
+  askTimeout: number
   command: string
   rest: string[]
   // run-specific flags
@@ -38,6 +39,12 @@ export interface CliArgs {
   model: string
   apiKey: string
   baseUrl: string
+  // ensure-reviewer flags
+  label?: string
+  connection?: string
+  // ask two-layer / dedupe flags
+  correlationId?: string
+  dedupeDir?: string
 }
 
 export function parseArgs(argv: string[]): CliArgs {
@@ -49,6 +56,7 @@ export function parseArgs(argv: string[]): CliArgs {
   let json = false
   let tlsCa: string | undefined
   let sendTimeout = 300_000 // 5 min
+  let askTimeout = 600_000 // 10 min — bounded wall-clock for `ask`
   const rest: string[] = []
   let command = ''
   const sources: string[] = []
@@ -63,6 +71,10 @@ export function parseArgs(argv: string[]): CliArgs {
   let model = ''
   let apiKey = ''
   let baseUrl = ''
+  let label: string | undefined
+  let connection: string | undefined
+  let correlationId: string | undefined
+  let dedupeDir: string | undefined
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]
@@ -87,6 +99,9 @@ export function parseArgs(argv: string[]): CliArgs {
         break
       case '--send-timeout':
         sendTimeout = parseInt(args[++i] ?? '300000', 10)
+        break
+      case '--ask-timeout':
+        askTimeout = parseInt(args[++i] ?? '600000', 10)
         break
       case '--source':
         sources.push(args[++i] ?? '')
@@ -126,6 +141,18 @@ export function parseArgs(argv: string[]): CliArgs {
       case '--base-url':
         baseUrl = args[++i] ?? ''
         break
+      case '--label':
+        label = args[++i]
+        break
+      case '--connection':
+        connection = args[++i]
+        break
+      case '--correlation-id':
+        correlationId = args[++i]
+        break
+      case '--dedupe-dir':
+        dedupeDir = args[++i]
+        break
       case '--help':
       case '-h':
         command = 'help'
@@ -154,7 +181,7 @@ export function parseArgs(argv: string[]): CliArgs {
   if (!apiKey) apiKey = process.env.LLM_API_KEY ?? ''
   if (!baseUrl) baseUrl = process.env.LLM_BASE_URL ?? ''
 
-  return { url, token, workspace, timeout, json, tlsCa, sendTimeout, command, rest, sources, mode, outputFormat, noCleanup, noSpinner, verbose, serverEntry, workspaceDir, provider, model, apiKey, baseUrl }
+  return { url, token, workspace, timeout, json, tlsCa, sendTimeout, askTimeout, command, rest, sources, mode, outputFormat, noCleanup, noSpinner, verbose, serverEntry, workspaceDir, provider, model, apiKey, baseUrl, label, connection, correlationId, dedupeDir }
 }
 
 // ---------------------------------------------------------------------------
@@ -179,6 +206,35 @@ async function resolveWorkspace(
     }
   } catch {
     // Fall through — workspace may not be needed
+  }
+  return undefined
+}
+
+/**
+ * Bind the client to a session's workspace so workspace-scoped push events
+ * (e.g. the `complete` broadcast) reach us. When `explicit` is given it wins;
+ * otherwise we read the session and switch to its own workspaceId. Best-effort:
+ * any failure falls through silently — the caller's durable-read fallback still
+ * guarantees correctness, this only protects the fast push path.
+ */
+async function resolveWorkspaceForSession(
+  client: CliRpcClient,
+  sessionId: string,
+  explicit?: string,
+): Promise<string | undefined> {
+  if (explicit) {
+    await client.invoke('window:switchWorkspace', explicit).catch(() => {})
+    return explicit
+  }
+  try {
+    const session = (await client.invoke('sessions:getMessages', sessionId)) as { workspaceId?: string }
+    const id = session?.workspaceId
+    if (id) {
+      await client.invoke('window:switchWorkspace', id).catch(() => {})
+      return id
+    }
+  } catch {
+    // Fall through — push may still arrive, and the durable read is authoritative.
   }
   return undefined
 }
@@ -488,6 +544,242 @@ async function cmdSend(client: CliRpcClient, args: CliArgs): Promise<void> {
   process.exit(exitCode)
 }
 
+/** Extract plain text from an assistant message's content (string or block array). */
+function textOf(msg: { content?: unknown } | undefined): string {
+  if (!msg) return ''
+  const content = msg.content
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .map((b) => {
+        if (typeof b === 'string') return b
+        if (b && typeof b === 'object' && 'text' in b) return String((b as { text: unknown }).text ?? '')
+        return ''
+      })
+      .join('')
+  }
+  return content == null ? '' : String(content)
+}
+
+/** Last non-intermediate assistant message — the team-spawn coordination-tail fix. */
+function resolveFinalMessage(
+  session: { lastFinalMessageId?: string | null; messages?: AskMessage[] } | undefined,
+): AskMessage | undefined {
+  const messages = session?.messages ?? []
+  const finalId = session?.lastFinalMessageId
+  if (finalId) {
+    const found = messages.find((m) => m.id === finalId)
+    if (found) return found
+  }
+  // Fallback: walk backwards for the last non-intermediate assistant message.
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]
+    if (m.role === 'assistant' && !m.isIntermediate) return m
+  }
+  return undefined
+}
+
+interface AskMessage {
+  id: string
+  role: string
+  content?: unknown
+  isIntermediate?: boolean
+}
+
+interface AskSession {
+  lastFinalMessageId?: string | null
+  messages?: AskMessage[]
+}
+
+/**
+ * Two-layer reply: a small fixed CONTROL HEADER the workflow routes on, plus a
+ * free-form PAYLOAD (the reply text) the channel never inspects.
+ */
+interface AskControlHeader {
+  correlationId?: string
+  sessionId: string
+  messageId: string | null
+  complete: boolean
+  timedOut: boolean
+  success: boolean
+}
+
+interface AskResult {
+  control: AskControlHeader
+  payload: string
+}
+
+/** URL-safe job filename for a correlation id (one file per correlation id). */
+function dedupeFilePath(dir: string, correlationId: string): string {
+  return `${dir}/${encodeURIComponent(correlationId)}.json`
+}
+
+/**
+ * Fast-path dedupe read: return a cached, done AskResult for this correlation id
+ * if one exists. Best-effort — any read/parse failure returns undefined so we
+ * fall through to a normal send.
+ */
+async function readDedupe(dir: string, correlationId: string): Promise<AskResult | undefined> {
+  try {
+    const file = Bun.file(dedupeFilePath(dir, correlationId))
+    if (!(await file.exists())) return undefined
+    const cached = (await file.json()) as { done?: boolean; control?: AskControlHeader; payload?: string }
+    if (cached?.done && cached.control) {
+      return { control: cached.control, payload: cached.payload ?? '' }
+    }
+  } catch {
+    // Fall through — corrupt/unreadable cache is treated as a cache miss.
+  }
+  return undefined
+}
+
+/** Write the job file marking this correlation id done (idempotent fast path). */
+async function writeDedupe(dir: string, correlationId: string, result: AskResult): Promise<void> {
+  try {
+    const { mkdir } = await import('fs/promises')
+    await mkdir(dir, { recursive: true })
+    await Bun.write(
+      dedupeFilePath(dir, correlationId),
+      JSON.stringify({ done: true, control: result.control, payload: result.payload }, null, 2),
+    )
+  } catch {
+    // Best effort — failing to persist the cache only forfeits the fast path.
+  }
+}
+
+/** Print an AskResult: two-layer JSON in --json mode, else the bare payload. */
+function emitAskResult(result: AskResult, jsonMode: boolean): void {
+  if (jsonMode) {
+    out({ control: result.control, payload: result.payload }, true)
+  } else {
+    out(result.payload, false)
+  }
+}
+
+/**
+ * Generic block-and-wait: send a message, wait for the `complete` push for THIS
+ * session (bounded by --ask-timeout), then do a single durable read via
+ * sessions:getMessages to fetch the authoritative final reply. The push is only
+ * a wake signal — the reply always comes from the durable read, so this can
+ * never hang: the wait loop always exits at the deadline and falls through to
+ * the read. Exits 0 on success, 1 on terminal error or timeout-with-no-reply.
+ */
+async function cmdAsk(client: CliRpcClient, args: CliArgs): Promise<void> {
+  const sessionId = args.rest[0]
+  if (!sessionId) {
+    err('Usage: ask <session-id> <message>')
+    process.exit(1)
+  }
+
+  const message = await readPrompt(args.rest.slice(1), args.rest)
+  if (!message.trim()) {
+    err('No message provided')
+    process.exit(1)
+  }
+
+  // Fast dedupe: when both --dedupe-dir and --correlation-id are set, a previously
+  // completed job short-circuits the send entirely (crash-and-retry is a no-op).
+  if (args.dedupeDir && args.correlationId) {
+    const cached = await readDedupe(args.dedupeDir, args.correlationId)
+    if (cached) {
+      emitAskResult(cached, args.json)
+      client.destroy()
+      process.exit(cached.control.success ? 0 : 1)
+    }
+  }
+
+  await client.connect()
+
+  // Bind the client to the session's workspace so the workspace-scoped `complete`
+  // broadcast reaches us via the push path. Without this the push never arrives and
+  // we degrade to the full --ask-timeout. --workspace overrides the auto-resolve.
+  await resolveWorkspaceForSession(client, sessionId, args.workspace)
+
+  // Baseline: capture the current final message id so we can confirm advancement.
+  const before = (await client.invoke('sessions:getMessages', sessionId)) as AskSession
+  const baselineFinalId = before?.lastFinalMessageId ?? null
+
+  // Attach the listener BEFORE sending so we can't miss the complete push.
+  let completed = false
+  let failed = false
+  const unsub = client.on('session:event', (event: unknown) => {
+    const ev = event as { type: string; sessionId: string; error?: unknown }
+    if (ev.sessionId !== sessionId) return
+    switch (ev.type) {
+      case 'complete':
+        completed = true
+        break
+      case 'error':
+        if (ev.error) err(String(ev.error))
+        failed = true
+        completed = true
+        break
+      case 'interrupted':
+        completed = true
+        break
+    }
+  })
+
+  // Fire the message — returns immediately while the agent works server-side.
+  await client.invoke('sessions:sendMessage', sessionId, message)
+
+  // Bounded wait — ALWAYS exits at the deadline, never an unbounded await.
+  const deadline = Date.now() + args.askTimeout
+  while (!completed && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  unsub()
+
+  // Durable read — authoritative, runs whether we woke via push or timed out.
+  let after = (await client.invoke('sessions:getMessages', sessionId)) as AskSession
+  let final = resolveFinalMessage(after)
+
+  // Persistence race: complete can fire microseconds before the message lands.
+  // One delayed re-read if the final id hasn't advanced past baseline.
+  if (completed && (final?.id == null || final.id === baselineFinalId)) {
+    await new Promise((r) => setTimeout(r, 500))
+    after = (await client.invoke('sessions:getMessages', sessionId)) as AskSession
+    final = resolveFinalMessage(after)
+  }
+
+  const advanced = final?.id != null && final.id !== baselineFinalId
+
+  if (!completed && !advanced) {
+    err(`ask timeout — no reply within ${args.askTimeout}ms`)
+    client.destroy()
+    process.exit(1)
+  }
+
+  if (!advanced) {
+    err('Completed but no new final message was produced')
+  }
+
+  // success = completed cleanly, not timed out, and a NEW final message advanced
+  // past the baseline (and no terminal error event arrived).
+  const success = completed && !failed && advanced
+  const result: AskResult = {
+    control: {
+      correlationId: args.correlationId,
+      sessionId,
+      messageId: final?.id ?? null,
+      complete: completed,
+      timedOut: !completed,
+      success,
+    },
+    payload: textOf(final),
+  }
+
+  // Persist the job file (mark done) so a same-correlation retry short-circuits.
+  if (args.dedupeDir && args.correlationId) {
+    await writeDedupe(args.dedupeDir, args.correlationId, result)
+  }
+
+  emitAskResult(result, args.json)
+
+  client.destroy()
+  process.exit(failed || !final ? 1 : 0)
+}
+
 interface LocalServer {
   client: CliRpcClient
   stop: () => Promise<void>
@@ -781,6 +1073,126 @@ async function cmdInvoke(client: CliRpcClient, args: CliArgs): Promise<void> {
 
   const result = await client.invoke(channel, ...invokeArgs)
   out(result, args.json)
+}
+
+/** Split a session label entry ("id" or "id::value") into its bare id. */
+function labelEntryId(entry: string): string {
+  const i = entry.indexOf('::')
+  return i === -1 ? entry : entry.slice(0, i)
+}
+
+/** Flatten a label tree (top-level + nested children) into a single list. */
+function flattenLabelTree(labels: Array<{ id: string; name?: string; children?: unknown[] }>): Array<{ id: string; name?: string }> {
+  const out: Array<{ id: string; name?: string }> = []
+  const walk = (list: Array<{ id: string; name?: string; children?: unknown[] }>) => {
+    for (const l of list) {
+      out.push({ id: l.id, name: l.name })
+      if (Array.isArray(l.children)) walk(l.children as typeof list)
+    }
+  }
+  walk(labels)
+  return out
+}
+
+/** Default LLM connection slug for a model: opus → claude-max, else pi-api-key (gpt-5.5). */
+function defaultConnectionForModel(model: string): string {
+  return /opus/i.test(model) ? 'claude-max' : 'pi-api-key'
+}
+
+/**
+ * Resolve (or create) a stable MAX-tier reviewer session carrying a label.
+ *
+ * Resolution: find the label by name in the workspace (creating it if absent),
+ * then return the first session whose labels include that label id. If none
+ * exists, CREATE one via the raw sessions:create RPC with model + llmConnection
+ * + thinkingLevel:'max' + permissionMode:'allow-all' + labels:[labelId].
+ *
+ * FAIL-CLOSED: always READ BACK the resolved/created session and assert the tier
+ * (model matches AND thinkingLevel === 'max'). Exits nonzero with a clear message
+ * if the tier is wrong — never silently returns a downgraded session.
+ */
+async function cmdEnsureReviewer(client: CliRpcClient, args: CliArgs): Promise<void> {
+  const labelName = args.label ?? 'cc-reviewer-max'
+  const model = args.model || 'gpt-5.5'
+  const connection = args.connection || defaultConnectionForModel(model)
+
+  await client.connect()
+  const workspaceId = await resolveWorkspace(client, args.workspace)
+  if (!workspaceId) {
+    err('No workspace available. Use --workspace <id>')
+    process.exit(1)
+  }
+
+  // Resolve the label by name (create it if it doesn't exist yet).
+  const existingLabels = flattenLabelTree(
+    (await client.invoke('labels:list', workspaceId)) as Array<{ id: string; name?: string; children?: unknown[] }>,
+  )
+  let label = existingLabels.find((l) => l.name === labelName || l.id === labelName)
+  if (!label) {
+    label = (await client.invoke('labels:create', workspaceId, { name: labelName })) as { id: string; name?: string }
+  }
+  const labelId = label.id
+
+  // Find an existing session carrying that label.
+  const sessions = (await client.invoke('sessions:get', workspaceId)) as Array<{ id: string; labels?: string[] }>
+  let sessionId = sessions.find((s) => (s.labels ?? []).some((e) => labelEntryId(e) === labelId))?.id
+  let created = false
+
+  if (!sessionId) {
+    // CREATE via the raw RPC — the convenience path silently drops these fields.
+    const session = (await client.invoke('sessions:create', workspaceId, {
+      name: `CC Reviewer — ${model} max`,
+      model,
+      llmConnection: connection,
+      thinkingLevel: 'max',
+      permissionMode: 'allow-all',
+      labels: [labelId],
+    })) as { id?: string }
+    sessionId = session?.id
+    created = true
+    if (!sessionId) {
+      err('sessions:create returned no session id')
+      process.exit(1)
+    }
+  }
+
+  // READ BACK and assert tier — fail-closed.
+  const readback = (await client.invoke('sessions:getMessages', sessionId)) as {
+    id?: string
+    model?: string
+    thinkingLevel?: string
+    llmConnection?: string
+  }
+  const gotModel = readback?.model
+  const gotThinking = readback?.thinkingLevel
+  if (gotModel !== model || gotThinking !== 'max') {
+    err(
+      `tier assertion failed for session ${sessionId}: ` +
+        `expected model=${model} thinkingLevel=max, got model=${gotModel ?? 'undefined'} thinkingLevel=${gotThinking ?? 'undefined'}`,
+    )
+    client.destroy()
+    process.exit(1)
+  }
+
+  if (args.json) {
+    out(
+      {
+        sessionId,
+        created,
+        label: labelName,
+        labelId,
+        model: gotModel,
+        thinkingLevel: gotThinking,
+        llmConnection: readback?.llmConnection ?? connection,
+      },
+      true,
+    )
+  } else {
+    out(sessionId, false)
+  }
+
+  client.destroy()
+  process.exit(0)
 }
 
 async function cmdListen(client: CliRpcClient, args: CliArgs): Promise<void> {
@@ -1929,6 +2341,18 @@ Commands:
   session messages <id>  Print session message history
   session delete <id>    Delete a session
   send <id> <message>    Send message and stream AI response
+  ask <id> <message>     Send, wait for completion push (bounded), print final reply
+                         --ask-timeout <ms>  Bounded wall-clock (default: 600000)
+                         --correlation-id <id>  Tag the --json control header for routing
+                         --dedupe-dir <path>    With --correlation-id: cache the result here;
+                                                a same-id retry short-circuits the send.
+                         --json prints { control: {correlationId, sessionId, messageId,
+                         complete, timedOut, success}, payload: <reply> }
+  ensure-reviewer        Resolve or create a MAX-tier reviewer session by label,
+                         asserting the tier on read-back (fail-closed). Prints the sessionId.
+                         --label <name>      Label to resolve/create (default: cc-reviewer-max)
+                         --model <id>        Model (default: gpt-5.5)
+                         --connection <slug> LLM connection (default: pi-api-key, or claude-max for opus)
   cancel <id>            Cancel in-progress processing
   invoke <channel> [...] Raw RPC call with JSON args
   listen <channel>       Subscribe to push events (Ctrl+C to stop)
@@ -2046,9 +2470,15 @@ export async function main(argv: string[] = process.argv): Promise<void> {
       case 'send':
         await cmdSend(client, args)
         break // cmdSend calls process.exit
+      case 'ask':
+        await cmdAsk(client, args)
+        break // cmdAsk calls process.exit
       case 'cancel':
         await cmdCancel(client, args)
         break
+      case 'ensure-reviewer':
+        await cmdEnsureReviewer(client, args)
+        break // cmdEnsureReviewer calls process.exit
       case 'invoke':
         await cmdInvoke(client, args)
         break

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -602,6 +602,8 @@ interface AskControlHeader {
   complete: boolean
   timedOut: boolean
   success: boolean
+  /** True when the server deduped this send (same idempotencyKey as a prior). */
+  deduped?: boolean
 }
 
 interface AskResult {
@@ -721,7 +723,13 @@ async function cmdAsk(client: CliRpcClient, args: CliArgs): Promise<void> {
   })
 
   // Fire the message — returns immediately while the agent works server-side.
-  await client.invoke('sessions:sendMessage', sessionId, message)
+  // Forward --correlation-id as the server idempotency key so a crash-and-retry
+  // with the same id is deduped at the server (complements the client-side
+  // --dedupe-dir fast path, which short-circuits before we ever connect).
+  const sendResult = (await client.invoke('sessions:sendMessage', sessionId, message,
+    undefined, undefined,
+    args.correlationId ? { idempotencyKey: args.correlationId } : undefined
+  )) as { accepted: true; messageId: string; deduped?: boolean }
 
   // Bounded wait — ALWAYS exits at the deadline, never an unbounded await.
   const deadline = Date.now() + args.askTimeout
@@ -765,6 +773,7 @@ async function cmdAsk(client: CliRpcClient, args: CliArgs): Promise<void> {
       complete: completed,
       timedOut: !completed,
       success,
+      ...(sendResult.deduped ? { deduped: true } : {}),
     },
     payload: textOf(final),
   }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -704,10 +704,19 @@ async function cmdAsk(client: CliRpcClient, args: CliArgs): Promise<void> {
   // Attach the listener BEFORE sending so we can't miss the complete push.
   let completed = false
   let failed = false
+  // Sliding liveness deadline: each server heartbeat for THIS session pushes the
+  // wait out by another --ask-timeout window, so a long-but-alive turn (e.g. a
+  // 77s team spawn or a long generation) does not hit the cap. Set after send.
+  let livenessDeadline = 0
   const unsub = client.on('session:event', (event: unknown) => {
     const ev = event as { type: string; sessionId: string; error?: unknown }
     if (ev.sessionId !== sessionId) return
     switch (ev.type) {
+      case 'heartbeat':
+        // Turn is provably alive — extend the bounded wait. The hard ceiling
+        // below still bounds total wall-clock if heartbeats stop.
+        livenessDeadline = Date.now() + args.askTimeout
+        break
       case 'complete':
         completed = true
         break
@@ -758,9 +767,18 @@ async function cmdAsk(client: CliRpcClient, args: CliArgs): Promise<void> {
     process.exit(0)
   }
 
-  // Bounded wait — ALWAYS exits at the deadline, never an unbounded await.
-  const deadline = Date.now() + args.askTimeout
-  while (!completed && Date.now() < deadline) {
+  // Bounded wait — ALWAYS exits at a deadline, never an unbounded await.
+  // Two bounds, whichever fires first:
+  //   1. livenessDeadline — a sliding --ask-timeout window from the last server
+  //      heartbeat (initialized here from the send). A turn that keeps emitting
+  //      heartbeats keeps pushing this out, so legitimately-long turns don't time
+  //      out; if heartbeats STOP, it lapses one --ask-timeout window later.
+  //   2. hardCeiling — an absolute cap so even a misbehaving heartbeat storm
+  //      cannot await forever. Generous multiple of --ask-timeout.
+  const now = Date.now()
+  livenessDeadline = now + args.askTimeout
+  const hardCeiling = now + args.askTimeout * 10
+  while (!completed && Date.now() < livenessDeadline && Date.now() < hardCeiling) {
     await new Promise((r) => setTimeout(r, 100))
   }
   unsub()

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -285,6 +285,10 @@ export interface Message {
   isPending?: boolean;
   // Queued: user message that is waiting to be processed (sent during ongoing response)
   isQueued?: boolean;
+  // Caller-supplied idempotency key (from SendMessageOptions.idempotencyKey).
+  // Stamped onto the persisted user message so the in-memory dedupe map can be
+  // rebuilt from disk after a server restart (see SessionManager hydration).
+  idempotencyKey?: string;
   // Intermediate text (commentary between tool calls, not final response)
   isIntermediate?: boolean;
   // Turn ID: Correlation ID from the API's message.id, groups all messages in an assistant turn
@@ -410,6 +414,9 @@ export interface StoredMessage {
   authWorkspace?: string;
   // Queued: user message that is waiting to be processed (persisted for recovery)
   isQueued?: boolean;
+  // Caller-supplied idempotency key, persisted so the server's dedupe map can be
+  // rebuilt from disk after a restart (see SessionManager hydration).
+  idempotencyKey?: string;
 }
 
 /**

--- a/packages/server-core/src/handlers/rpc/sessions.ts
+++ b/packages/server-core/src/handlers/rpc/sessions.ts
@@ -214,12 +214,15 @@ export function registerSessionsHandlers(server: RpcServer, deps: HandlerDeps): 
     // Capture the caller's clientId for error routing
     const callerClientId = ctx.clientId
 
-    return await new Promise<{ accepted: true; messageId: string }>((resolve, reject) => {
+    return await new Promise<{ accepted: true; messageId: string; deduped?: boolean }>((resolve, reject) => {
       let acked = false
-      const onAck = (messageId: string) => {
+      // `deduped` is true when the server short-circuited a repeat send carrying
+      // the same options.idempotencyKey: messageId is the prior ack, no new turn
+      // was started. Backward compatible — callers ignoring the field are fine.
+      const onAck = (messageId: string, deduped?: boolean) => {
         if (!acked) {
           acked = true
-          resolve({ accepted: true, messageId })
+          resolve({ accepted: true, messageId, deduped })
         }
       }
 

--- a/packages/server-core/src/sessions/SessionManager.ts
+++ b/packages/server-core/src/sessions/SessionManager.ts
@@ -1936,6 +1936,9 @@ export class SessionManager implements ISessionManager {
     const stored = loadStoredSession(managed.workspace.rootPath, managed.id)
     if (stored) {
       managed.messages = (stored.messages || []).map(storedToMessage)
+      // Rebuild the idempotency dedupe map from disk (see rebuildIdempotencyResults)
+      // so server-enforced idempotency survives a restart on this path too.
+      this.rebuildIdempotencyResults(managed)
       managed.tokenUsage = stored.tokenUsage
       // Deferred-load fields (intentionally undefined after startup, see
       // loadSessionsFromDisk). Populate from disk only if not already set in
@@ -2428,6 +2431,11 @@ export class SessionManager implements ISessionManager {
       managed.transferredSessionSummaryApplied = storedSession.transferredSessionSummaryApplied
       sessionLog.debug(`Lazy-loaded ${managed.messages.length} messages for session ${managed.id}`)
 
+      // Rebuild the in-memory idempotency dedupe map from disk so a same-key
+      // retry that arrives AFTER a server restart still re-acks the original
+      // message instead of starting a fresh turn.
+      this.rebuildIdempotencyResults(managed)
+
       // Queue recovery: find orphaned queued messages from crash/restart and re-queue them
       const orphanedQueued = managed.messages.filter(m =>
         m.role === 'user' && m.isQueued === true
@@ -2453,6 +2461,27 @@ export class SessionManager implements ISessionManager {
       }
     }
     managed.messagesLoaded = true
+  }
+
+  /**
+   * Rebuild the per-session idempotency dedupe map (key -> messageId) from the
+   * messages just loaded from durable storage. Called from every session-load /
+   * hydrate path AFTER `managed.messages` is populated and BEFORE any new send
+   * can dedupe (sends go through ensureMessagesLoaded first). This makes
+   * server-enforced idempotency survive a restart: a persisted user message that
+   * carries an `idempotencyKey` repopulates the mapping it would have had in
+   * memory before the crash. If two persisted messages share a key (should not
+   * happen — the gate prevents a second persist), the earliest one wins, matching
+   * the in-memory "first send recorded, retries dedupe to it" semantics.
+   */
+  private rebuildIdempotencyResults(managed: ManagedSession): void {
+    for (const msg of managed.messages) {
+      if (msg.role !== 'user' || !msg.idempotencyKey) continue
+      managed.idempotencyResults ??= new Map()
+      if (!managed.idempotencyResults.has(msg.idempotencyKey)) {
+        managed.idempotencyResults.set(msg.idempotencyKey, msg.id)
+      }
+    }
   }
 
   /**
@@ -5535,6 +5564,9 @@ export class SessionManager implements ISessionManager {
         timestamp: this.monotonic(),
         attachments: storedAttachments,
         badges: options?.badges,
+        // Stamp the idempotency key so it round-trips to disk and the dedupe map
+        // can be rebuilt on session load after a restart.
+        ...(idempotencyKey ? { idempotencyKey } : {}),
       }
       managed.messages.push(userMessage)
 
@@ -5587,6 +5619,9 @@ export class SessionManager implements ISessionManager {
         timestamp: this.monotonic(),
         attachments: storedAttachments, // Include for persistence (has thumbnailBase64)
         badges: options?.badges,  // Include content badges (sources, skills with embedded icons)
+        // Stamp the idempotency key so it round-trips to disk and the dedupe map
+        // can be rebuilt on session load after a restart.
+        ...(idempotencyKey ? { idempotencyKey } : {}),
       }
       managed.messages.push(userMessage)
 

--- a/packages/server-core/src/sessions/SessionManager.ts
+++ b/packages/server-core/src/sessions/SessionManager.ts
@@ -771,6 +771,12 @@ interface ManagedSession {
   // Incremented each time a new message starts processing.
   // Used to detect if a follow-up message has superseded the current one (stale-request guard).
   processingGeneration: number
+  // Caller-supplied idempotency keys accepted during this session's in-memory
+  // lifetime -> the messageId we acked for them. A repeat send with the same key
+  // re-acks the prior messageId instead of starting a second turn (see sendMessage).
+  // Lives in memory: survives WS reconnects (server process unchanged) but NOT a
+  // server restart. Lazily created on first keyed send.
+  idempotencyResults?: Map<string, string>  // key -> messageId
   // NOTE: Parent-child tracking state (pendingTools, parentToolStack, toolToParentMap,
   // pendingTextParent) has been removed. CraftAgent now provides parentToolUseId
   // directly on all events using the SDK's authoritative parent_tool_use_id field.
@@ -5426,8 +5432,12 @@ export class SessionManager implements ISessionManager {
      * work begins. The RPC handler uses this to send a synchronous "accepted"
      * ack to the client so a crash mid-stream doesn't lose the user message
      * (#616). Pre-persist errors still reject the outer promise as before.
+     *
+     * `deduped` is true only when this ack is a replay of a prior send that
+     * carried the same idempotencyKey — no new user message was persisted and no
+     * model turn was started. Fresh sends ack with `deduped` falsy.
      */
-    onAck?: (messageId: string) => void,
+    onAck?: (messageId: string, deduped?: boolean) => void,
     /**
      * Optional transport context. The `sessions.sendMessage` RPC handler passes
      * `{ callerClientId: ctx.clientId }` so the SM can pin the desktop client
@@ -5441,6 +5451,30 @@ export class SessionManager implements ISessionManager {
       throw new Error(`Session ${sessionId} not found`)
     }
     this.setLastMessageClientId(sessionId, rpcContext?.callerClientId)
+
+    // Server-enforced idempotency. A caller-supplied key (options.idempotencyKey)
+    // dedupes a repeat send with the same {sessionId, key} BEFORE any persist or
+    // turn-start: we re-ack the prior messageId and return without running the
+    // model again. Lives in SessionManager (not the RPC handler) so EVERY caller
+    // — RPC and intra-server — is deduped. The mapping is recorded post-persist at
+    // each onAck site below. In-memory only (survives reconnects, not a restart);
+    // the realistic trigger is crash-and-retry (sequential), so a genuinely
+    // concurrent same-key double-send is a known v1 limitation.
+    //
+    // Gated on !existingMessageId: an internal queued-message replay
+    // (processNextQueuedMessage) re-enters sendMessage with the SAME options
+    // (hence same key) plus existingMessageId. That message was already acked +
+    // key-recorded at enqueue time and now needs to actually run the model, so it
+    // must NOT be treated as a duplicate. Only fresh external sends dedupe.
+    const idempotencyKey = options?.idempotencyKey
+    if (idempotencyKey && !existingMessageId) {
+      const prior = managed.idempotencyResults?.get(idempotencyKey)
+      if (prior) {
+        sessionLog.info(`sendMessage: deduped idempotency key ${idempotencyKey} -> ${prior} for ${sessionId}`)
+        onAck?.(prior, true)
+        return
+      }
+    }
 
     // Source-activation auto-retry dedup (craft-agents-oss#804). When the server
     // has just scheduled or committed a "[<slug> activated]" retry, drop a matching
@@ -5528,6 +5562,9 @@ export class SessionManager implements ISessionManager {
       // before we tell the renderer "accepted" — `persistSession` only
       // enqueues with a 500ms debounce. (#616 reliability fix.)
       await this.flushSession(managed.id)
+      // Record the idempotency mapping AFTER persist so a same-key retry that
+      // arrives later re-acks this message instead of starting a fresh turn.
+      if (idempotencyKey) (managed.idempotencyResults ??= new Map()).set(idempotencyKey, userMessage.id)
       onAck?.(userMessage.id)
       return
     }
@@ -5561,6 +5598,9 @@ export class SessionManager implements ISessionManager {
       // `persistSession` is debounced (500ms). #616.
       this.persistSession(managed)
       await this.flushSession(managed.id)
+      // Record the idempotency mapping AFTER persist so a same-key retry that
+      // arrives later re-acks this message instead of starting a fresh turn.
+      if (idempotencyKey) (managed.idempotencyResults ??= new Map()).set(idempotencyKey, userMessage.id)
       onAck?.(userMessage.id)
 
       // Emit user_message event so UI can confirm the optimistic message

--- a/packages/server-core/src/sessions/SessionManager.ts
+++ b/packages/server-core/src/sessions/SessionManager.ts
@@ -171,6 +171,12 @@ const MAX_ADMIN_REMEMBER_MINUTES = 60
 const MAX_ANNOTATIONS_PER_MESSAGE = 200
 const MAX_ANNOTATION_JSON_BYTES = 32 * 1024
 
+// Cadence of the in-turn liveness heartbeat (see startHeartbeat). Long-but-alive
+// turns (e.g. a 77s team spawn) emit this so clients can distinguish liveness
+// from a stall and extend their bounded wait. Kept well under typical client
+// ask-timeout windows so several heartbeats land before any deadline.
+const HEARTBEAT_INTERVAL_MS = 12_000
+
 // Window during which fs.watch metadata-revert events from our own atomic write
 // are ignored, so the watcher does not roll back the in-memory mutation we
 // just persisted. See onSessionMetadataChange.
@@ -766,6 +772,8 @@ interface ManagedSession {
   isProcessing: boolean
   /** Set when user requests stop - allows event loop to drain before clearing isProcessing */
   stopRequested?: boolean
+  /** Liveness heartbeat interval, running while isProcessing is true. Cleared on turn end. */
+  heartbeatTimer?: ReturnType<typeof setInterval>
   lastMessageAt: number
   streamingText: string
   // Incremented each time a new message starts processing.
@@ -1177,8 +1185,42 @@ export class SessionManager implements ISessionManager {
     managed.isProcessing = processing
     if (!was && processing) {
       sessionRuntimeHooks.onSessionStarted()
+      this.startHeartbeat(managed)
     } else if (was && !processing) {
       sessionRuntimeHooks.onSessionStopped()
+      this.stopHeartbeat(managed)
+    }
+  }
+
+  /**
+   * While a turn is in progress, emit a lightweight workspace-scoped liveness
+   * event every HEARTBEAT_INTERVAL_MS so a long-but-alive turn is provably
+   * distinct from a stall. Cleaned up on any turn end (complete / interrupted /
+   * error / timeout / plan+auth handoff) because every path routes through
+   * setProcessing(managed, false).
+   */
+  private startHeartbeat(managed: ManagedSession): void {
+    // Defensive: never leak a prior timer.
+    this.stopHeartbeat(managed)
+    managed.heartbeatTimer = setInterval(() => {
+      // Stop self if processing ended without setProcessing(false) somehow.
+      if (!managed.isProcessing) {
+        this.stopHeartbeat(managed)
+        return
+      }
+      this.sendEvent(
+        { type: 'heartbeat', sessionId: managed.id, ts: Date.now() },
+        managed.workspace.id,
+      )
+    }, HEARTBEAT_INTERVAL_MS)
+    // Don't keep the process alive solely for the heartbeat.
+    managed.heartbeatTimer.unref?.()
+  }
+
+  private stopHeartbeat(managed: ManagedSession): void {
+    if (managed.heartbeatTimer) {
+      clearInterval(managed.heartbeatTimer)
+      managed.heartbeatTimer = undefined
     }
   }
 

--- a/packages/shared/src/protocol/dto.ts
+++ b/packages/shared/src/protocol/dto.ts
@@ -218,8 +218,10 @@ export interface SendMessageOptions {
    * Caller-supplied idempotency key. When set, the server dedupes a repeat send
    * with the same {sessionId, idempotencyKey} BEFORE starting a turn: it re-acks
    * the prior messageId (with `deduped: true`) instead of persisting a second
-   * user message or running the model again. Survives reconnects within a server
-   * process lifetime; NOT a server restart (in-memory map). See SessionManager.
+   * user message or running the model again. The key is stamped onto the persisted
+   * user message (Message.idempotencyKey in @craft-agent/core), so the dedupe map
+   * is rebuilt from disk on session load and survives a server restart. See
+   * SessionManager.
    */
   idempotencyKey?: string
 }

--- a/packages/shared/src/protocol/dto.ts
+++ b/packages/shared/src/protocol/dto.ts
@@ -214,6 +214,14 @@ export interface SendMessageOptions {
   skillSlugs?: string[]
   badges?: ContentBadge[]
   optimisticMessageId?: string
+  /**
+   * Caller-supplied idempotency key. When set, the server dedupes a repeat send
+   * with the same {sessionId, idempotencyKey} BEFORE starting a turn: it re-acks
+   * the prior messageId (with `deduped: true`) instead of persisting a second
+   * user message or running the model again. Survives reconnects within a server
+   * process lifetime; NOT a server restart (in-memory map). See SessionManager.
+   */
+  idempotencyKey?: string
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/shared/src/protocol/dto.ts
+++ b/packages/shared/src/protocol/dto.ts
@@ -172,6 +172,7 @@ export type SessionEvent =
   | { type: 'error'; sessionId: string; error: string; timestamp?: number }
   | { type: 'typed_error'; sessionId: string; error: TypedError; timestamp?: number }
   | { type: 'complete'; sessionId: string; tokenUsage?: Session['tokenUsage']; hasUnread?: boolean }
+  | { type: 'heartbeat'; sessionId: string; ts: number }
   | { type: 'interrupted'; sessionId: string; message?: Message; queuedMessages?: string[] }
   | { type: 'status'; sessionId: string; message: string; statusType?: 'compacting' }
   | { type: 'info'; sessionId: string; message: string; statusType?: 'compaction_complete'; level?: 'info' | 'warning' | 'error' | 'success'; timestamp?: number }


### PR DESCRIPTION
A small, hang-proof **command channel** for `craft-cli` plus the server-side pieces that make
programmatic sends safe and observable. Built in layers; happy to split further if preferred.

### `craft-cli ask <sessionId> "<prompt>"`
Send a message and wait for the turn to complete, **without the `send` wait-loop hang**:
subscribe to the workspace-scoped `session:event` *before* sending, treat `complete` as a wake
signal, and **always** resolve the final reply from a durable `getMessages` read under a hard
wall-clock deadline (push-primary + bounded timeout + durable fallback — never an unbounded
await). `--json` emits a two-layer `{ control: {sessionId, messageId, complete, timedOut,
success, deduped?}, payload }`. Final-reply extraction uses `lastFinalMessageId` (with an
`isIntermediate`-skipping fallback) so team-spawn coordination tails don't get mistaken for the
answer.

### `craft-cli ensure-reviewer`
Resolve-or-create a MAX-tier session by label (`--label`, `--model`, `--connection` all
required), then **fail closed**: read back and assert model + `thinkingLevel === 'max'` rather
than silently returning a downgraded session.

### Server-enforced, persisted idempotency (`sessions:sendMessage`)
Optional `idempotencyKey` on `SendMessageOptions`: a repeat key short-circuits **before** a
second user message is persisted or a turn starts, re-acking the prior `messageId` with
`deduped: true`. The key is stamped onto the persisted message and **rehydrated on session
load**, so a crash-and-retry after a server restart still dedupes. Internal queued-message
replays are excluded (gated on an existing messageId) so they still run.

### Heartbeat liveness
The server emits a periodic `session:event` `heartbeat` while a turn is in progress; `ask`
slides its deadline on each heartbeat so a long-but-alive turn doesn't hit the cap, with a hard
ceiling so it can still never await forever.

### Notes
- Protocol additions: `SendMessageOptions.idempotencyKey`, `Message.idempotencyKey`, a
  `heartbeat` `session:event`. All optional/backward-compatible.
- Tested locally: build + typecheck clean; idempotency (same key → no second turn) and
  restart-persistence verified live against a running server.

> Draft — feedback welcome, especially on the protocol additions and whether to split into
> per-feature PRs.
