### PR TITLE
Honor CRAFT_CONFIG_DIR for app state paths

### DIFF
--- a/apps/electron/resources/bridge-mcp-server/index.js
+++ b/apps/electron/resources/bridge-mcp-server/index.js
@@ -17919,7 +17919,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 function getCredentialCachePath(workspaceId, sourceSlug) {
-  return join(homedir(), ".craft-agent", "workspaces", workspaceId, "sources", sourceSlug, ".credential-cache.json");
+  return join(process.env.CRAFT_CONFIG_DIR || join(homedir(), ".craft-agent"), "workspaces", workspaceId, "sources", sourceSlug, ".credential-cache.json");
 }
 function readCredential(workspaceId, sourceSlug) {
   const cachePath = getCredentialCachePath(workspaceId, sourceSlug);

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -85,6 +85,7 @@ import { createApplicationMenu } from './menu'
 import { WindowManager } from './window-manager'
 import { loadWindowState, saveWindowState } from './window-state'
 import { getWorkspaces, getWorkspaceByNameOrId, loadStoredConfig, addWorkspace, saveConfig } from '@craft-agent/shared/config'
+import { CONFIG_DIR } from '@craft-agent/shared/config/paths'
 import { getDefaultWorkspacesDir } from '@craft-agent/shared/workspaces'
 import { initializeDocs } from '@craft-agent/shared/docs'
 import { initializeReleaseNotes } from '@craft-agent/shared/release-notes'
@@ -645,7 +646,7 @@ app.whenReady().then(async () => {
             sessionManager: sm,
             credentialManager: getCredentialManager(),
             getMessagingDir: (wsId: string) =>
-              join(homedir(), '.craft-agent', 'workspaces', wsId, 'messaging'),
+              join(CONFIG_DIR, 'workspaces', wsId, 'messaging'),
             getLegacyMessagingDir: (wsId: string) => {
               const ws = getWorkspaces().find((w) => w.id === wsId)
               return ws ? join(ws.rootPath, 'messaging') : undefined

--- a/apps/electron/src/main/logger.ts
+++ b/apps/electron/src/main/logger.ts
@@ -1,7 +1,7 @@
 import log from 'electron-log/main'
 import { appendFileSync, existsSync, mkdirSync, renameSync, rmSync, statSync } from 'node:fs'
 import { dirname, join } from 'node:path'
-import { homedir } from 'node:os'
+import { CONFIG_DIR } from '@craft-agent/shared/config/paths'
 import type {
   MessagingLogContext,
   MessagingLogMeta,
@@ -81,7 +81,7 @@ export const searchLog = log.scope('search')
  * Kept outside the Electron-managed logs folder so messaging issues can be
  * inspected independently at a stable path across debug and production builds.
  */
-export const messagingGatewayLogPath = join(homedir(), '.craft-agent', 'logs', 'messaging-gateway.log')
+export const messagingGatewayLogPath = join(CONFIG_DIR, 'logs', 'messaging-gateway.log')
 const messagingGatewayBackupPath = `${messagingGatewayLogPath}.1`
 const MESSAGING_LOG_MAX_BYTES = 5 * 1024 * 1024 // 5MB
 

--- a/apps/electron/src/main/window-state.ts
+++ b/apps/electron/src/main/window-state.ts
@@ -2,7 +2,7 @@ import { writeFileSync, existsSync, mkdirSync } from 'fs'
 import { readJsonFileSync } from '@craft-agent/shared/utils/files'
 import { mainLog } from './logger'
 import { join } from 'path'
-import { homedir } from 'os'
+import { CONFIG_DIR } from '@craft-agent/shared/config/paths'
 
 export interface WindowBounds {
   x: number
@@ -29,7 +29,6 @@ export interface WindowState {
   lastFocusedWorkspaceId?: string
 }
 
-const CONFIG_DIR = join(homedir(), '.craft-agent')
 const WINDOW_STATE_FILE = join(CONFIG_DIR, 'window-state.json')
 
 /**

--- a/packages/server-core/src/handlers/rpc/auth.ts
+++ b/packages/server-core/src/handlers/rpc/auth.ts
@@ -1,8 +1,8 @@
 import { unlink } from 'fs/promises'
 import { join } from 'path'
-import { homedir } from 'os'
 import { RPC_CHANNELS } from '@craft-agent/shared/protocol'
 import { getCredentialManager } from '@craft-agent/shared/credentials'
+import { CONFIG_DIR } from '@craft-agent/shared/config/paths'
 import type { RpcServer } from '@craft-agent/server-core/transport'
 import type { HandlerDeps } from '../handler-deps'
 import { requestClientConfirmDialog } from '@craft-agent/server-core/transport'
@@ -59,7 +59,7 @@ export function registerAuthHandlers(server: RpcServer, deps: HandlerDeps): void
       }
 
       // Delete the config file
-      const configPath = join(homedir(), '.craft-agent', 'config.json')
+      const configPath = join(CONFIG_DIR, 'config.json')
       await unlink(configPath).catch(() => {
         // Ignore if file doesn't exist
       })

--- a/packages/server-core/src/handlers/rpc/workspace.ts
+++ b/packages/server-core/src/handlers/rpc/workspace.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs'
 import { join } from 'path'
-import { homedir } from 'os'
 import { RPC_CHANNELS } from '@craft-agent/shared/protocol'
 import { getWorkspaceByNameOrId, addWorkspace, setActiveWorkspace, updateWorkspaceRemoteServer } from '@craft-agent/shared/config'
+import { CONFIG_DIR } from '@craft-agent/shared/config/paths'
 import { perf } from '@craft-agent/shared/utils'
 import { pushTyped, type RpcServer } from '@craft-agent/server-core/transport'
 import type { HandlerDeps } from '../handler-deps'
@@ -60,7 +60,7 @@ export function registerWorkspaceCoreHandlers(server: RpcServer, deps: HandlerDe
 
   // Check if a workspace slug already exists (for validation before creation)
   server.handle(RPC_CHANNELS.workspaces.CHECK_SLUG, async (_ctx, slug: string) => {
-    const defaultWorkspacesDir = join(homedir(), '.craft-agent', 'workspaces')
+    const defaultWorkspacesDir = join(CONFIG_DIR, 'workspaces')
     const workspacePath = join(defaultWorkspacesDir, slug)
     const exists = existsSync(workspacePath)
     return { exists, path: workspacePath }

--- a/packages/server-core/src/services/privileged-execution-broker.ts
+++ b/packages/server-core/src/services/privileged-execution-broker.ts
@@ -1,8 +1,8 @@
 import { createHash } from 'node:crypto'
 import { appendFile, mkdir } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
-import { homedir } from 'node:os'
 import type { Logger } from '../runtime/platform'
+import { CONFIG_DIR } from '@craft-agent/shared/config/paths'
 
 export interface PrivilegedExecutionRequest {
   requestId: string
@@ -22,7 +22,7 @@ interface PendingPrivilegedRequest extends PrivilegedExecutionRequest {
 }
 
 const DEFAULT_APPROVAL_TTL_SECONDS = 120
-const AUDIT_LOG_PATH = join(homedir(), '.craft-agent', 'logs', 'privileged-actions.jsonl')
+const AUDIT_LOG_PATH = join(CONFIG_DIR, 'logs', 'privileged-actions.jsonl')
 
 /**
  * PrivilegedExecutionBroker

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -26,7 +26,6 @@
  */
 
 import { join } from 'node:path'
-import { homedir } from 'node:os'
 import { readFileSync, existsSync } from 'node:fs'
 import { version as packageVersion } from '../package.json'
 import { enableDebug } from '@craft-agent/shared/utils/debug'
@@ -35,6 +34,7 @@ import { validateSession, createWebuiHandler, nodeHttpAdapter } from '@craft-age
 import type { WebuiHandler } from '@craft-agent/server-core/webui'
 import { getCredentialManager } from '@craft-agent/shared/credentials'
 import { getWorkspaces } from '@craft-agent/shared/config'
+import { CONFIG_DIR } from '@craft-agent/shared/config/paths'
 import { createMessagingBootstrap, type MessagingBootstrapHandle } from '@craft-agent/messaging-gateway'
 
 // --generate-token: print a crypto-random token and exit
@@ -211,7 +211,7 @@ const instance = await (async () => {
           sessionManager,
           credentialManager: getCredentialManager(),
           getMessagingDir: (wsId: string) =>
-            join(homedir(), '.craft-agent', 'workspaces', wsId, 'messaging'),
+            join(CONFIG_DIR, 'workspaces', wsId, 'messaging'),
           // Headless has no legacy messaging dir — workspaces start clean.
           whatsapp: {
             workerEntry: waWorkerEntry,

--- a/packages/session-tools-core/src/handlers/config-validate.ts
+++ b/packages/session-tools-core/src/handlers/config-validate.ts
@@ -35,7 +35,7 @@ export async function handleConfigValidate(
   args: ConfigValidateArgs
 ): Promise<ToolResult> {
   const { target, sourceSlug } = args;
-  const craftAgentRoot = join(homedir(), '.craft-agent');
+  const craftAgentRoot = process.env.CRAFT_CONFIG_DIR || join(homedir(), '.craft-agent');
 
   // If full validators available (Claude), use them
   if (ctx.validators) {

--- a/packages/shared/src/agent/core/prerequisite-manager.ts
+++ b/packages/shared/src/agent/core/prerequisite-manager.ts
@@ -11,10 +11,10 @@
  */
 
 import { existsSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { resolve, join } from 'node:path';
 import { expandPath } from './path-processor.ts';
 import { getBrowserToolEnabled } from '../../config/storage.ts';
+import { CONFIG_DIR } from '../../config/paths.ts';
 
 // ============================================================
 // Types
@@ -49,7 +49,7 @@ export interface PrerequisiteManagerConfig {
 const EXEMPT_SLUGS = new Set(['session', 'craft-agents-docs']);
 
 /** Global browser tools docs path required before browser tool usage. */
-const BROWSER_TOOLS_DOC_PATH = resolve(join(homedir(), '.craft-agent', 'docs', 'browser-tools.md'));
+const BROWSER_TOOLS_DOC_PATH = resolve(join(CONFIG_DIR, 'docs', 'browser-tools.md'));
 
 // ============================================================
 // Rules

--- a/packages/shared/src/credentials/backends/secure-storage.ts
+++ b/packages/shared/src/credentials/backends/secure-storage.ts
@@ -39,9 +39,10 @@ import { join, dirname } from 'path';
 import type { CredentialBackend } from './types.ts';
 import type { CredentialId, StoredCredential } from '../types.ts';
 import { credentialIdToAccount, accountToCredentialId } from '../types.ts';
+import { CONFIG_DIR } from '../../config/paths.ts';
 
 // File location
-const CREDENTIALS_DIR = join(homedir(), '.craft-agent');
+const CREDENTIALS_DIR = CONFIG_DIR;
 const CREDENTIALS_FILE = join(CREDENTIALS_DIR, 'credentials.enc');
 
 // File format constants

--- a/packages/shared/src/docs/index.ts
+++ b/packages/shared/src/docs/index.ts
@@ -9,12 +9,11 @@
  */
 
 import { join } from 'path';
-import { homedir } from 'os';
 import { existsSync, mkdirSync, writeFileSync, readdirSync, readFileSync } from 'fs';
 import { getBundledAssetsDir } from '../utils/paths.ts';
 import { debug } from '../utils/debug.ts';
+import { CONFIG_DIR } from '../config/paths.ts';
 
-const CONFIG_DIR = join(homedir(), '.craft-agent');
 const DOCS_DIR = join(CONFIG_DIR, 'docs');
 
 // Track if docs have been initialized this session (prevents re-init on hot reload)

--- a/packages/shared/src/interceptor-common.ts
+++ b/packages/shared/src/interceptor-common.ts
@@ -10,8 +10,8 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync, appendFileSync, mkdirSync, statSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { CONFIG_DIR } from './config/paths.ts';
 
 // ============================================================================
 // CONSTANTS
@@ -27,7 +27,7 @@ export const DEBUG = INTERCEPTOR_LOGGING_ENABLED &&
   (process.argv.includes('--debug') || process.env.CRAFT_DEBUG === '1');
 
 /** Config file path for reading settings in the SDK subprocess */
-export const CONFIG_FILE = join(homedir(), '.craft-agent', 'config.json');
+export const CONFIG_FILE = join(CONFIG_DIR, 'config.json');
 
 /** Session directory — set by env var (subprocess) or setSessionDir() (main process) */
 let _sessionDir: string | null = process.env.CRAFT_SESSION_DIR || null;
@@ -36,7 +36,7 @@ let _sessionDir: string | null = process.env.CRAFT_SESSION_DIR || null;
 // LOGGING
 // ============================================================================
 
-export const LOG_DIR = join(homedir(), '.craft-agent', 'logs');
+export const LOG_DIR = join(CONFIG_DIR, 'logs');
 export const LOG_FILE = join(LOG_DIR, 'interceptor.log');
 
 // Ensure log directory exists at module load
@@ -171,7 +171,7 @@ function getErrorFilePath(): string {
   // Prefer session-scoped file to avoid cross-session error consumption.
   if (_sessionDir) return join(_sessionDir, 'api-error.json');
   // Fallback for legacy/non-session contexts.
-  return join(homedir(), '.craft-agent', 'api-error.json');
+  return join(CONFIG_DIR, 'api-error.json');
 }
 
 function getStoredError(sessionDir?: string): LastApiError | null {

--- a/packages/shared/src/release-notes/index.ts
+++ b/packages/shared/src/release-notes/index.ts
@@ -8,12 +8,11 @@
  */
 
 import { join } from 'path';
-import { homedir } from 'os';
 import { existsSync, mkdirSync, writeFileSync, readdirSync, readFileSync } from 'fs';
 import { getBundledAssetsDir } from '../utils/paths.ts';
 import { debug } from '../utils/debug.ts';
+import { CONFIG_DIR } from '../config/paths.ts';
 
-const CONFIG_DIR = join(homedir(), '.craft-agent');
 const RELEASE_NOTES_DIR = join(CONFIG_DIR, 'release-notes');
 
 let releaseNotesInitialized = false;

--- a/packages/shared/src/utils/logo.ts
+++ b/packages/shared/src/utils/logo.ts
@@ -6,14 +6,13 @@
  */
 
 import { debug } from './debug.ts';
-import { homedir } from 'os';
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { readJsonFileSync } from './files.ts';
+import { CONFIG_DIR } from '../config/paths.ts';
 
 // Cache path for persisted provider domains
-const CRAFT_AGENT_DIR = join(homedir(), '.craft-agent');
-const PROVIDER_DOMAINS_CACHE_PATH = join(CRAFT_AGENT_DIR, 'provider-domains.json');
+const PROVIDER_DOMAINS_CACHE_PATH = join(CONFIG_DIR, 'provider-domains.json');
 
 // Google Favicon V2 API - free, reliable, no API key needed
 // Updated URL: Google migrated from /s2/favicons to faviconV2

--- a/packages/shared/src/workspaces/storage.ts
+++ b/packages/shared/src/workspaces/storage.ts
@@ -16,13 +16,13 @@ import {
   statSync,
 } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
 import { randomUUID } from 'crypto';
 import { expandPath, toPortablePath } from '../utils/paths.ts';
 import { atomicWriteFileSync, readJsonFileSync } from '../utils/files.ts';
 import { getDefaultStatusConfig, saveStatusConfig, ensureDefaultIconFiles } from '../statuses/storage.ts';
 import { getDefaultLabelConfig, saveLabelConfig } from '../labels/storage.ts';
 import { loadConfigDefaults } from '../config/storage.ts';
+import { CONFIG_DIR } from '../config/paths.ts';
 import { parsePermissionMode, PERMISSION_MODE_ORDER } from '../agent/mode-types.ts';
 import { normalizeThinkingLevel } from '../agent/thinking-levels.ts';
 import type {
@@ -32,7 +32,6 @@ import type {
   WorkspaceSummary,
 } from './types.ts';
 
-const CONFIG_DIR = join(homedir(), '.craft-agent');
 const DEFAULT_WORKSPACES_DIR = join(CONFIG_DIR, 'workspaces');
 
 // ============================================================


### PR DESCRIPTION
## Summary
- Route Craft-owned app state paths through `CONFIG_DIR` / `CRAFT_CONFIG_DIR` instead of hardcoded `~/.craft-agent` paths.
- Covers credentials, logs, window state, workspace defaults, docs/release notes, messaging state, and related config validation/cache paths.
- Keeps OS home directory usage for actual user-home behavior separate from app-state storage.

## Validation
- `cd packages/shared && bun run tsc --noEmit`
- `cd packages/server-core && bun run tsc --noEmit`
- `cd packages/server && bun run tsc --noEmit`
- `cd apps/electron && bun run typecheck`

## Note
- `bun run typecheck:all` currently fails on upstream `main` before this patch reaches the changed app-state paths because `packages/session-tools-core` extends a missing `tsconfig.base.json` and has an existing `validation.ts` narrowing error.