### PR TITLE
fix(sessions): register branch session before browser-pane gate

### DIFF
--- a/apps/electron/src/main/__tests__/session-branch-rollback.isolated.ts
+++ b/apps/electron/src/main/__tests__/session-branch-rollback.isolated.ts
@@ -107,6 +107,12 @@ mock.module('@craft-agent/shared/config', () => ({
   touchLlmConnection: async () => {},
   isCompatProvider: () => false,
   isAnthropicProvider: () => true,
+  defaultMidStreamBehavior: (providerType: string) => (providerType === 'anthropic' ? 'queue' : 'steer'),
+  resolveMidStreamBehavior: () => 'queue',
+  resetManagedAnthropicAuthEnvVars: () => {},
+  loadPreferences: () => ({}),
+  modelSupportsImages: () => true,
+  getModelsForProviderType: () => [],
 }))
 
 mock.module('@craft-agent/shared/workspaces', () => ({
@@ -365,5 +371,38 @@ describe('session branch rollback on preflight failure', () => {
     expect(getOrCreateAgentCalled).toBe(true)
     expect(deletedIds).toEqual(['child-1'])
     expect(storedById.has('child-1')).toBe(false)
+  })
+
+  // Regression: the child must be registered in this.sessions BEFORE branch
+  // preflight runs getOrCreateAgent(). Otherwise the browser-pane gate resolves
+  // a remote BrowserPaneManager via this.sessions.get(id), finds nothing, and
+  // throws "Browser pane manager unavailable despite passing the gate" under
+  // rpcServer (remote) deployments. See SessionManager.createSession ordering.
+  it('registers the child session before branch preflight invokes getOrCreateAgent', async () => {
+    const manager = new SessionManager()
+
+    let registeredAtPreflight: boolean | undefined
+
+    ;(manager as any).ensureMessagesLoaded = async (_managed: any) => {}
+    ;(manager as any).getOrCreateAgent = async (managed: any) => {
+      registeredAtPreflight = (manager as any).sessions.has(managed.id)
+      managed.poolServer = { stop: () => {} }
+      managed.agent = {
+        supportsBranching: true,
+        ensureBranchReady: async () => {},
+        destroy: () => {},
+      }
+      return managed.agent
+    }
+
+    const session = await manager.createSession('ws-1', {
+      branchFromSessionId: 'source-1',
+      branchFromMessageId: 'm1',
+    } as any)
+
+    expect(registeredAtPreflight).toBe(true)
+    expect(session.id).toBe('child-1')
+    expect((manager as any).sessions.has('child-1')).toBe(true)
+    expect(deletedIds).toEqual([])
   })
 })

--- a/bun.lock
+++ b/bun.lock
@@ -115,7 +115,7 @@
     },
     "apps/cli": {
       "name": "@craft-agent/cli",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "bin": {
         "craft-cli": "src/index.ts",
       },
@@ -131,7 +131,7 @@
     },
     "apps/electron": {
       "name": "@craft-agent/electron",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/messaging-gateway": "workspace:*",
@@ -178,32 +178,9 @@
         "@types/ws": "^8.18.1",
       },
     },
-    "apps/marketing": {
-      "name": "@craft-agent/marketing",
-      "version": "0.9.4",
-      "dependencies": {
-        "@craft-agent/ui": "workspace:*",
-        "@paper-design/shaders-react": "^0.0.70",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-router-dom": "^7.13.0",
-        "shiki": "^3.21.0",
-        "three": "^0.170.0",
-      },
-      "devDependencies": {
-        "@tailwindcss/vite": "^4.1.18",
-        "@types/react": "^18.3.0",
-        "@types/react-dom": "^18.3.0",
-        "@types/three": "^0.170.0",
-        "@vitejs/plugin-react": "^5.1.2",
-        "tailwindcss": "^4.1.18",
-        "typescript": "^5.0.0",
-        "vite": "^6.2.4",
-      },
-    },
     "apps/viewer": {
       "name": "@craft-agent/viewer",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/ui": "workspace:*",
@@ -231,7 +208,7 @@
     },
     "apps/webui": {
       "name": "@craft-agent/webui",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "dependencies": {
         "@craft-agent/shared": "workspace:*",
         "@craft-agent/ui": "workspace:*",
@@ -246,7 +223,7 @@
     },
     "packages/core": {
       "name": "@craft-agent/core",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "devDependencies": {
         "@types/uuid": "^11.0.0",
       },
@@ -255,32 +232,9 @@
         "@modelcontextprotocol/sdk": ">=1.0.0",
       },
     },
