### PR TITLE
fix(ci): restore validation baseline

### DIFF
--- a/packages/pi-agent-server/src/index.ts
+++ b/packages/pi-agent-server/src/index.ts
@@ -1179,7 +1179,8 @@ function handleSessionEvent(event: AgentSessionEvent): void {
           (c) => c.type === 'toolCall' && c.name && isPrefetchableTool(c.name),
         );
         if (prefetchableToolCalls.length >= 2) {
-          debugLog(`Prefetching ${prefetchableToolCalls.length} parallel ${prefetchableToolCalls[0].name} calls`);
+          const firstPrefetchableToolCall = prefetchableToolCalls[0]!;
+          debugLog(`Prefetching ${prefetchableToolCalls.length} parallel ${firstPrefetchableToolCall.name} calls`);
           for (const tc of prefetchableToolCalls) {
             const requestId = `prefetch-${tc.id}`;
             const promise = new Promise<{ content: string; isError: boolean }>((resolve) => {

--- a/packages/pi-agent-server/src/tools/search/providers/ddg.ts
+++ b/packages/pi-agent-server/src/tools/search/providers/ddg.ts
@@ -66,9 +66,10 @@ function extractUrlFromDuckDuckGoHref(href: string): string | null {
   if (!href) return null;
 
   const uddgMatch = href.match(/[?&]uddg=([^&]+)/);
-  if (uddgMatch) {
+  const encodedUrl = uddgMatch?.[1];
+  if (encodedUrl) {
     try {
-      return decodeURIComponent(uddgMatch[1]);
+      return decodeURIComponent(encodedUrl);
     } catch {
       return null;
     }

--- a/packages/pi-agent-server/src/tools/web-fetch.ts
+++ b/packages/pi-agent-server/src/tools/web-fetch.ts
@@ -385,7 +385,7 @@ export function createWebFetchTool(
 
       const contentType = (response.headers.get('content-type') || '')
         .toLowerCase()
-        .split(';')[0]
+        .split(';')[0]!
         .trim();
 
       // Binary content types — stream with size limit

--- a/scripts/check-i18n-coverage.ts
+++ b/scripts/check-i18n-coverage.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env bun
+/**
+ * check-i18n-coverage.ts — CI-safe i18n callsite coverage check.
+ *
+ * Verifies that every statically-known translation key referenced from code
+ * exists in packages/shared/src/i18n/locales/en.json.
+ *
+ * This intentionally checks only literal keys. Dynamic expressions such as
+ * `t(`status.${id}`)` are skipped because they are validated at runtime by
+ * i18next's missing-key warnings and often map to user-defined identifiers.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+
+const REPO_ROOT = resolve(import.meta.dir ?? new URL('.', import.meta.url).pathname, '..')
+const EN_LOCALE_PATH = resolve(REPO_ROOT, 'packages', 'shared', 'src', 'i18n', 'locales', 'en.json')
+
+const SCAN_ROOTS = ['apps', 'packages', 'scripts']
+const CODE_EXTENSIONS = new Set(['.ts', '.tsx'])
+const SKIP_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  'out',
+  'coverage',
+  '.next',
+  '.turbo',
+  '.vite',
+])
+
+const en = JSON.parse(readFileSync(EN_LOCALE_PATH, 'utf-8')) as Record<string, string>
+const enKeys = new Set(Object.keys(en))
+
+type Reference = {
+  key: string
+  file: string
+  line: number
+  column: number
+  kind: string
+}
+
+function isCodeFile(path: string): boolean {
+  for (const extension of CODE_EXTENSIONS) {
+    if (path.endsWith(extension)) return true
+  }
+  return false
+}
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue
+    const path = join(dir, entry)
+    const stat = statSync(path)
+    if (stat.isDirectory()) {
+      yield* walk(path)
+    } else if (stat.isFile() && isCodeFile(path)) {
+      yield path
+    }
+  }
+}
+
+function lineColumn(source: string, index: number): { line: number; column: number } {
+  let line = 1
+  let lastLineStart = 0
+  for (let i = 0; i < index; i++) {
+    if (source.charCodeAt(i) === 10) {
+      line++
+      lastLineStart = i + 1
+    }
+  }
+  return { line, column: index - lastLineStart + 1 }
+}
+
+function isStaticKey(key: string): boolean {
+  // Locale keys are flat dotted identifiers. Skipping non-dotted strings avoids
+  // false positives for unrelated helpers named `t` in tests or libraries.
+  return key.includes('.') && !key.includes('${')
+}
+
+function collectReferences(file: string): Reference[] {
+  const source = readFileSync(file, 'utf-8')
+  const rel = relative(REPO_ROOT, file)
+  const refs: Reference[] = []
+
+  const patterns: Array<{ kind: string; regex: RegExp; keyGroup: number }> = [
+    // t('key'), t("key"), i18n.t('key'), i18next.t('key')
+    { kind: 't()', regex: /\b(?:i18n|i18next)?\.?t\(\s*(['"])([^'"`]+)\1/g, keyGroup: 2 },
+    // <Trans i18nKey="key" />
+    { kind: 'i18nKey', regex: /\bi18nKey\s*=\s*(['"])([^'"]+)\1/g, keyGroup: 2 },
+    // <Trans i18nKey={'key'} />
+    { kind: 'i18nKey', regex: /\bi18nKey\s*=\s*\{\s*(['"])([^'"]+)\1\s*\}/g, keyGroup: 2 },
+  ]
+
+  for (const { kind, regex, keyGroup } of patterns) {
+    for (const match of source.matchAll(regex)) {
+      const key = match[keyGroup]
+      if (!key || !isStaticKey(key)) continue
+      const { line, column } = lineColumn(source, match.index ?? 0)
+      refs.push({ key, file: rel, line, column, kind })
+    }
+  }
+
+  return refs
+}
+
+const references: Reference[] = []
+for (const root of SCAN_ROOTS) {
+  const path = resolve(REPO_ROOT, root)
+  try {
+    if (statSync(path).isDirectory()) {
+      for (const file of walk(path)) references.push(...collectReferences(file))
+    }
+  } catch {
+    // Optional scan root absent in some checkouts.
+  }
+}
+
+function hasLocaleKey(key: string): boolean {
+  if (enKeys.has(key)) return true
+  // i18next pluralization callsites use the base key with `{ count }`, while
+  // locale files store the concrete plural forms. Treat the base key as
+  // covered when the required English plural pair exists.
+  return enKeys.has(`${key}_one`) && enKeys.has(`${key}_other`)
+}
+
+const missing = references.filter((ref) => !hasLocaleKey(ref.key))
+
+if (missing.length) {
+  console.error('i18n coverage check failed:')
+  for (const ref of missing) {
+    console.error(`  ${ref.file}:${ref.line}:${ref.column} ${ref.kind} references missing key "${ref.key}"`)
+  }
+  console.error(`\n${missing.length} missing i18n key reference(s).`)
+  process.exit(1)
+}
+
+const uniqueKeys = new Set(references.map((ref) => ref.key))
+console.log(`i18n coverage OK (${uniqueKeys.size} static keys referenced, ${enKeys.size} keys available)`)

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["bun"],
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}


### PR DESCRIPTION
## Summary

Restores the current `Validate` workflow baseline on `main`.

`bun run validate:ci` was failing before any feature-specific checks could be trusted because:

1. Several package tsconfigs extend `../../tsconfig.base.json`, but the root `tsconfig.base.json` file was missing.
2. `validate:ci` calls `lint:i18n:coverage`, but `scripts/check-i18n-coverage.ts` was missing.
3. Once the shared TS config was restored, three strict `pi-agent-server` type errors surfaced.

## Changes

- Add root `tsconfig.base.json` used by server-side package tsconfigs.
- Add `scripts/check-i18n-coverage.ts` to validate static `t('...')`, `i18n.t('...')`, and `<Trans i18nKey="...">` references against `en.json`.
  - Literal keys only; dynamic keys are skipped intentionally.
  - Base plural callsites are accepted when `_one` / `_other` exist.
- Fix `pi-agent-server` strictness issues:
  - guard DuckDuckGo `uddg` regex capture before `decodeURIComponent`
  - prove the prefetch list’s first item exists after the `length >= 2` check
  - assert the first `content-type.split(';')` segment exists

## Validation

Passed locally:

- `bun run validate:ci`
- `bun test packages/pi-agent-server/src/model-resolution.test.ts packages/pi-agent-server/src/session-tool-registration.test.ts packages/pi-agent-server/src/tools/search/create-search-tool.test.ts packages/pi-agent-server/src/tools/search/resolve-provider.test.ts packages/pi-agent-server/src/tools/search/providers/chatgpt.test.ts packages/pi-agent-server/src/tools/search/providers/openai.test.ts`

GitHub Actions note: this PR’s `Validate` workflow currently shows `action_required` because it was opened from a fork and needs maintainer approval to run.

🤖 Prepared with Craft Agent
