### PR TITLE
fix(electron): inherit Windows system proxy

### DIFF
--- a/apps/electron/src/main/__tests__/network-proxy.test.ts
+++ b/apps/electron/src/main/__tests__/network-proxy.test.ts
@@ -2,7 +2,75 @@
  * Tests for network proxy bypass rules (NO_PROXY parsing and matching).
  */
 import { describe, it, expect } from 'bun:test';
-import { parseNoProxyRules, shouldBypassProxy } from '../network-proxy-utils';
+import {
+  normalizeProxyUrl,
+  parseNoProxyRules,
+  parseWindowsInternetSettings,
+  parseWindowsProxyOverride,
+  parseWindowsProxyServer,
+  shouldBypassProxy,
+} from '../network-proxy-utils';
+
+describe('normalizeProxyUrl', () => {
+  it('adds an HTTP scheme when Windows stores only host and port', () => {
+    expect(normalizeProxyUrl('proxy.example:8080')).toBe('http://proxy.example:8080');
+  });
+
+  it('preserves an existing scheme and trims whitespace', () => {
+    expect(normalizeProxyUrl('  https://proxy.example:8443  ')).toBe('https://proxy.example:8443');
+  });
+});
+
+describe('parseWindowsProxyServer', () => {
+  it('uses one proxy value for both HTTP and HTTPS', () => {
+    expect(parseWindowsProxyServer('proxy.example:8080')).toEqual({
+      httpProxy: 'http://proxy.example:8080',
+      httpsProxy: 'http://proxy.example:8080',
+    });
+  });
+
+  it('parses protocol-specific proxy values', () => {
+    expect(parseWindowsProxyServer('http=http-proxy.example:8080;https=https-proxy.example:8443')).toEqual({
+      httpProxy: 'http://http-proxy.example:8080',
+      httpsProxy: 'http://https-proxy.example:8443',
+    });
+  });
+});
+
+describe('parseWindowsProxyOverride', () => {
+  it('converts separators and expands the Windows local-host marker', () => {
+    expect(parseWindowsProxyOverride('*.example.test;<local>')).toBe(
+      '.example.test,localhost,127.0.0.1,::1',
+    );
+  });
+});
+
+describe('parseWindowsInternetSettings', () => {
+  it('parses enabled Windows Internet Settings registry output', () => {
+    const output = `
+HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings
+    ProxyEnable    REG_DWORD    0x1
+    ProxyServer    REG_SZ       proxy.example:8080
+    ProxyOverride  REG_SZ       <local>;*.example.test
+`;
+
+    expect(parseWindowsInternetSettings(output)).toEqual({
+      enabled: true,
+      httpProxy: 'http://proxy.example:8080',
+      httpsProxy: 'http://proxy.example:8080',
+      noProxy: 'localhost,127.0.0.1,::1,.example.test',
+    });
+  });
+
+  it('ignores disabled Windows proxy settings', () => {
+    const output = `
+    ProxyEnable    REG_DWORD    0x0
+    ProxyServer    REG_SZ       proxy.example:8080
+`;
+
+    expect(parseWindowsInternetSettings(output)).toBeUndefined();
+  });
+});
 
 describe('parseNoProxyRules', () => {
   it('returns empty array for undefined/empty input', () => {

--- a/apps/electron/src/main/network-proxy-utils.ts
+++ b/apps/electron/src/main/network-proxy-utils.ts
@@ -4,10 +4,82 @@
  * Parses NO_PROXY rules and determines whether a given URL should bypass the proxy.
  */
 
+import type { NetworkProxySettings } from '@craft-agent/shared/config/types';
+
 /** Split a comma-separated string into trimmed, non-empty entries. */
 export function splitCommaSeparated(str: string | undefined): string[] {
   if (!str) return [];
   return str.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+/** Ensure a proxy value such as `host:port` is a valid URL for undici. */
+export function normalizeProxyUrl(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+}
+
+/**
+ * Parse Windows' ProxyServer value.
+ *
+ * Windows stores either one proxy for all protocols (`host:port`) or a
+ * semicolon-separated map (`http=host:port;https=host:port`).
+ */
+export function parseWindowsProxyServer(
+  proxyServer: string | undefined,
+): Pick<NetworkProxySettings, 'httpProxy' | 'httpsProxy'> {
+  if (!proxyServer?.trim()) return {};
+
+  const entries = proxyServer.split(';').map(entry => entry.trim()).filter(Boolean);
+  const mapped: Record<string, string> = {};
+  for (const entry of entries) {
+    const separator = entry.indexOf('=');
+    if (separator > 0) {
+      mapped[entry.slice(0, separator).toLowerCase()] = entry.slice(separator + 1);
+    }
+  }
+
+  if (Object.keys(mapped).length > 0) {
+    return {
+      httpProxy: normalizeProxyUrl(mapped.http ?? mapped.https),
+      httpsProxy: normalizeProxyUrl(mapped.https ?? mapped.http),
+    };
+  }
+
+  const proxy = normalizeProxyUrl(proxyServer);
+  return { httpProxy: proxy, httpsProxy: proxy };
+}
+
+/** Convert Windows' semicolon-separated ProxyOverride value to NO_PROXY form. */
+export function parseWindowsProxyOverride(proxyOverride: string | undefined): string | undefined {
+  const normalized = proxyOverride
+    ?.split(';')
+    .flatMap(entry => entry.trim().toLowerCase() === '<local>'
+      ? ['localhost', '127.0.0.1', '::1']
+      : entry.trim().replace(/^\*\./, '.'))
+    .filter(Boolean)
+    .join(',');
+  return normalized || undefined;
+}
+
+/** Parse `reg query` output for the Windows Internet Settings key. */
+export function parseWindowsInternetSettings(output: string): NetworkProxySettings | undefined {
+  const values: Record<string, string> = {};
+  for (const line of output.split(/\r?\n/)) {
+    const match = line.match(/^\s*(ProxyEnable|ProxyServer|ProxyOverride)\s+REG_\w+\s+(.+)$/i);
+    if (match) values[match[1].toLowerCase()] = match[2].trim();
+  }
+
+  if (Number.parseInt(values.proxyenable ?? '', 0) !== 1) return undefined;
+
+  const proxies = parseWindowsProxyServer(values.proxyserver);
+  if (!proxies.httpProxy && !proxies.httpsProxy) return undefined;
+
+  return {
+    enabled: true,
+    ...proxies,
+    noProxy: parseWindowsProxyOverride(values.proxyoverride),
+  };
 }
 
 export interface NoProxyRule {

--- a/apps/electron/src/main/network-proxy.ts
+++ b/apps/electron/src/main/network-proxy.ts
@@ -6,9 +6,17 @@
  * - Electron side: calls session.setProxy() on default + browser-pane sessions.
  */
 
+import { execFileSync } from 'node:child_process';
 import { app, session } from 'electron';
 import { Agent, Dispatcher, ProxyAgent, setGlobalDispatcher } from 'undici';
-import { parseNoProxyRules, shouldBypassProxy, splitCommaSeparated, type NoProxyRule } from './network-proxy-utils';
+import {
+  normalizeProxyUrl,
+  parseNoProxyRules,
+  parseWindowsInternetSettings,
+  shouldBypassProxy,
+  splitCommaSeparated,
+  type NoProxyRule,
+} from './network-proxy-utils';
 import { getNetworkProxySettings, setNetworkProxySettings } from '@craft-agent/shared/config/storage';
 import type { NetworkProxySettings } from '@craft-agent/shared/config/types';
 import { BROWSER_PANE_SESSION_PARTITION } from './browser-pane-manager';
@@ -16,6 +24,10 @@ import log from './logger';
 
 // Track the current dispatcher so we can close it when reconfiguring
 let currentProxyDispatcher: Dispatcher | null = null;
+const syncedProcessProxyEnv = new Map<string, { applied: string; previous: string | undefined }>();
+
+const WINDOWS_INTERNET_SETTINGS_KEY =
+  'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings';
 
 /**
  * Custom undici Dispatcher that routes requests through proxy agents based on protocol,
@@ -75,6 +87,68 @@ class ProtocolProxyDispatcher extends Dispatcher {
   }
 }
 
+function readWindowsSystemProxySettings(): NetworkProxySettings | undefined {
+  if (process.platform !== 'win32') return undefined;
+
+  try {
+    const output = execFileSync('reg', ['query', WINDOWS_INTERNET_SETTINGS_KEY], {
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    return parseWindowsInternetSettings(output);
+  } catch (error) {
+    log.warn('[proxy] Failed to read Windows system proxy settings:', error);
+    return undefined;
+  }
+}
+
+function resolveEffectiveProxySettings(
+  settings: NetworkProxySettings | undefined,
+): NetworkProxySettings | undefined {
+  if (settings?.enabled && (settings.httpProxy || settings.httpsProxy)) {
+    return {
+      ...settings,
+      httpProxy: normalizeProxyUrl(settings.httpProxy),
+      httpsProxy: normalizeProxyUrl(settings.httpsProxy),
+    };
+  }
+  return readWindowsSystemProxySettings();
+}
+
+function syncProcessProxyEnv(settings: NetworkProxySettings | undefined): void {
+  for (const [key, { applied, previous }] of syncedProcessProxyEnv) {
+    if (process.env[key] !== applied) continue;
+    if (previous === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = previous;
+    }
+  }
+  syncedProcessProxyEnv.clear();
+
+  const httpProxy = settings?.httpProxy;
+  const httpsProxy = settings?.httpsProxy ?? httpProxy;
+
+  if (httpProxy) {
+    setProcessProxyEnv('HTTP_PROXY', httpProxy);
+    setProcessProxyEnv('http_proxy', httpProxy);
+  }
+  if (httpsProxy) {
+    setProcessProxyEnv('HTTPS_PROXY', httpsProxy);
+    setProcessProxyEnv('https_proxy', httpsProxy);
+  }
+  if (settings?.noProxy) {
+    setProcessProxyEnv('NO_PROXY', settings.noProxy);
+    setProcessProxyEnv('no_proxy', settings.noProxy);
+  }
+}
+
+function setProcessProxyEnv(key: string, value: string): void {
+  const previous = process.env[key];
+  process.env[key] = value;
+  syncedProcessProxyEnv.set(key, { applied: value, previous });
+}
+
 /**
  * Configure the Node.js global undici dispatcher for proxy routing.
  */
@@ -112,7 +186,9 @@ async function configureElectronProxy(settings: NetworkProxySettings | undefined
 
   const proxyConfig = settings?.enabled
     ? buildElectronProxyConfig(settings)
-    : { mode: 'direct' as const };
+    : process.platform === 'win32'
+      ? { mode: 'system' as const }
+      : { mode: 'direct' as const };
 
   const sessions = [
     session.defaultSession,
@@ -151,18 +227,20 @@ function buildElectronProxyConfig(settings: NetworkProxySettings): Electron.Prox
  */
 export async function applyConfiguredProxySettings(): Promise<void> {
   const settings = getNetworkProxySettings();
+  const effectiveSettings = resolveEffectiveProxySettings(settings);
+  const hasManualProxy = !!settings?.enabled && (!!settings.httpProxy || !!settings.httpsProxy);
 
-  const hasHttpProxy = !!settings?.httpProxy;
-  const hasNoProxy = !!settings?.noProxy;
   log.info('[proxy] Applying proxy settings:', {
-    enabled: settings?.enabled ?? false,
-    hasHttpProxy,
-    hasHttpsProxy: !!settings?.httpsProxy,
-    hasNoProxy,
+    enabled: effectiveSettings?.enabled ?? false,
+    source: hasManualProxy ? 'manual' : effectiveSettings ? 'windows-system' : 'system',
+    hasHttpProxy: !!effectiveSettings?.httpProxy,
+    hasHttpsProxy: !!effectiveSettings?.httpsProxy,
+    hasNoProxy: !!effectiveSettings?.noProxy,
   });
 
-  configureNodeProxy(settings);
-  await configureElectronProxy(settings);
+  syncProcessProxyEnv(effectiveSettings);
+  configureNodeProxy(effectiveSettings);
+  await configureElectronProxy(effectiveSettings);
 }
 
 /**


### PR DESCRIPTION
## Summary
- follow Windows Internet Settings when no custom Craft proxy is configured
- apply the effective proxy to undici, Electron sessions, and SDK subprocess environments
- normalize Windows proxy/override values and restore pre-existing proxy environment variables when settings change
- add unit coverage for Windows registry proxy parsing

## Testing
- `bun test apps/electron/src/main/__tests__/network-proxy.test.ts` (20 passed)
- `git diff --check`
- `bun run typecheck:electron` currently reports unrelated existing errors in `src/main/index.ts` and `src/renderer/main.tsx`
- Electron lint could not run because dependency installation failed integrity checks in the local validation environment

## Privacy
- contains only generic proxy parsing examples; no credentials, local paths, MCP configuration, or user-specific proxy addresses
