### PR TITLE
fix(mcp): sanitize source proxy tool names

### DIFF
--- a/packages/shared/src/agent/claude-agent.ts
+++ b/packages/shared/src/agent/claude-agent.ts
@@ -429,10 +429,12 @@ function createSourceProxyServers(pool: McpClientPool): Record<string, ReturnTyp
     const mcpTools = pool.getTools(slug);
     if (mcpTools.length === 0) continue;
 
-    const proxyTools = mcpTools.map(mcpTool => {
-      const proxyName = `mcp__${slug}__${mcpTool.name}`;
+    const proxyTools = mcpTools.flatMap(mcpTool => {
+      const proxyName = pool.getProxyToolName(slug, mcpTool.name);
+      const proxyLocalName = pool.getProxyToolLocalName(slug, mcpTool.name);
+      if (!proxyName || !proxyLocalName) return [];
       return tool(
-        mcpTool.name,
+        proxyLocalName,
         mcpTool.description || `Tool from ${slug}`,
         {
           ...jsonSchemaToZodShape((mcpTool.inputSchema as Record<string, unknown>) || {}),

--- a/packages/shared/src/mcp/mcp-pool.ts
+++ b/packages/shared/src/mcp/mcp-pool.ts
@@ -55,6 +55,38 @@ export interface McpToolResult {
   sourceSlug?: string;
 }
 
+const LLM_TOOL_NAME_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+const LLM_TOOL_NAME_MAX_LENGTH = 128;
+
+function sanitizeToolNamePart(value: string): string {
+  const sanitized = value.replace(/[^A-Za-z0-9_-]/g, '_');
+  return sanitized.length > 0 ? sanitized : 'tool';
+}
+
+function truncateWithSuffix(base: string, suffix: string): string {
+  return `${base.slice(0, LLM_TOOL_NAME_MAX_LENGTH - suffix.length)}${suffix}`;
+}
+
+function buildSafeProxyToolName(slug: string, originalName: string, usedNames: Set<string>): string {
+  const safeSlug = sanitizeToolNamePart(slug);
+  const safeTool = sanitizeToolNamePart(originalName);
+  let baseName = `mcp__${safeSlug}__${safeTool}`;
+
+  if (baseName.length > LLM_TOOL_NAME_MAX_LENGTH) {
+    baseName = baseName.slice(0, LLM_TOOL_NAME_MAX_LENGTH);
+  }
+
+  let candidate = baseName;
+  let counter = 2;
+  while (usedNames.has(candidate) || !LLM_TOOL_NAME_PATTERN.test(candidate)) {
+    const suffix = `_${counter}`;
+    candidate = truncateWithSuffix(baseName, suffix);
+    counter++;
+  }
+
+  return candidate;
+}
+
 /**
  * Convert SdkMcpServerConfig (used by backend types) to CraftMcpClient config.
  */
@@ -111,6 +143,9 @@ export class McpClientPool {
   /** Proxy tool name → { slug, originalName } (e.g., "mcp__linear__createIssue" → { slug: "linear", originalName: "createIssue" }) */
   private proxyTools = new Map<string, { slug: string; originalName: string }>();
 
+  /** Source slug → original tool name → safe proxy tool name */
+  private sourceToolProxyNames = new Map<string, Map<string, string>>();
+
   /** Optional debug logger */
   private debugFn: ((msg: string) => void) | undefined;
 
@@ -158,10 +193,15 @@ export class McpClientPool {
     this.clients.set(slug, client);
     this.toolCache.set(slug, tools);
 
+    const usedProxyNames = new Set(this.proxyTools.keys());
+    const sourceProxyNames = new Map<string, string>();
     for (const tool of tools) {
-      const proxyName = `mcp__${slug}__${tool.name}`;
+      const proxyName = buildSafeProxyToolName(slug, tool.name, usedProxyNames);
+      usedProxyNames.add(proxyName);
+      sourceProxyNames.set(tool.name, proxyName);
       this.proxyTools.set(proxyName, { slug, originalName: tool.name });
     }
+    this.sourceToolProxyNames.set(slug, sourceProxyNames);
 
     this.debug(`Connected source ${slug}: ${tools.length} tools`);
   }
@@ -203,6 +243,7 @@ export class McpClientPool {
     for (const [proxyName, info] of this.proxyTools) {
       if (info.slug === slug) this.proxyTools.delete(proxyName);
     }
+    this.sourceToolProxyNames.delete(slug);
     this.toolCache.delete(slug);
     this.activeConfigs.delete(slug);
     this.debug(`Disconnected source: ${slug}`);
@@ -217,6 +258,7 @@ export class McpClientPool {
     this.clients.clear();
     this.toolCache.clear();
     this.proxyTools.clear();
+    this.sourceToolProxyNames.clear();
     this.activeConfigs.clear();
     this.debug('Disconnected all MCP clients');
   }
@@ -333,6 +375,24 @@ export class McpClientPool {
   }
 
   /**
+   * Resolve the LLM-facing proxy name for an original MCP tool name.
+   */
+  getProxyToolName(slug: string, originalName: string): string | null {
+    return this.sourceToolProxyNames.get(slug)?.get(originalName) ?? null;
+  }
+
+  /**
+   * Resolve the source-local safe tool name used by SDK MCP servers.
+   */
+  getProxyToolLocalName(slug: string, originalName: string): string | null {
+    const proxyName = this.getProxyToolName(slug, originalName);
+    if (!proxyName) return null;
+
+    const prefix = `mcp__${sanitizeToolNamePart(slug)}__`;
+    return proxyName.startsWith(prefix) ? proxyName.slice(prefix.length) : proxyName;
+  }
+
+  /**
    * Generate proxy tool definitions for all connected sources (or a subset).
    * These are passed to backends for tool registration.
    */
@@ -343,11 +403,13 @@ export class McpClientPool {
     for (const slug of targetSlugs) {
       const tools = this.toolCache.get(slug) || [];
       for (const tool of tools) {
+        const proxyName = this.getProxyToolName(slug, tool.name);
+        if (!proxyName) continue;
         // Strip $schema — AJV (Pi agent) fails on unregistered meta-schema URIs.
         // Same pattern as getToolDefsAsJsonSchema() in tool-defs.ts.
         const { $schema, ...cleanSchema } = (tool.inputSchema as Record<string, unknown>) || {};
         defs.push({
-          name: `mcp__${slug}__${tool.name}`,
+          name: proxyName,
           description: tool.description || `Tool from ${slug}`,
           inputSchema: Object.keys(cleanSchema).length > 0 ? cleanSchema : { type: 'object', properties: {} },
         });

--- a/packages/shared/tests/mcp-pool.test.ts
+++ b/packages/shared/tests/mcp-pool.test.ts
@@ -24,10 +24,16 @@ const mockTools: Tool[] = [
   },
 ];
 
-function makeMockClient(): PoolClient {
+function makeMockClient(
+  tools: Tool[] = mockTools,
+  onCallTool?: (name: string, args: Record<string, unknown>) => void
+): PoolClient {
   return {
-    listTools: async () => mockTools,
-    callTool: async () => ({ content: [{ type: 'text', text: 'ok' }] }),
+    listTools: async () => tools,
+    callTool: async (name, args) => {
+      onCallTool?.(name, args);
+      return { content: [{ type: 'text', text: 'ok' }] };
+    },
     close: async () => {},
   };
 }
@@ -48,6 +54,14 @@ class TestablePool extends McpClientPool {
     this.connectCalls.push({ slug, config });
     await this.registerClient(slug, makeMockClient());
     this.activeConfigs.set(slug, config);
+  }
+
+  async registerTools(
+    slug: string,
+    tools: Tool[],
+    onCallTool?: (name: string, args: Record<string, unknown>) => void
+  ): Promise<void> {
+    await this.registerClient(slug, makeMockClient(tools, onCallTool));
   }
 
   async disconnect(slug: string): Promise<void> {
@@ -182,5 +196,67 @@ describe('McpClientPool.sync — config change detection', () => {
 
     expect(failures).toContain('craft');
     expect(failPool.isConnected('craft')).toBe(false);
+  });
+});
+
+describe('McpClientPool proxy tool names', () => {
+  let pool: TestablePool;
+
+  beforeEach(() => {
+    pool = new TestablePool();
+  });
+
+  it('sanitizes invalid MCP tool names and routes calls to the original name', async () => {
+    const calledNames: string[] = [];
+
+    await pool.registerTools(
+      'dingtalk-ai-table',
+      [
+        {
+          name: 'pat.batch_plan',
+          description: 'A dotted MCP tool name',
+          inputSchema: { type: 'object' as const, properties: {} },
+        },
+      ],
+      (name) => calledNames.push(name)
+    );
+
+    const defs = pool.getProxyToolDefs();
+
+    expect(defs).toHaveLength(1);
+    expect(defs[0].name).toBe('mcp__dingtalk-ai-table__pat_batch_plan');
+    expect(defs[0].name).toMatch(/^[A-Za-z0-9_-]{1,128}$/);
+    expect(pool.getProxyToolLocalName('dingtalk-ai-table', 'pat.batch_plan')).toBe('pat_batch_plan');
+
+    await pool.callTool(defs[0].name, { ok: true });
+
+    expect(calledNames).toEqual(['pat.batch_plan']);
+  });
+
+  it('deduplicates tool names that collide after sanitization', async () => {
+    await pool.registerTools('source', [
+      { name: 'foo.bar', description: 'dot', inputSchema: { type: 'object' as const, properties: {} } },
+      { name: 'foo/bar', description: 'slash', inputSchema: { type: 'object' as const, properties: {} } },
+      { name: 'foo_bar', description: 'underscore', inputSchema: { type: 'object' as const, properties: {} } },
+    ]);
+
+    expect(pool.getProxyToolDefs().map(def => def.name)).toEqual([
+      'mcp__source__foo_bar',
+      'mcp__source__foo_bar_2',
+      'mcp__source__foo_bar_3',
+    ]);
+  });
+
+  it('keeps generated proxy names within provider length limits', async () => {
+    const longName = 'x'.repeat(200);
+
+    await pool.registerTools('source', [
+      { name: longName, description: 'long', inputSchema: { type: 'object' as const, properties: {} } },
+    ]);
+
+    const [def] = pool.getProxyToolDefs();
+
+    expect(def.name.length).toBeLessThanOrEqual(128);
+    expect(def.name).toMatch(/^[A-Za-z0-9_-]{1,128}$/);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #864.

MCP source tool names can legally contain characters such as `.`, `:`, or `/`, but model providers reject LLM-facing tool/function names outside `[A-Za-z0-9_-]` and length limits. The source proxy path was forwarding names like `mcp__dingtalk-ai-table__pat.batch_plan` directly, causing OpenAI/Codex request validation failures before the model could respond.

This PR makes the MCP pool generate provider-safe proxy names once when a source is registered, keeps a reverse mapping to the original MCP tool name, and reuses that mapping for both Pi/OpenAI proxy tool definitions and Claude source proxy servers.

## Changes

- Sanitize MCP source proxy tool names to `[A-Za-z0-9_-]` and cap at 128 chars.
- Deduplicate collisions deterministically with numeric suffixes.
- Preserve routing back to the original MCP tool name for execution.
- Update Claude source proxy server registration to expose the safe local tool name while calling through the safe full proxy name.
- Add regression coverage for dotted tool names, sanitized-name collisions, and long names.

## Verification

- `bun test packages/shared/tests/mcp-pool.test.ts`
- `cd packages/shared && bun run tsc --noEmit`
