### PR TITLE
fix(auto-update): persist update diagnostics in production (#891)

### DIFF
--- a/apps/electron/src/main/auto-update.ts
+++ b/apps/electron/src/main/auto-update.ts
@@ -19,7 +19,7 @@ import { app, BrowserWindow } from 'electron'
 import { platform } from 'os'
 import * as path from 'path'
 import * as fs from 'fs'
-import { mainLog } from './logger'
+import { mainLog, autoUpdateLog } from './logger'
 import { getAppVersion } from '@craft-agent/shared/version'
 import {
   getDismissedUpdateVersion,
@@ -145,7 +145,7 @@ autoUpdater.on('checking-for-update', () => {
 })
 
 autoUpdater.on('update-available', (info) => {
-  mainLog.info(`[auto-update] Update available: ${updateInfo.currentVersion} → ${info.version}`)
+  autoUpdateLog.info(`Update available: ${updateInfo.currentVersion} → ${info.version}`)
 
   // First, check electron-updater's internal state (most reliable)
   const internalState = checkElectronUpdaterState()
@@ -206,7 +206,7 @@ autoUpdater.on('download-progress', (progress) => {
 })
 
 autoUpdater.on('update-downloaded', async (info) => {
-  mainLog.info(`[auto-update] Update downloaded: v${info.version}`)
+  autoUpdateLog.info(`Update downloaded: v${info.version}`)
 
   updateInfo = {
     ...updateInfo,
@@ -223,7 +223,7 @@ autoUpdater.on('update-downloaded', async (info) => {
 })
 
 autoUpdater.on('error', (error) => {
-  mainLog.error('[auto-update] Error:', error.message)
+  autoUpdateLog.error('electron-updater error', error)
 
   updateInfo = {
     ...updateInfo,
@@ -359,7 +359,7 @@ export async function checkForUpdates(options: CheckOptions = {}): Promise<Updat
       }
     }
   } catch (error) {
-    mainLog.error('[auto-update] Check failed:', error)
+    autoUpdateLog.error('Update check failed', error)
     updateInfo = {
       ...updateInfo,
       downloadState: 'error',
@@ -386,7 +386,7 @@ export async function installUpdate(): Promise<void> {
     throw new Error('No update ready to install')
   }
 
-  mainLog.info('[auto-update] Installing update and restarting...')
+  autoUpdateLog.info('Installing update and restarting...')
 
   updateInfo = { ...updateInfo, downloadState: 'installing' }
   broadcastUpdateInfo()
@@ -400,7 +400,7 @@ export async function installUpdate(): Promise<void> {
   // Diagnostic correlation with before-quit's [update-flow] log. If these
   // window counts diverge, electron-updater is destroying windows between
   // here and before-quit firing — confirms the multi-window restore bug.
-  mainLog.info('[update-flow] installUpdate pre-quit', {
+  autoUpdateLog.info('installUpdate pre-quit', {
     electronWindowCount: BrowserWindow.getAllWindows().length,
     downloadState: updateInfo.downloadState,
     latestVersion: updateInfo.latestVersion,
@@ -412,7 +412,7 @@ export async function installUpdate(): Promise<void> {
   try {
     beforeUpdateQuitHook?.()
   } catch (err) {
-    mainLog.error('[auto-update] beforeUpdateQuit hook failed:', err)
+    autoUpdateLog.error('beforeUpdateQuit hook failed', err)
   }
 
   try {
@@ -421,7 +421,7 @@ export async function installUpdate(): Promise<void> {
     autoUpdater.quitAndInstall(false, true)
   } catch (error) {
     __isUpdating = false
-    mainLog.error('[auto-update] quitAndInstall failed:', error)
+    autoUpdateLog.error('quitAndInstall failed', error)
     updateInfo = { ...updateInfo, downloadState: 'error' }
     broadcastUpdateInfo()
     throw error
@@ -444,7 +444,7 @@ export interface UpdateOnLaunchResult {
  * - Auto-downloads if update available
  */
 export async function checkForUpdatesOnLaunch(): Promise<UpdateOnLaunchResult> {
-  mainLog.info('[auto-update] Checking for updates on launch...')
+  autoUpdateLog.info('Checking for updates on launch...')
 
   const info = await checkForUpdates({ autoDownload: true })
 

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -111,7 +111,7 @@ import { handleDeepLink } from './deep-link'
 import { BrowserPaneManager } from './browser-pane-manager'
 import { OAuthFlowStore } from '@craft-agent/shared/auth'
 import { registerThumbnailScheme, registerThumbnailHandler } from './thumbnail-protocol'
-import log, { isDebugMode, mainLog, getLogFilePath, getMessagingGatewayLogFilePath, messagingGatewayLog } from './logger'
+import log, { isDebugMode, mainLog, getLogFilePath, getMessagingGatewayLogFilePath, messagingGatewayLog, autoUpdateLog } from './logger'
 import { setPerfEnabled, enableDebug } from '@craft-agent/shared/utils'
 import { registerPiModelResolver } from '@craft-agent/shared/config'
 import { getPiModelsForAuthProvider, getAllPiModels } from '@craft-agent/shared/config'
@@ -1186,13 +1186,22 @@ app.on('before-quit', async (event) => {
     } else {
       captureAndSaveWindowState('before-quit')
     }
-    // Diagnostic correlation with installUpdate's [update-flow] log.
-    mainLog.info('[update-flow] before-quit save', {
+    // Diagnostic correlation with installUpdate's [update-flow] log. During an
+    // update-quit, record it to the dedicated always-on auto-update log (#891)
+    // so the install/quit handoff is diagnosable in production; normal quits
+    // stay on the debug-only main log.
+    const isUpdateQuit = isUpdating()
+    const beforeQuitSave = {
       windowCount: windows.length,
       electronWindowCount: BrowserWindow.getAllWindows().length,
-      isUpdating: isUpdating(),
-      reason: isUpdating() ? 'update-quit' : 'user-quit',
-    })
+      isUpdating: isUpdateQuit,
+      reason: isUpdateQuit ? 'update-quit' : 'user-quit',
+    }
+    if (isUpdateQuit) {
+      autoUpdateLog.info('before-quit save', beforeQuitSave)
+    } else {
+      mainLog.info('[update-flow] before-quit save', beforeQuitSave)
+    }
   }
 
   // Flush all pending session writes before quitting

--- a/apps/electron/src/main/logger.ts
+++ b/apps/electron/src/main/logger.ts
@@ -202,6 +202,73 @@ export const messagingGatewayLog: MessagingLogger = new StructuredMessagingGatew
 })
 
 /**
+ * Dedicated auto-update log.
+ *
+ * In packaged builds the Electron file/console transports are disabled (see
+ * above), so every `[auto-update]` / `[update-flow]` diagnostic is dropped —
+ * leaving update-install failures undiagnosable in the field (see #891). This
+ * dedicated, always-on rotating log records the update lifecycle at a stable
+ * path regardless of debug mode, mirroring the messaging-gateway log above.
+ */
+export const autoUpdateLogPath = join(homedir(), '.craft-agent', 'logs', 'auto-update.log')
+const autoUpdateBackupPath = `${autoUpdateLogPath}.1`
+const AUTO_UPDATE_LOG_MAX_BYTES = 2 * 1024 * 1024 // 2MB
+
+function rotateAutoUpdateLogIfNeeded(nextLineBytes: number): void {
+  if (!existsSync(autoUpdateLogPath)) return
+  try {
+    const currentSize = statSync(autoUpdateLogPath).size
+    if (currentSize + nextLineBytes <= AUTO_UPDATE_LOG_MAX_BYTES) return
+    if (existsSync(autoUpdateBackupPath)) {
+      rmSync(autoUpdateBackupPath, { force: true })
+    }
+    renameSync(autoUpdateLogPath, autoUpdateBackupPath)
+  } catch (error) {
+    mainLog.warn('[auto-update] failed to rotate dedicated log file', normalizeLogValue(error))
+  }
+}
+
+function writeAutoUpdateLog(level: 'info' | 'warn' | 'error', message: string, meta?: unknown): void {
+  const entry = {
+    timestamp: new Date().toISOString(),
+    level,
+    scope: 'auto-update',
+    ...(meta !== undefined ? { meta: normalizeLogValue(meta) } : {}),
+    message,
+  }
+
+  const line = JSON.stringify(entry) + '\n'
+  try {
+    mkdirSync(dirname(autoUpdateLogPath), { recursive: true })
+    rotateAutoUpdateLogIfNeeded(Buffer.byteLength(line))
+    appendFileSync(autoUpdateLogPath, line, 'utf8')
+  } catch (error) {
+    mainLog.warn('[auto-update] failed to write dedicated log entry', normalizeLogValue(error))
+  }
+
+  // Mirror to the Electron logger too (a no-op in production where transports
+  // are disabled, but keeps --debug console/file output intact).
+  if (level === 'error') {
+    mainLog.error('[auto-update]', message, entry)
+  } else if (level === 'warn') {
+    mainLog.warn('[auto-update]', message, entry)
+  } else if (isDebugMode) {
+    mainLog.info('[auto-update]', message, entry)
+  }
+}
+
+/** Always-on structured logger for the auto-update lifecycle (see #891). */
+export const autoUpdateLog = {
+  info: (message: string, meta?: unknown) => writeAutoUpdateLog('info', message, meta),
+  warn: (message: string, meta?: unknown) => writeAutoUpdateLog('warn', message, meta),
+  error: (message: string, meta?: unknown) => writeAutoUpdateLog('error', message, meta),
+}
+
+export function getAutoUpdateLogFilePath(): string {
+  return autoUpdateLogPath
+}
+
+/**
  * Get the path to the current Electron main log file.
  * Returns undefined if file logging is disabled.
  */


### PR DESCRIPTION
Related to #891 (does not fix the install failure itself — makes it diagnosable).

## Problem
While investigating #891 (auto-update downloads but never installs on macOS), the blocker is that **there is nothing to diagnose from**. Packaged builds disable both log transports:

```ts
// apps/electron/src/main/logger.ts  (non-debug branch)
log.transports.file.level = false
log.transports.console.level = false
```

`auto-update.ts` is well-instrumented (`update-available`, `update-downloaded`, the `[update-flow]` install↔quit correlation, `quitAndInstall failed`, the electron-updater `error` handler), but in production every one of those `mainLog` calls is silently dropped. A user hitting #891 has no on-disk trail, and neither does a maintainer triaging the report.

## Change
Add a dedicated, **always-on** rotating log at `~/.craft-agent/logs/auto-update.log` — JSON lines, 2 MB + one `.1` backup — **mirroring the existing always-on `messaging-gateway.log`** in the same module (so this matches an established convention rather than introducing a new one, and doesn't re-enable the globally-disabled transports).

- Routes the high-signal update lifecycle + error events through it; verbose internal debug lines stay on the debug-only main log.
- During an update-quit, the `before-quit` correlation entry (window counts, `isUpdating`) is recorded too, so the full `installUpdate → before-quit → quitAndInstall` handoff is reconstructable from one file.
- Still mirrors to the Electron logger, so `--debug` console/file output is unchanged.

## Why not just fix the installer?
The install/quit lifecycle (`index.ts` `before-quit`, `auto-update.ts` `installUpdate`) looks correct — it uses `app.quit()` (not the force `app.exit(0)`) on the update path and guards on `isUpdating()`. I couldn't reproduce the macOS ShipIt failure or point at a defect, so rather than guess at lifecycle code, this makes the failure observable so the root cause can be pinned down from real-world logs.

## Testing
- `tsc --noEmit` clean for `apps/electron`.
- Mirrors the existing `messaging-gateway.log` writer (which ships without a dedicated unit test); change is additive and the output still flows through the existing Electron logger under `--debug`.
- Tip for anyone reproducing #891: launch the packaged app with `--debug` (`open "/Applications/Craft Agents.app" --args --debug`) to also get full console/file logging via `resolveDebugMode()`.