-    "packages/craft-agents-commands": {
-      "name": "@craft-agent/craft-agents-commands",
-      "version": "0.9.4",
-      "dependencies": {
-        "@craft-agent/shared": "workspace:*",
-      },
-      "devDependencies": {
-        "@types/bun": "latest",
-        "@types/node": "^25.0.8",
-      },
-    },
-    "packages/craft-cli": {
-      "name": "@craft-agent/craft-cli",
-      "version": "0.9.4",
-      "dependencies": {
-        "@craft-agent/craft-agents-commands": "workspace:*",
-        "@craft-agent/shared": "workspace:*",
-      },
-      "devDependencies": {
-        "@types/bun": "latest",
-        "@types/node": "^25.0.8",
-      },
-    },
     "packages/messaging-gateway": {
       "name": "@craft-agent/messaging-gateway",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/messaging-whatsapp-worker": "workspace:*",
@@ -296,7 +250,7 @@
     },
     "packages/messaging-whatsapp-worker": {
       "name": "@craft-agent/messaging-whatsapp-worker",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "dependencies": {
         "@whiskeysockets/baileys": "^6.7.0",
       },
@@ -307,7 +261,7 @@
     },
     "packages/pi-agent-server": {
       "name": "@craft-agent/pi-agent-server",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "bin": {
         "pi-agent-server": "./dist/index.js",
       },
@@ -327,7 +281,7 @@
     },
     "packages/server": {
       "name": "@craft-agent/server",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "bin": {
         "craft-server": "src/index.ts",
       },
@@ -345,7 +299,7 @@
     },
     "packages/server-core": {
       "name": "@craft-agent/server-core",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/shared": "workspace:*",
@@ -361,7 +315,7 @@
     },
     "packages/session-mcp-server": {
       "name": "@craft-agent/session-mcp-server",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "bin": {
         "session-mcp-server": "./dist/index.js",
       },
@@ -377,7 +331,7 @@
     },
     "packages/session-tools-core": {
       "name": "@craft-agent/session-tools-core",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "dependencies": {
         "beautiful-mermaid": "*",
         "gray-matter": "^4.0.3",
@@ -390,7 +344,7 @@
     },
     "packages/shared": {
       "name": "@craft-agent/shared",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/session-tools-core": "workspace:*",
@@ -420,7 +374,7 @@
     },
     "packages/ui": {
       "name": "@craft-agent/ui",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "dependencies": {
         "@craft-agent/core": "workspace:*",
         "@craft-agent/shared": "workspace:*",
@@ -682,13 +636,7 @@
 
     "@craft-agent/core": ["@craft-agent/core@workspace:packages/core"],
 
-    "@craft-agent/craft-agents-commands": ["@craft-agent/craft-agents-commands@workspace:packages/craft-agents-commands"],
-
-    "@craft-agent/craft-cli": ["@craft-agent/craft-cli@workspace:packages/craft-cli"],
-
     "@craft-agent/electron": ["@craft-agent/electron@workspace:apps/electron"],
-
-    "@craft-agent/marketing": ["@craft-agent/marketing@workspace:apps/marketing"],
 
     "@craft-agent/messaging-gateway": ["@craft-agent/messaging-gateway@workspace:packages/messaging-gateway"],
 
@@ -1560,8 +1508,6 @@
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
-    "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
-
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -1636,11 +1582,7 @@
 
     "@types/shell-quote": ["@types/shell-quote@1.7.5", "", {}, "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw=="],
 
-    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
-
     "@types/tedious": ["@types/tedious@4.0.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
-
-    "@types/three": ["@types/three@0.170.0", "", { "dependencies": { "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": "*", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~0.18.1" } }, "sha512-CUm2uckq+zkCY7ZbFpviRttY+6f9fvwm6YqSqPfA5K22s9w7R4VnA3rzJse8kHVvuzLcTx+CjNCs2NYe0QFAyg=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -1649,8 +1591,6 @@
     "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
     "@types/verror": ["@types/verror@1.10.11", "", {}, "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg=="],
-
-    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -1693,8 +1633,6 @@
     "@wasm-audio-decoders/ogg-vorbis": ["@wasm-audio-decoders/ogg-vorbis@0.1.20", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7", "codec-parser": "2.5.0" } }, "sha512-zaQPasU5usRjUDXtXOHYED5tfkR4QMXd+EH3Nrz1+4+M5pCsdD+s9YxJqb0oqnTyRu/KUujOmu5Z/m/NT47vwg=="],
 
     "@wasm-audio-decoders/opus-ml": ["@wasm-audio-decoders/opus-ml@0.0.2", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-58rWEqDGg+CKCyEeKm2KoxxSwTWtHh/NLTW9ObR4K8CGF6VwuuGudEI1CtniS/oSRmL1nJq/eh8MKARiluw4DQ=="],
-
-    "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
 
     "@whiskeysockets/baileys": ["@whiskeysockets/baileys@6.17.16", "", { "dependencies": { "@adiwajshing/keyed-db": "^0.2.4", "@cacheable/node-cache": "^1.4.0", "@hapi/boom": "^9.1.3", "@whiskeysockets/eslint-config": "github:whiskeysockets/eslint-config", "async-lock": "^1.4.1", "audio-decode": "^2.1.3", "axios": "^1.6.0", "cache-manager": "^5.7.6", "libphonenumber-js": "^1.10.20", "libsignal": "github:WhiskeySockets/libsignal-node", "lodash": "^4.17.21", "music-metadata": "^7.12.3", "pino": "^9.6", "protobufjs": "^7.2.4", "uuid": "^10.0.0", "ws": "^8.13.0" }, "peerDependencies": { "jimp": "^0.16.1", "link-preview-js": "^3.0.0", "qrcode-terminal": "^0.12.0", "sharp": "^0.32.6" }, "optionalPeers": ["jimp", "link-preview-js", "qrcode-terminal", "sharp"] }, "sha512-cZoUaKpO4fsDUNiCtyZfbjkW0Bjl/IudzHLCvpqfqtq5TACQzNynYsYdKPJz1I8Cu/SSEvmewk0RorIs0zDWyw=="],
 
@@ -2782,8 +2720,6 @@
 
     "merge-refs": ["merge-refs@2.0.0", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg=="],
 
-    "meshoptimizer": ["meshoptimizer@0.18.1", "", {}, "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw=="],
-
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
@@ -3206,10 +3142,6 @@
 
     "react-resizable-panels": ["react-resizable-panels@3.0.6", "", { "peerDependencies": { "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew=="],
 
-    "react-router": ["react-router@7.13.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw=="],
-
-    "react-router-dom": ["react-router-dom@7.13.0", "", { "dependencies": { "react-router": "7.13.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g=="],
-
     "react-simple-code-editor": ["react-simple-code-editor@0.14.1", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-BR5DtNRy+AswWJECyA17qhUDvrrCZ6zXOCfkQY5zSmb96BVUbpVAv03WpcjcwtCwiLbIANx3gebHOcXYn1EHow=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
@@ -3321,8 +3253,6 @@
     "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -3471,8 +3401,6 @@
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
     "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
-
-    "three": ["three@0.170.0", "", {}, "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ=="],
 
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
 
@@ -3870,12 +3798,6 @@
 
     "@craft-agent/cli/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
 
-    "@craft-agent/craft-agents-commands/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
-
-    "@craft-agent/craft-cli/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
-
-    "@craft-agent/marketing/@paper-design/shaders-react": ["@paper-design/shaders-react@0.0.70", "", { "dependencies": { "@paper-design/shaders": "0.0.70" }, "peerDependencies": { "@types/react": "^18 || ^19", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-9DkZXcyehorsZzyWnYV3OOO1i7rF7a5CkasjKJ1h1tLlY3JJLUEX9W+gZz7JgWHyvCimUu0OSq1sbHTb2OntRw=="],
-
     "@craft-agent/messaging-gateway/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
 
     "@craft-agent/messaging-whatsapp-worker/@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
@@ -4240,8 +4162,6 @@
 
     "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
-    "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
-
     "read-pkg-up/find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "^2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
 
     "readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
@@ -4493,12 +4413,6 @@
     "@craft-agent/cli/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "@craft-agent/cli/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
-
-    "@craft-agent/craft-agents-commands/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
-
-    "@craft-agent/craft-cli/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
-
-    "@craft-agent/marketing/@paper-design/shaders-react/@paper-design/shaders": ["@paper-design/shaders@0.0.70", "", {}, "sha512-d9LQcmPoEm3+Y6Vuz7cvsnSelfTM5QD63yQ3ddLM7QGYfoSjbQiU38kzjA4O3oCQ6zv23o/IGvGA8k9S/L+kZw=="],
 
     "@craft-agent/messaging-gateway/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/packages/server-core/src/domain/connection-setup-logic.ts
+++ b/packages/server-core/src/domain/connection-setup-logic.ts
@@ -147,6 +147,11 @@ export const BUILT_IN_CONNECTION_TEMPLATES: Record<string, {
     providerType: 'anthropic',
     authType: 'oauth',
   },
+  'claude-code-env': {
+    name: 'Claude Code (SDK self-auth)',
+    providerType: 'anthropic',
+    authType: 'environment',
+  },
   'chatgpt-plus': {
     name: 'ChatGPT Plus',
     providerType: 'pi',

--- a/packages/server-core/src/model-fetchers/index.ts
+++ b/packages/server-core/src/model-fetchers/index.ts
@@ -164,6 +164,11 @@ class ModelRefreshService {
       const fetcher = this.fetchers[providerType]
       if (!fetcher) continue
 
+      // SDK self-auth: credentials live in the agent subprocess's env, not in
+      // the server. Auto-refresh has no key to call /v1/models with and would
+      // emit hourly WARNs. Manual refreshNow() still attempts.
+      if (conn.authType === 'environment') continue
+
       // Immediate non-blocking fetch
       this.refreshConnection(conn.slug).catch(err => {
         handlerLog.warn(`Initial model refresh failed for ${conn.slug}: ${err instanceof Error ? err.message : err}`)
@@ -203,6 +208,8 @@ class ModelRefreshService {
     // Ensure periodic timer is running
     const connection = getLlmConnection(slug)
     if (!connection || isCompatProvider(connection.providerType)) return
+    // SDK self-auth: see startAll() comment — skip timer install.
+    if (connection.authType === 'environment') return
 
     const providerType = connection.providerType as FetchableProvider
     const fetcher = this.fetchers[providerType]

--- a/packages/server-core/src/sessions/SessionManager.ts
+++ b/packages/server-core/src/sessions/SessionManager.ts
@@ -2822,6 +2822,13 @@ export class SessionManager implements ISessionManager {
       messagesLoaded: !isBranch,  // Branched sessions: lazy-load messages from JSONL
     })
 
+    // Register the session before branch preflight runs getOrCreateAgent(): the
+    // browser-pane gate resolves a remote BrowserPaneManager via
+    // this.sessions.get(id), so an unregistered session trips the "passed the
+    // gate" guard under rpcServer (remote) deployments. rollbackFailedBranchCreation
+    // removes it again if preflight fails.
+    this.sessions.set(storedSession.id, managed)
+
     // Eagerly load messages for branched sessions so the renderer gets the full
     // conversation immediately (needed for scroll-to-bottom on panel open)
     if (isBranch) {
@@ -2874,8 +2881,6 @@ export class SessionManager implements ISessionManager {
     if (managed.previousPermissionMode) {
       hydratePreviousPermissionMode(storedSession.id, managed.previousPermissionMode)
     }
-
-    this.sessions.set(storedSession.id, managed)
 
     // Initialize session metadata in AutomationSystem for diffing
     const automationSystem = this.automationSystems.get(workspaceRootPath)

--- a/packages/shared/src/agent/claude-agent.ts
+++ b/packages/shared/src/agent/claude-agent.ts
@@ -1,5 +1,6 @@
 import { query, createSdkMcpServer, tool, AbortError, type Query, type SDKUserMessage, type SDKAssistantMessageError, type Options } from '@anthropic-ai/claude-agent-sdk';
 import { getDefaultOptions, resetClaudeConfigCheck } from './options.ts';
+import { discoverEnabledClaudePlugins } from './claude-plugins.ts';
 // Local type for SDK user message content blocks (text, image, document)
 // Replaces import from @anthropic-ai/sdk/resources — keeps SDK as agent-only dependency
 type ContentBlockParam =
@@ -1345,9 +1346,11 @@ export class ClaudeAgent extends BaseAgent {
         },
         // Selectively disable tools - file tools are disabled (use MCP), web/code controlled by settings
         disallowedTools,
-        // No plugins — skills are handled by BaseAgent.chat() via read-before-execute
-        // (the model reads SKILL.md files directly, enforced by PrerequisiteManager)
-        plugins: [],
+        // Load CLI-installed plugins enabled via ~/.claude/settings.json (enabledPlugins).
+        // Plugin skills bypass craft's PrerequisiteManager read-before-execute — they're
+        // surfaced through the SDK's own plugin namespace (`<plugin>:<skill>`), not the
+        // [skill:slug] syntax. Set CRAFT_DISABLE_CLAUDE_PLUGINS=1 to opt out.
+        plugins: discoverEnabledClaudePlugins(),
       };
 
       // Capture the binary path the SDK will actually use (Electron-bundled custom

--- a/packages/shared/src/agent/claude-agent.ts
+++ b/packages/shared/src/agent/claude-agent.ts
@@ -867,7 +867,15 @@ export class ClaudeAgent extends BaseAgent {
       // - EnterPlanMode/ExitPlanMode: We use safe mode instead (user-controlled via UI)
       // - AskUserQuestion: Requires interactive UI to show question options to user
       // Note: Mini agents use a minimal tool list directly, so no additional blocking needed
-      const disallowedTools: string[] = ['EnterPlanMode', 'ExitPlanMode', 'AskUserQuestion', 'Skill'];
+      //
+      // `Skill` is intentionally allowed (paired with the discoverEnabledClaudePlugins()
+      // patch above): without it, plugin-provided SKILL.md files load into the model's
+      // context but the model has no way to invoke them. Trade-off: plugin skills bypass
+      // craft's PrerequisiteManager read-before-execute gate that protects craft-native
+      // `[skill:slug]` invocations. Acceptable here because plugins are user-installed
+      // and inspected via the marketplace; toggle off by adding `'Skill'` back if a
+      // stricter policy is required.
+      const disallowedTools: string[] = ['EnterPlanMode', 'ExitPlanMode', 'AskUserQuestion'];
 
       // Build MCP servers config
       // Mini agents: only session tools (config_validate) to minimize token usage

--- a/packages/shared/src/agent/claude-plugins.ts
+++ b/packages/shared/src/agent/claude-plugins.ts
@@ -1,0 +1,75 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import type { Options } from '@anthropic-ai/claude-agent-sdk';
+import { debug } from '../utils/debug.ts';
+
+type SdkPluginConfig = NonNullable<Options['plugins']>[number];
+
+interface InstalledPluginEntry {
+  scope: 'user' | 'project';
+  installPath: string;
+  version: string;
+}
+
+interface InstalledPluginsFile {
+  version: number;
+  plugins: Record<string, InstalledPluginEntry[]>;
+}
+
+interface ClaudeSettingsFile {
+  enabledPlugins?: Record<string, boolean>;
+}
+
+/**
+ * Discover plugins installed via the Claude Code CLI marketplace.
+ *
+ * Reads:
+ *   $CLAUDE_CONFIG_DIR/plugins/installed_plugins.json  (install paths)
+ *   $CLAUDE_CONFIG_DIR/settings.json                   (enabledPlugins map)
+ *
+ * Returns SdkPluginConfig[] suitable for the SDK's `plugins` option.
+ * Silently returns [] on any read/parse error so the agent still boots.
+ *
+ * Set CRAFT_DISABLE_CLAUDE_PLUGINS=1 to force-disable (CI / multi-tenant).
+ */
+export function discoverEnabledClaudePlugins(): SdkPluginConfig[] {
+  if (process.env.CRAFT_DISABLE_CLAUDE_PLUGINS === '1') {
+    debug('[claude-plugins] disabled by CRAFT_DISABLE_CLAUDE_PLUGINS=1');
+    return [];
+  }
+
+  try {
+    const claudeHome = process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), '.claude');
+    const installedFile = join(claudeHome, 'plugins', 'installed_plugins.json');
+    const settingsFile = join(claudeHome, 'settings.json');
+
+    if (!existsSync(installedFile)) {
+      debug('[claude-plugins] no installed_plugins.json — skipping plugin load');
+      return [];
+    }
+
+    const installed = JSON.parse(readFileSync(installedFile, 'utf8')) as InstalledPluginsFile;
+    const enabled: Record<string, boolean> = existsSync(settingsFile)
+      ? (JSON.parse(readFileSync(settingsFile, 'utf8')) as ClaudeSettingsFile).enabledPlugins ?? {}
+      : {};
+
+    const result: SdkPluginConfig[] = [];
+    for (const [pluginKey, entries] of Object.entries(installed.plugins ?? {})) {
+      if (enabled[pluginKey] !== true) continue;
+      const entry = entries[0];
+      if (!entry?.installPath) continue;
+      if (!existsSync(join(entry.installPath, '.claude-plugin', 'plugin.json'))) {
+        debug(`[claude-plugins] manifest missing for ${pluginKey} at ${entry.installPath}`);
+        continue;
+      }
+      result.push({ type: 'local', path: entry.installPath });
+    }
+
+    debug(`[claude-plugins] loading ${result.length} enabled plugins: ${result.map(p => p.path).join(', ')}`);
+    return result;
+  } catch (err) {
+    debug('[claude-plugins] discovery failed:', err);
+    return [];
+  }
+}

--- a/packages/shared/src/config/llm-connections.ts
+++ b/packages/shared/src/config/llm-connections.ts
@@ -723,7 +723,7 @@ export function isValidProviderAuthCombination(
   authType: LlmAuthType
 ): boolean {
   const validCombinations: Record<LlmProviderType, LlmAuthType[]> = {
-    anthropic: ['api_key', 'oauth'],
+    anthropic: ['api_key', 'oauth', 'environment'],
     pi: ['api_key', 'oauth', 'iam_credentials', 'environment', 'none'],
     pi_compat: ['api_key_with_endpoint', 'none'],
   };

--- a/packages/shared/src/config/models.ts
+++ b/packages/shared/src/config/models.ts
@@ -92,10 +92,21 @@ export const MODEL_REGISTRY: ModelDefinition[] = [
   // Anthropic Claude Models
   // ----------------------------------------
   {
-    id: 'claude-opus-4-7',
-    name: 'Opus 4.7',
+    id: 'claude-opus-4-8',
+    name: 'Opus 4.8',
     shortName: 'Opus',
     description: 'Most capable for complex work',
+    descriptionKey: 'model.opusDesc',
+    provider: 'anthropic',
+    contextWindow: 1_000_000,
+  },
+  {
+    id: 'claude-opus-4-7',
+    name: 'Opus 4.7',
+    // shortName intentionally collides with 4.8. 4.8 is listed first, so
+    // findModelIdByShortName('Opus') resolves to 4.8.
+    shortName: 'Opus',
+    description: 'Previous Opus release',
     descriptionKey: 'model.opusDesc',
     provider: 'anthropic',
     contextWindow: 1_000_000,
@@ -107,8 +118,8 @@ export const MODEL_REGISTRY: ModelDefinition[] = [
   {
     id: 'claude-opus-4-6',
     name: 'Opus 4.6',
-    // shortName intentionally collides with 4.7. 4.7 is listed first, so
-    // findModelIdByShortName('Opus') keeps returning 4.7 — zero behavior
+    // shortName intentionally collides with 4.8/4.7. 4.8 is listed first,
+    // so findModelIdByShortName('Opus') resolves to 4.8 — zero behavior
     // change for callers that reference "Opus" abstractly.
     shortName: 'Opus',
     description: 'Previous Opus release',

--- a/patches/0001-anthropic-environment-auth.patch
+++ b/patches/0001-anthropic-environment-auth.patch
@@ -1,0 +1,29 @@
+diff --git a/packages/server-core/src/domain/connection-setup-logic.ts b/packages/server-core/src/domain/connection-setup-logic.ts
+index 9e0db8b..c20a510 100644
+--- a/packages/server-core/src/domain/connection-setup-logic.ts
++++ b/packages/server-core/src/domain/connection-setup-logic.ts
+@@ -115,6 +115,11 @@ export const BUILT_IN_CONNECTION_TEMPLATES: Record<string, {
+     providerType: 'anthropic',
+     authType: 'oauth',
+   },
++  'claude-code-env': {
++    name: 'Claude Code (SDK self-auth)',
++    providerType: 'anthropic',
++    authType: 'environment',
++  },
+   'chatgpt-plus': {
+     name: 'ChatGPT Plus',
+     providerType: 'pi',
+diff --git a/packages/shared/src/config/llm-connections.ts b/packages/shared/src/config/llm-connections.ts
+index d815ed9..47d4dfc 100644
+--- a/packages/shared/src/config/llm-connections.ts
++++ b/packages/shared/src/config/llm-connections.ts
+@@ -599,7 +599,7 @@ export function isValidProviderAuthCombination(
+   authType: LlmAuthType
+ ): boolean {
+   const validCombinations: Record<LlmProviderType, LlmAuthType[]> = {
+-    anthropic: ['api_key', 'oauth'],
++    anthropic: ['api_key', 'oauth', 'environment'],
+     pi: ['api_key', 'oauth', 'iam_credentials', 'environment', 'none'],
+     pi_compat: ['api_key_with_endpoint', 'none'],
+   };


### PR DESCRIPTION
## Summary
- Branch creation under **remote (`rpcServer`) deployments** threw `Browser pane manager unavailable despite passing the gate — this is a bug`. Root cause: `getOrCreateAgent` runs during branch preflight, but the session was registered in `this.sessions` only *after* the preflight block. The remote `BrowserPaneManager` resolver (`getBrowserPaneManagerForSession`) looks the session up via `this.sessions.get(id)`, so it returned `null` and tripped the gate guard. Local Electron was unaffected (it injects `browserPaneManager` directly and never needs the map).
- **Fix:** move `this.sessions.set(...)` ahead of the branch-preflight block. `rollbackFailedBranchCreation` already deletes from `this.sessions` on failure, so the failure contract is unchanged.
- **Tests:** the related isolated test was already red on `main` (its config mock lacked recently-added exports and failed at module load, taking the whole `bun test` suite with it). Added the missing mock exports and a regression test asserting the session is registered *before* preflight invokes `getOrCreateAgent`.

## Test plan
- [x] `bun run typecheck` (server-core) passes
- [x] `bun test ./apps/electron/src/main/__tests__/session-branch-rollback.isolated.ts` — 4/4 pass
- [x] Reverting only the `SessionManager` fix makes the new regression test fail (`registeredAtPreflight: false`), confirming it guards the bug
- [ ] Manual: branch a session on a remote (`rpcServer`) deployment and confirm no "Browser pane manager unavailable" error