### PR TITLE
fix(ui): per-group pagination for status/unread session grouping (#501)

### DIFF
--- a/apps/electron/src/renderer/hooks/__tests__/useSessionSearch.test.ts
+++ b/apps/electron/src/renderer/hooks/__tests__/useSessionSearch.test.ts
@@ -66,4 +66,41 @@ describe('computeCollapsedPagination', () => {
     expect(result.paginatedItems.map(s => s.id)).toEqual(['a', 'b'])
     expect(result.collapsedGroupsMeta).toEqual([])
   })
+
+  it('status grouping surfaces old open-work items regardless of age, capping per group (#501)', () => {
+    // 3 recent "done" + 2 much older "in-progress". With a tiny global window
+    // (displayLimit=2) the old in-progress items would be sliced out entirely;
+    // per-group pagination must still surface them in their group.
+    const sessions = [
+      makeSession('done1', { sessionStatus: 'done', lastMessageAt: Date.parse('2026-03-10T10:00:00.000Z') }),
+      makeSession('done2', { sessionStatus: 'done', lastMessageAt: Date.parse('2026-03-09T10:00:00.000Z') }),
+      makeSession('done3', { sessionStatus: 'done', lastMessageAt: Date.parse('2026-03-08T10:00:00.000Z') }),
+      makeSession('todoOld1', { sessionStatus: 'in-progress', lastMessageAt: Date.parse('2026-02-01T10:00:00.000Z') }),
+      makeSession('todoOld2', { sessionStatus: 'in-progress', lastMessageAt: Date.parse('2026-01-15T10:00:00.000Z') }),
+    ]
+
+    const result = computeCollapsedPagination(sessions, 2, undefined, 'status')
+    const ids = result.paginatedItems.map(s => s.id)
+
+    // Both old in-progress items appear despite being chronologically last.
+    expect(ids).toContain('todoOld1')
+    expect(ids).toContain('todoOld2')
+    // The "done" group is still capped per group (2 of 3 shown).
+    expect(result.paginatedItems.filter(s => s.sessionStatus === 'done')).toHaveLength(2)
+    // More remains because the done group overflows its per-group window.
+    expect(result.hasMore).toBe(true)
+  })
+
+  it('date grouping keeps the single global chronological window (unchanged)', () => {
+    const sessions = [
+      makeSession('a', { lastMessageAt: Date.parse('2026-03-06T10:00:00.000Z') }),
+      makeSession('b', { lastMessageAt: Date.parse('2026-03-05T10:00:00.000Z') }),
+      makeSession('c', { lastMessageAt: Date.parse('2026-03-04T10:00:00.000Z') }),
+    ]
+
+    const result = computeCollapsedPagination(sessions, 2, undefined, 'date')
+
+    expect(result.paginatedItems.map(s => s.id)).toEqual(['a', 'b'])
+    expect(result.hasMore).toBe(true)
+  })
 })

