### PR TITLE
fix: add autoCapitalize="off" to chat input to fix Chinese IME (fixes #837)

### DIFF
--- a/apps/electron/src/renderer/components/ui/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ui/rich-text-input.tsx
@@ -777,6 +777,7 @@ export const RichTextInput = React.forwardRef<RichTextInputHandle, RichTextInput
         <div
           ref={divRef}
           contentEditable={!disabled}
+          autoCapitalize="off"
           suppressContentEditableWarning
           tabIndex={disabled ? -1 : 0}
           className={cn(


### PR DESCRIPTION
fix: add autoCapitalize="off" to chat input to fix Chinese IME (fixes #837)

The contentEditable chat input was missing autoCapitalize="off",
causing the browser to force-capitalize the first letter of every
message. This breaks Chinese IME input (Pinyin, etc.) where
auto-capitalization interferes with composition.

Adding autoCapitalize="off" on the contentEditable div prevents
this behavior while not affecting normal text input.