### PR TITLE
fix(workspace): confirm before deleting a workspace

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/CompactWorkspaceSwitcher.tsx
+++ b/apps/electron/src/renderer/components/app-shell/CompactWorkspaceSwitcher.tsx
@@ -131,6 +131,8 @@ export function CompactWorkspaceSwitcher({
       toast.error(t('toast.cannotRemoveActiveWorkspace'))
       return
     }
+    const confirmed = await window.electronAPI.showDeleteWorkspaceConfirmation(workspace.name)
+    if (!confirmed) return
     const removed = await window.electronAPI.removeWorkspace(workspace.id)
     if (removed) {
       toast.success(t('toast.removedWorkspace', { name: workspace.name }))

--- a/apps/electron/src/renderer/components/app-shell/WorkspaceSwitcher.tsx
+++ b/apps/electron/src/renderer/components/app-shell/WorkspaceSwitcher.tsx
@@ -142,6 +142,8 @@ export function WorkspaceSwitcher({
       toast.error(t('toast.cannotRemoveActiveWorkspace'))
       return
     }
+    const confirmed = await window.electronAPI.showDeleteWorkspaceConfirmation(workspace.name)
+    if (!confirmed) return
     const removed = await window.electronAPI.removeWorkspace(workspace.id)
     if (removed) {
       toast.success(t('toast.removedWorkspace', { name: workspace.name }))

--- a/apps/electron/src/shared/__tests__/ipc-channels.test.ts
+++ b/apps/electron/src/shared/__tests__/ipc-channels.test.ts
@@ -26,6 +26,7 @@ const EXPECTED_CHANNELS: string[] = [
   'appearance:setRichToolDescriptions',
   'auth:logout',
   'auth:showDeleteSessionConfirmation',
+  'auth:showDeleteWorkspaceConfirmation',
   'auth:showLogoutConfirmation',
   'automations:changed',
   'automations:delete',

--- a/apps/electron/src/shared/types.ts
+++ b/apps/electron/src/shared/types.ts
@@ -380,6 +380,7 @@ export interface ElectronAPI {
   // Auth
   showLogoutConfirmation(): Promise<boolean>
   showDeleteSessionConfirmation(name: string): Promise<boolean>
+  showDeleteWorkspaceConfirmation(name: string): Promise<boolean>
   logout(): Promise<void>
 
   // Credential health check (startup validation)

--- a/apps/electron/src/transport/channel-map.ts
+++ b/apps/electron/src/transport/channel-map.ts
@@ -119,6 +119,7 @@ export const CHANNEL_MAP = {
   // Auth
   showLogoutConfirmation: invoke(RPC_CHANNELS.auth.SHOW_LOGOUT_CONFIRMATION),
   showDeleteSessionConfirmation: invoke(RPC_CHANNELS.auth.SHOW_DELETE_SESSION_CONFIRMATION),
+  showDeleteWorkspaceConfirmation: invoke(RPC_CHANNELS.auth.SHOW_DELETE_WORKSPACE_CONFIRMATION),
   logout: invoke(RPC_CHANNELS.auth.LOGOUT),
   getCredentialHealth: invoke(RPC_CHANNELS.credentials.HEALTH_CHECK),
 

--- a/packages/server-core/src/handlers/rpc/auth.ts
+++ b/packages/server-core/src/handlers/rpc/auth.ts
@@ -11,6 +11,7 @@ export const HANDLED_CHANNELS = [
   RPC_CHANNELS.auth.LOGOUT,
   RPC_CHANNELS.auth.SHOW_LOGOUT_CONFIRMATION,
   RPC_CHANNELS.auth.SHOW_DELETE_SESSION_CONFIRMATION,
+  RPC_CHANNELS.auth.SHOW_DELETE_WORKSPACE_CONFIRMATION,
   RPC_CHANNELS.credentials.HEALTH_CHECK,
 ] as const
 
@@ -40,6 +41,22 @@ export function registerAuthHandlers(server: RpcServer, deps: HandlerDeps): void
       cancelId: 0,
       title: 'Delete Conversation',
       message: `Are you sure you want to delete: "${name}"?`,
+      detail: 'This action cannot be undone.',
+    })
+    // result.response is the index of the clicked button
+    // 0 = Cancel, 1 = Delete
+    return result.response === 1
+  })
+
+  // Show delete workspace confirmation dialog (routed to client)
+  server.handle(RPC_CHANNELS.auth.SHOW_DELETE_WORKSPACE_CONFIRMATION, async (ctx, name: string) => {
+    const result = await requestClientConfirmDialog(server, ctx.clientId, {
+      type: 'warning',
+      buttons: ['Cancel', 'Delete'],
+      defaultId: 0,
+      cancelId: 0,
+      title: 'Delete Workspace',
+      message: `Are you sure you want to delete the workspace "${name}"?`,
       detail: 'This action cannot be undone.',
     })
     // result.response is the index of the clicked button

--- a/packages/shared/src/protocol/channels.ts
+++ b/packages/shared/src/protocol/channels.ts
@@ -159,6 +159,7 @@ export const RPC_CHANNELS = {
     LOGOUT: 'auth:logout',
     SHOW_LOGOUT_CONFIRMATION: 'auth:showLogoutConfirmation',
     SHOW_DELETE_SESSION_CONFIRMATION: 'auth:showDeleteSessionConfirmation',
+    SHOW_DELETE_WORKSPACE_CONFIRMATION: 'auth:showDeleteWorkspaceConfirmation',
   },
   credentials: {
     HEALTH_CHECK: 'credentials:healthCheck',

--- a/packages/shared/src/protocol/routing.ts
+++ b/packages/shared/src/protocol/routing.ts
@@ -53,6 +53,7 @@ export const LOCAL_ONLY_CHANNELS = new Set<string>([
   RPC_CHANNELS.auth.LOGOUT,
   RPC_CHANNELS.auth.SHOW_LOGOUT_CONFIRMATION,
   RPC_CHANNELS.auth.SHOW_DELETE_SESSION_CONFIRMATION,
+  RPC_CHANNELS.auth.SHOW_DELETE_WORKSPACE_CONFIRMATION,
 
   // shell — local OS shell (openFile/showInFolder guarded for remote)
   RPC_CHANNELS.shell.OPEN_URL,


### PR DESCRIPTION
## What
Deleting a workspace from the workspace switcher dropdown removed it **immediately, with no confirmation** — one stray click permanently deletes a workspace and its sessions.

This adds a native confirmation dialog before deletion.

## How
Mirrors the existing `showDeleteSessionConfirmation` pattern exactly:
- New `auth:showDeleteWorkspaceConfirmation` RPC channel — added in `channels.ts`, `routing.ts` (`LOCAL_ONLY_CHANNELS`), the server-core `auth.ts` handler (reusing the already-imported `requestClientConfirmDialog`), `channel-map.ts`, and the `ElectronAPI` type.
- Routed to the client, so it also works in remote / thin-client mode.
- Both `WorkspaceSwitcher` and `CompactWorkspaceSwitcher` now `await` confirmation before calling `removeWorkspace`.

Dialog copy: **Delete Workspace** — *Are you sure you want to delete the workspace "&lt;name&gt;"? This action cannot be undone.* `[Cancel] [Delete]`

## Testing
- `bun test` — the ipc-channels wire-format test and the protocol/routing tests pass (26 passing) with the new channel added.
- `tsc --noEmit` clean on the three edited packages (`shared`, `server-core`, `electron`).
- Expected behavior: deleting a workspace now prompts; **Cancel** aborts, **Delete** removes. (The active-workspace guard is unchanged.)