--- a/apps/electron/src/renderer/hooks/useSessionSearch.ts
+++ b/apps/electron/src/renderer/hooks/useSessionSearch.ts
@@ -137,13 +137,48 @@ export function computeCollapsedPagination(
   collapsedGroups?: Set<string>,
   groupingMode?: 'date' | 'status' | 'unread',
 ): CollapsedPaginationResult {
-  // Fast path: no collapse state → original slice
-  if (!collapsedGroups || collapsedGroups.size === 0) {
-    return {
-      paginatedItems: items.slice(0, displayLimit),
-      hasMore: displayLimit < items.length,
-      collapsedGroupsMeta: [],
+  // `date` grouping is inherently chronological, so a single global window
+  // (newest-first, grow on scroll) is the correct lazy-load behavior.
+  //
+  // `status` / `unread` grouping is NOT chronological: an old To-do/Needs-review
+  // or unread session should surface in its group regardless of age. A global
+  // chronological slice silently drops such items out of their group once they
+  // fall past the loaded window (#501). For these modes we therefore paginate
+  // *per group* — each group reveals up to `displayLimit` of its own most-recent
+  // items — so small open-work groups show in full while large groups (e.g.
+  // Done) stay bounded. `displayLimit` still grows on scroll via the caller.
+  const perGroup = groupingMode === 'status' || groupingMode === 'unread'
+
+  // Pick the visible items honoring `displayLimit`, optionally skipping groups in
+  // `excludeKeys` (collapsed groups). Preserves the incoming item order.
+  const paginate = (excludeKeys?: Set<string>): { picked: SessionMeta[]; hasMore: boolean } => {
+    if (!perGroup) {
+      const list = excludeKeys && excludeKeys.size > 0
+        ? items.filter(item => !excludeKeys.has(getCollapseGroupKey(item, groupingMode)))
+        : items
+      return { picked: list.slice(0, displayLimit), hasMore: displayLimit < list.length }
     }
+    const perGroupCount = new Map<string, number>()
+    const picked: SessionMeta[] = []
+    let hasMore = false
+    for (const item of items) {
+      const key = getCollapseGroupKey(item, groupingMode)
+      if (excludeKeys?.has(key)) continue
+      const shown = perGroupCount.get(key) ?? 0
+      if (shown < displayLimit) {
+        picked.push(item)
+        perGroupCount.set(key, shown + 1)
+      } else {
+        hasMore = true
+      }
+    }
+    return { picked, hasMore }
+  }
+
+  // Fast path: no collapse state.
+  if (!collapsedGroups || collapsedGroups.size === 0) {
+    const { picked, hasMore } = paginate()
+    return { paginatedItems: picked, hasMore, collapsedGroupsMeta: [] }
   }
 
   const groupKeysInView = new Set(items.map(item => getCollapseGroupKey(item, groupingMode)))
@@ -151,11 +186,8 @@ export function computeCollapsedPagination(
   // Safety guard: don't allow collapse state to hide the entire list when only one
   // group exists in the current filtered view (there would be no meaningful collapse UX).
   if (groupKeysInView.size <= 1) {
-    return {
-      paginatedItems: items.slice(0, displayLimit),
-      hasMore: displayLimit < items.length,
-      collapsedGroupsMeta: [],
-    }
+    const { picked, hasMore } = paginate()
+    return { paginatedItems: picked, hasMore, collapsedGroupsMeta: [] }
   }
 
   const effectiveCollapsedKeys = new Set(
@@ -163,35 +195,24 @@ export function computeCollapsedPagination(
   )
 
   if (effectiveCollapsedKeys.size === 0) {
-    return {
-      paginatedItems: items.slice(0, displayLimit),
-      hasMore: displayLimit < items.length,
-      collapsedGroupsMeta: [],
-    }
+    const { picked, hasMore } = paginate()
+    return { paginatedItems: picked, hasMore, collapsedGroupsMeta: [] }
   }
 
-  const expandedItems: SessionMeta[] = []
   const collapsedCounts = new Map<string, number>()
-
   for (const item of items) {
     const groupKey = getCollapseGroupKey(item, groupingMode)
-
     if (effectiveCollapsedKeys.has(groupKey)) {
       collapsedCounts.set(groupKey, (collapsedCounts.get(groupKey) || 0) + 1)
-    } else {
-      expandedItems.push(item)
     }
   }
 
+  const { picked, hasMore } = paginate(effectiveCollapsedKeys)
   const meta: CollapsedGroupMeta[] = Array.from(collapsedCounts.entries()).map(
     ([key, count]) => ({ key, count })
   )
 
-  return {
-    paginatedItems: expandedItems.slice(0, displayLimit),
-    hasMore: displayLimit < expandedItems.length,
-    collapsedGroupsMeta: meta,
-  }
+  return { paginatedItems: picked, hasMore, collapsedGroupsMeta: meta }
 }
 
 interface FilterMatchOptions {


### PR DESCRIPTION
Fixes #501.

## Problem
When the sidebar is grouped by **status** (To-do / Needs review / Done) or **unread**, older sessions in the open-work groups silently disappear. As #501 reports, an open To-do from two weeks ago doesn't show in the To-do group at all until you scroll far enough down the full chronological list to "discover" it.

### Root cause
Sessions are grouped only **after** the chronologically-sorted list is sliced to the current lazy-load window:

```ts
// computeCollapsedPagination (useSessionSearch.ts)
paginatedItems: items.slice(0, displayLimit)   // global chronological slice
// …SessionList then buckets these into status/unread/date groups
```

So a group can only contain items whose **global** recency rank is within `displayLimit` (starts at 50, +50 per scroll). For `date` grouping that's correct — newest dates first. For `status`/`unread` it's wrong: those groups aren't chronological, so old-but-open items fall outside the window and vanish from their group. With a few hundred sessions this presents as a hard "cap" on what's visible.

## Fix
Paginate **per group** for `status` and `unread` modes: each group reveals up to `displayLimit` of its own most-recent items. Small open-work groups (To-do, Needs review, Unread) show in full regardless of age; large groups (Done, Read) stay bounded, and `displayLimit` still grows on scroll. `date` grouping is untouched and remains byte-for-byte equivalent.

The change is localized to `computeCollapsedPagination`; all slicing now routes through one `paginate()` helper that is flat for `date`/ungrouped and per-group for `status`/`unread`.

## Testing
- `bun test apps/electron/src/renderer/hooks/__tests__/useSessionSearch.test.ts` — 5 pass (3 existing + 2 new).
  - New: status grouping surfaces old open items while capping the large group per-group.
  - New: date grouping keeps the single global chronological window (regression guard).
- `tsc --noEmit` clean for `apps/electron`.

## Note on approach
This keeps the perf-protecting window intact (each group is still bounded), which seemed the safest reading of the intended behavior. If you'd prefer a different design for the open-work groups (e.g. "always render all non-terminal statuses, only cap Done"), happy to adjust.
