### PR TITLE
[codex] Add Native Agent Room P0-P3

### DIFF
--- a/docs/native-agent-room-implementation-log.md
+++ b/docs/native-agent-room-implementation-log.md
@@ -1,0 +1,324 @@
+# Native Agent Room Implementation Log
+
+## 2026-07-02: Repository Inspection and P0 Blocker
+
+Milestone completed: none. P0 has not started.
+
+Files changed:
+
+- `native-agent-room-blueprint-v0.1.md`
+- `docs/native-agent-room-implementation-plan.md`
+- `docs/native-agent-room-implementation-log.md`
+
+Behavior added:
+
+- Saved the Blueprint into the project root.
+- Added a P0-P3 implementation plan based on the Blueprint.
+- Recorded that the current worktree has no editable Craft Agents source code.
+
+Verification commands run:
+
+- `find . -maxdepth 4 -not -path './.git/*' -print | sort`
+- `git status -sb`
+- `git remote -v`
+- `sed -n '1,260p' native-agent-room-blueprint-v0.1.md`
+- `sed -n '261,620p' native-agent-room-blueprint-v0.1.md`
+- `sed -n '620,1125p' native-agent-room-blueprint-v0.1.md`
+- `sed -n '1126,1605p' native-agent-room-blueprint-v0.1.md`
+- `sed -n '1606,1935p' native-agent-room-blueprint-v0.1.md`
+- `find /Applications/Craft\ Agents.app/Contents/Resources/app -maxdepth 2 -type f`
+- `sed -n '1,220p' /Applications/Craft\ Agents.app/Contents/Resources/app/package.json`
+- `git -C /Applications/Craft\ Agents.app/Contents/Resources/app status -sb`
+
+Result:
+
+- Current project worktree only contained `.git` and the Blueprint before this log/plan were added.
+- No `package.json`, `src`, `packages`, `lib`, `server`, `app`, test files, build config, or persistence layer exist in the current worktree.
+- The installed app bundle contains application resources, but it is not a git repository and its TypeScript/package files are not an editable source worktree for this project.
+- No test, typecheck, or build command is available in the current worktree.
+
+Known gaps:
+
+- Existing Craft Agents data model, storage, API, UI, test, and agent/session patterns cannot be identified from the current worktree because the source code is absent.
+- P0 data model and persistence cannot be implemented or verified until the editable source repository is available.
+
+Next milestone:
+
+- P0: Data model and persistence, after the correct Craft Agents source repository is provided or placed in this project.
+
+## 2026-07-02: Source Availability Recheck
+
+Milestone completed: none. P0 is still blocked.
+
+Files changed:
+
+- `docs/native-agent-room-implementation-log.md`
+
+Behavior added:
+
+- Rechecked whether editable Craft Agents source code had been added to the current project.
+- Checked whether the installed app bundle could be treated as a complete source workspace.
+
+Verification commands run:
+
+- `find . -maxdepth 4 -not -path './.git/*' -print | sort`
+- `git status -sb`
+- `find /Applications/Craft\ Agents.app/Contents/Resources/app -maxdepth 2 -type f \( -name 'package.json' -o -name 'pnpm-workspace.yaml' -o -name 'yarn.lock' -o -name 'pnpm-lock.yaml' -o -name 'package-lock.json' -o -name 'turbo.json' -o -name 'vitest.config.*' -o -name 'tsconfig.json' \) -print | sort`
+- `find /Applications/Craft\ Agents.app/Contents/Resources/app/packages -maxdepth 2 -type d -print | sort`
+- `rg -n "workspace:\*|scripts|test|typecheck|build" /Applications/Craft\ Agents.app/Contents/Resources/app/package.json`
+
+Result:
+
+- Current project still has no editable Craft Agents application source, package manifest, tests, persistence layer, API layer, or UI layer.
+- The installed app bundle exposes some TypeScript files, but it is not a git repository.
+- Its `package.json` depends on `@craft-agent/core`, `@craft-agent/messaging-gateway`, `@craft-agent/server-core`, `@craft-agent/shared`, and `@craft-agent/ui` via `workspace:*`.
+- The app bundle only contains `packages/shared` under `packages/`, so it is not a complete workspace and cannot be reliably used for P0-P3 implementation or verification.
+
+Known gaps:
+
+- P0-P3 still require the editable Craft Agents source repository.
+- No relevant test/typecheck/build command is available in the current project.
+
+Next milestone:
+
+- P0: Data model and persistence, once the correct source repository is available.
+
+## 2026-07-02: OSS Repository Attached
+
+Milestone completed: setup only. P0 has not started.
+
+Files changed:
+
+- `docs/native-agent-room-implementation-plan.md`
+- `docs/native-agent-room-implementation-log.md`
+
+Behavior added:
+
+- Added `https://github.com/craft-ai-agents/craft-agents-oss.git` as `origin`.
+- Fetched `origin/main` and checked out the OSS source into the current worktree.
+- Updated the implementation plan to target `packages/shared/src/native-agent-room/` with workspace-scoped JSON persistence.
+
+Verification commands run:
+
+- `git remote add origin https://github.com/craft-ai-agents/craft-agents-oss.git`
+- `git fetch origin main`
+- `git ls-tree -r --name-only origin/main | rg '^(native-agent-room-blueprint-v0\.1\.md|docs/native-agent-room-implementation-(plan|log)\.md)$'`
+- `git checkout -B main origin/main`
+- `git status -sb`
+- `sed -n '1,240p' package.json`
+- `sed -n '1,260p' packages/shared/package.json`
+- `sed -n '1,320p' packages/shared/src/workspaces/storage.ts`
+- `sed -n '1,340p' packages/shared/src/sessions/storage.ts`
+- `sed -n '1,260p' packages/shared/src/statuses/storage.ts`
+- `sed -n '1,220p' packages/shared/src/views/storage.ts`
+
+Result:
+
+- The current worktree now contains the Craft Agents OSS monorepo.
+- Existing storage and tests are file-based, workspace-scoped, and centered in `packages/shared`.
+- No P0 implementation has been made yet.
+
+Known gaps:
+
+- Native Agent Room objects, persistence, room operations, RoomBus, inbox routing, attention routing, and ContextPack generation still need implementation.
+
+Next milestone:
+
+- P0: Data model and persistence.
+
+## 2026-07-02: P0 Data Model and Persistence
+
+Milestone completed: P0.
+
+Files changed:
+
+- `packages/shared/package.json`
+- `packages/shared/src/native-agent-room/index.ts`
+- `packages/shared/src/native-agent-room/storage.ts`
+- `packages/shared/src/native-agent-room/types.ts`
+- `packages/shared/src/native-agent-room/__tests__/storage.test.ts`
+- `docs/native-agent-room-implementation-log.md`
+
+Behavior added:
+
+- Added Native Agent Room domain types for Project, Room, TeamTemplate, RoleCard, RoomMember, Task, Artifact, Decision, RoomBusEvent, AgentInbox, TimelineItem, and ContextPack.
+- Added workspace-scoped JSON persistence under `{workspaceRootPath}/native-agent-room/`.
+- Added CRUD helpers for projects, team templates, rooms, project artifacts, and room-available artifacts.
+- Added public shared package export `@craft-agent/shared/native-agent-room`.
+- Preserved existing app behavior by not wiring UI/API/runtime paths yet.
+
+Verification commands run:
+
+- `bun install`
+- `bun test packages/shared/src/native-agent-room/__tests__/storage.test.ts`
+- `bun run typecheck:shared`
+
+Result:
+
+- P0 focused test passed: 3 tests, 12 assertions.
+- Shared package typecheck passed.
+
+Known gaps:
+
+- Room creation flows are not implemented yet.
+- RoomBus events do not route to inboxes yet.
+- ContextPack generation and attention routing are not implemented yet.
+- No polished UI was added by design.
+
+Next milestone:
+
+- P1: Room creation and role configuration.
+
+## 2026-07-02: P1 Room Creation and Role Configuration
+
+Milestone completed: P1.
+
+Files changed:
+
+- `packages/shared/src/native-agent-room/types.ts`
+- `packages/shared/src/native-agent-room/storage.ts`
+- `packages/shared/src/native-agent-room/index.ts`
+- `packages/shared/src/native-agent-room/room-operations.ts`
+- `packages/shared/src/native-agent-room/__tests__/room-operations.test.ts`
+- `docs/native-agent-room-implementation-log.md`
+
+Behavior added:
+
+- Added room-level workflow and RoomBus policy configuration snapshots.
+- Implemented Create Room from Team Template.
+- Implemented Duplicate Room Config without copying tasks, artifacts, decisions, events, timeline, or inbox item history.
+- Implemented Fork Room with copied history and remapped room-scoped ids.
+- Implemented Save Room as Team Template using only role, workflow, and RoomBus policy configuration.
+- Implemented room role prompt editing without mutating the source template.
+
+Verification commands run:
+
+- `bun test packages/shared/src/native-agent-room/__tests__/storage.test.ts packages/shared/src/native-agent-room/__tests__/room-operations.test.ts`
+- `bun run typecheck:shared`
+
+Result:
+
+- Native Agent Room P0/P1 focused tests passed: 8 tests, 51 assertions.
+- Shared package typecheck passed.
+
+Known gaps:
+
+- RoomBus protocol validation and inbox routing are not implemented yet.
+- Attention routing and ContextPack generation are not implemented yet.
+- No polished UI was added by design.
+
+Next milestone:
+
+- P2: RoomBus and Agent Inbox.
+
+## 2026-07-02: P2 RoomBus and Agent Inbox
+
+Milestone completed: P2.
+
+Files changed:
+
+- `packages/shared/src/native-agent-room/index.ts`
+- `packages/shared/src/native-agent-room/room-bus.ts`
+- `packages/shared/src/native-agent-room/__tests__/room-bus.test.ts`
+- `docs/native-agent-room-implementation-log.md`
+
+Behavior added:
+
+- Implemented RoomBus event publishing.
+- Implemented target resolution for agent, role, all, task, and artifact targets.
+- Implemented mechanical validation for event type, resolvable targets, request `expectedOutput`, TTL/max hops, and simple parent-chain loop prevention.
+- Implemented inbox routing for target agents and sender tracking for open request events.
+- Implemented parent request resolution for answer/review/resolve responses.
+- Implemented minimal task status updates for review/blocker events.
+
+Verification commands run:
+
+- `bun test packages/shared/src/native-agent-room/__tests__/storage.test.ts packages/shared/src/native-agent-room/__tests__/room-operations.test.ts packages/shared/src/native-agent-room/__tests__/room-bus.test.ts`
+- `bun run typecheck:shared`
+
+Result:
+
+- Native Agent Room P0-P2 focused tests passed: 14 tests, 67 assertions.
+- Shared package typecheck passed.
+
+Known gaps:
+
+- `@Agent`, `@Role`, `@all`, `@task`, and `@artifact` attention signals are not implemented yet.
+- ContextPack generation is not implemented yet.
+- No polished UI was added by design.
+
+Next milestone:
+
+- P3: Attention Model and Context Resolver.
+
+## 2026-07-02: P3 Attention Model and Context Resolver
+
+Milestone completed: P3.
+
+Files changed:
+
+- `packages/shared/src/native-agent-room/index.ts`
+- `packages/shared/src/native-agent-room/attention.ts`
+- `packages/shared/src/native-agent-room/room-bus.ts`
+- `packages/shared/src/native-agent-room/__tests__/attention.test.ts`
+- `docs/native-agent-room-implementation-log.md`
+
+Behavior added:
+
+- Implemented explicit attention parsing for `@Agent`, `@Role`, `@all`, `@task:<id>`, and `@artifact:<id>`.
+- Implemented implicit routing for task owners, artifact owners, dependent task owners, and decision relevance.
+- Integrated attention routing into RoomBus event publishing so messages and updates enter the relevant Agent Inboxes.
+- Implemented ContextPack generation with RoleCard, Member Directory, Current Task, Required Artifacts, Relevant Decisions, Attention Events, Inbox Items, Timeline, and Context Used.
+- Excluded deprecated artifacts, rejected decisions, unrelated room content, and unrelated transcript events from ContextPack results.
+
+Verification commands run:
+
+- `bun test packages/shared/src/native-agent-room/__tests__/storage.test.ts packages/shared/src/native-agent-room/__tests__/room-operations.test.ts packages/shared/src/native-agent-room/__tests__/room-bus.test.ts packages/shared/src/native-agent-room/__tests__/attention.test.ts`
+- `bun run typecheck:shared`
+
+Result:
+
+- Native Agent Room P0-P3 focused tests passed: 19 tests, 89 assertions.
+- Shared package typecheck passed.
+
+Known gaps:
+
+- P4 Artifact/Decision system hardening is not implemented.
+- P5 automatic Room Timeline generation is not implemented.
+- P6 polished three-column UI is not implemented.
+- Native Agent Room is available as shared business logic; app UI/API wiring remains future work.
+
+Next milestone:
+
+- P4, outside the requested scope.
+
+## 2026-07-02: Final P0-P3 Verification
+
+Milestone completed: P0-P3 final verification.
+
+Files changed:
+
+- `docs/native-agent-room-implementation-log.md`
+
+Behavior added:
+
+- Restored unrelated `bun.lock` churn caused by dependency installation.
+- Re-ran final P0-P3 verification after restoring the lockfile.
+
+Verification commands run:
+
+- `bun test packages/shared/src/native-agent-room/__tests__/storage.test.ts packages/shared/src/native-agent-room/__tests__/room-operations.test.ts packages/shared/src/native-agent-room/__tests__/room-bus.test.ts packages/shared/src/native-agent-room/__tests__/attention.test.ts`
+- `bun run typecheck:shared`
+
+Result:
+
+- Native Agent Room P0-P3 focused tests passed: 19 tests, 89 assertions.
+- Shared package typecheck passed.
+
+Known gaps:
+
+- Same as P3: UI/API wiring and P4+ are outside the requested scope.
+
+Next milestone:
+
+- None for this request.

--- a/docs/native-agent-room-implementation-plan.md
+++ b/docs/native-agent-room-implementation-plan.md
@@ -1,0 +1,107 @@
+# Native Agent Room Implementation Plan
+
+Source of truth: [native-agent-room-blueprint-v0.1.md](../native-agent-room-blueprint-v0.1.md)
+
+## Current Repository State
+
+The current git worktree is based on `craft-ai-agents/craft-agents-oss` at `origin/main`.
+
+Relevant existing patterns:
+
+- Monorepo package manager: Bun.
+- Shared domain logic lives under `packages/shared/src`.
+- Workspace-scoped persistence uses files under the workspace root, for example `sessions/`, `statuses/config.json`, `views.json`, and `sources/`.
+- Tests use `bun:test` with temporary workspace directories.
+- Existing timestamps use millisecond numbers, so Native Agent Room storage follows that convention while preserving the Blueprint object model.
+
+Implementation landing zone:
+
+- `packages/shared/src/native-agent-room/`
+- Persisted files under `{workspaceRootPath}/native-agent-room/`
+- Public export path: `@craft-agent/shared/native-agent-room`
+
+## Implementation Principles
+
+- Implement only Blueprint milestones P0 through P3.
+- Preserve existing Craft Agents behavior unless a change is required by P0-P3.
+- Keep Project, Room, Team Template, RoomBus Event, Agent Inbox, Task, Artifact, Decision, Timeline, and Context Pack as structured facts.
+- Do not implement polished full UI, complex DAG scheduling, automatic parallel execution, deployment, or unrelated refactors.
+- Do not advance to the next milestone until the previous milestone is implemented and verified.
+
+## P0: Data Model and Persistence
+
+Goal: Craft Agents natively knows Project and Room exist.
+
+Implementation:
+
+- Add domain types for Project, Room, TeamTemplate, RoleCard, RoomMember, Task, Artifact, Decision, RoomBusEvent, AgentInbox, TimelineItem, and ContextPack.
+- Add filesystem storage adapters following the existing workspace-scoped JSON persistence pattern.
+- Add repository/service functions for create/read/update operations needed by later milestones.
+- Add focused tests for serialization, persistence, and basic relations:
+  - Project owns rooms, artifacts, and team templates.
+  - Room owns members, tasks, artifacts, decisions, events, inboxes, and timeline items.
+  - Project-level artifacts can be referenced by rooms.
+
+Verification gate:
+
+- Run the repository's relevant unit tests and typecheck/build command.
+- P1 must not start until P0 passes.
+
+## P1: Room Creation and Role Configuration
+
+Goal: users can create rooms and configure multiple agent roles.
+
+Implementation once P0 is verified:
+
+- Implement Create Room from Team Template.
+- Implement Duplicate Room Config without copying history, artifacts, tasks, decisions, inboxes, or timeline.
+- Implement Fork Room with copied history, artifacts, tasks, decisions, timeline, and context state.
+- Implement Save Room as Team Template with only role, prompt, workflow, context policy, and RoomBus policy.
+- Add the minimal role prompt editing path required by existing UI/API conventions.
+
+Verification gate:
+
+- Tests prove the four creation/copy flows copy only the Blueprint-approved state.
+- Run typecheck/build and relevant UI/API tests.
+- P2 must not start until P1 passes.
+
+## P2: RoomBus and Agent Inbox
+
+Goal: agents communicate through controlled protocol events that populate the right inboxes.
+
+Implementation once P1 is verified:
+
+- Implement RoomBus events for ask_agent, answer_agent, raise_blocker, request_review, review_result, handoff_task, artifact_update, and announcement.
+- Validate target existence, event type, request expectedOutput, TTL/max hops, and simple loop prevention.
+- Route direct RoomBus requests to target Agent Inboxes.
+- Keep event records observable and linked to task/artifact/decision where present.
+
+Verification gate:
+
+- Tests prove direct target routing and request validation.
+- Run typecheck/build and relevant service/API tests.
+- P3 must not start until P2 passes.
+
+## P3: Attention Model and Context Resolver
+
+Goal: an agent reads a Context Pack instead of the full transcript.
+
+Implementation once P2 is verified:
+
+- Route @Agent, @Role, @all, @task, and @artifact attention signals.
+- Route implicit task owner, artifact owner, dependency update, and decision relevance signals.
+- Generate ContextPack containing RoleCard, Member Directory, Current Task, Required Artifacts, Direct Mentions, Assigned RoomBus Events, Relevant Decisions, Room Timeline, InboxItems, and ContextUsed.
+- Exclude full transcript, private memory, unrelated rooms, unrelated historical events, deprecated artifacts, and rejected decisions.
+
+Verification gate:
+
+- Tests prove included and excluded context for at least the Blueprint's Frontend/Pricing Page scenario.
+- Run typecheck/build and relevant service/API tests.
+
+## Out of Scope for P0-P3
+
+- Polished Room UI.
+- Complex DAG scheduling.
+- Automatic parallel execution.
+- Deployment or release packaging.
+- Broad rewrites of the existing session UI.

--- a/native-agent-room-blueprint-v0.1.md
+++ b/native-agent-room-blueprint-v0.1.md
@@ -1,0 +1,1924 @@
+可以。下面是一版 **Native Agent Room Blueprint v0.1**，按我们已经确定的方向整理，目标是能直接指导后续开发、拆任务、做验收。
+
+---
+
+# Native Agent Room Blueprint v0.1
+
+## 0. 一句话定义
+
+**Native Agent Room 是 Craft Agents 的原生多 Agent 协作空间。**
+
+它以 **Project** 作为上层对象，以 **Room** 承载具体页面 / 功能 / 任务协作，以 **RoomBus** 管理 Agent-to-Agent 受控通信，以 **Agent Inbox + Attention Model** 解决上下文分发，以 **Artifact / Task / Decision / RoomBus Event** 作为事实来源，以 **Room Timeline** 表达协作进度。
+
+核心不是做一个热闹的 AI 群聊，而是做：
+
+> **可复用、可观察、可追踪、可评审的多 Agent 项目协作系统。**
+
+---
+
+# 1. 我们的目标
+
+## 1.1 产品目标
+
+构建一个 Craft Agents 原生能力，使用户可以：
+
+```text
+创建 Project
+↓
+配置共享文档、设计规范、团队模板
+↓
+创建多个 Room
+↓
+在 Room 内配置多个 Agent 角色
+↓
+Agent 通过群聊式界面推进任务
+↓
+Agent 之间通过 RoomBus 受控协作
+↓
+系统通过 Inbox / @ / Task / Artifact / Decision 进行上下文分发
+↓
+最终产出可审阅的页面、代码、测试报告、设计规范等 artifacts
+```
+
+第一个核心场景是：
+
+> **完整网站 / 页面开发流程。**
+
+例如：
+
+```text
+Project: SaaS 官网
+├── Project-level Artifacts
+│   ├── design-tokens.json
+│   ├── design-token-guide.md
+│   ├── component-guidelines.md
+│   ├── brand-voice.md
+│   └── shared-rules.md
+│
+├── Team Templates
+│   └── Page Development Team
+│
+└── Rooms
+    ├── Home Page Room
+    ├── Pricing Page Room
+    ├── Features Page Room
+    └── Contact Page Room
+```
+
+每个 Room 可以独立推进一个页面，但共享同一个 Project 的设计规范、组件规则、品牌语气和团队模板。
+
+---
+
+## 1.2 设计目标
+
+这个系统要解决五个问题。
+
+### 目标一：让 Agent 知道彼此存在
+
+每个 Agent 不再是孤立 session，而是 Room 里的成员。
+
+它知道：
+
+```text
+房间里有哪些 Agent
+每个 Agent 负责什么
+自己可以向谁提问
+谁会消费自己的产物
+谁可以 review 自己的产物
+```
+
+---
+
+### 目标二：让 Agent 协作受控，而不是自由乱聊
+
+Agent 不直接互相调用，而是通过 RoomBus：
+
+```text
+Agent A
+↓
+RoomBus
+↓
+Agent B
+```
+
+RoomBus 负责记录：
+
+```text
+谁向谁提了要求
+请求类型是什么
+关联哪个 task / artifact
+状态是否 resolved
+是否可能出现循环
+```
+
+MVP 阶段 RoomBus **不需要判断请求是否合理**，只需要做协议校验、记录和防死循环。
+
+---
+
+### 目标三：降低上下文压力
+
+Agent 不读取完整群聊。
+
+Agent 的上下文来自：
+
+```text
+Role Contract
++ Member Directory
++ Current Task
++ Required Artifacts
++ Direct Mentions
++ Assigned RoomBus Events
++ Owned Task / Artifact Updates
++ Dependency Updates
++ Relevant Decisions
++ Room Timeline
+```
+
+默认不包含：
+
+```text
+完整聊天记录
+其他 Agent 的私有上下文
+无关 Room 内容
+无关历史消息
+已废弃 artifact
+被拒绝的 decision
+无关 resolved events
+```
+
+---
+
+### 目标四：让用户能看懂协作过程
+
+用户看到的是群聊式推进，但底层是结构化事件。
+
+例如：
+
+```text
+Frontend → Backend [ask_agent]
+api-contract v1 缺少 yearlyPrice，请补充。
+
+Backend → Frontend [answer_agent]
+已更新 api-contract v2，新增 yearlyPrice。
+
+QA → Frontend [review_result]
+mobile pricing card overflow，severity: blocking。
+```
+
+用户还能看到每个 Agent 读取了哪些上下文：
+
+```text
+Frontend Agent read:
+- pricing-ui-spec.md@v2
+- design-tokens.json@v3
+- api-contract-pricing.json@v2
+- QA-004 mobile overflow issue
+- @Frontend from UI Designer
+```
+
+---
+
+### 目标五：让 Room 可复用、可复制、可 fork
+
+用户可能要开发 6 到 8 个页面，因此 Room 配置必须可复用。
+
+最终支持四类操作：
+
+```text
+1. Create Room from Team Template
+2. Duplicate Room Config
+3. Fork Room
+4. Save Room as Team Template
+```
+
+其中：
+
+```text
+Team Template 复用角色、prompt、工具权限、默认 workflow。
+Room Instance 保存具体页面的上下文、任务、产物和事件。
+Fork Room 用于基于已有上下文探索另一个方案。
+```
+
+---
+
+# 2. 上下文环境
+
+这里的“上下文环境”分两层：
+
+```text
+产品上下文环境
+Agent 上下文环境
+```
+
+---
+
+## 2.1 产品上下文环境
+
+系统最终由这些核心对象组成：
+
+```text
+Project
+├── Project Artifacts
+├── Team Templates
+└── Rooms
+
+Room
+├── Members
+├── Tasks
+├── Artifacts
+├── Decisions
+├── RoomBus Events
+├── Agent Inboxes
+└── Room Timeline
+```
+
+---
+
+## 2.2 Project
+
+Project 是最高层对象。
+
+不要叫 Website Project，也不要叫 Site Project，统一叫：
+
+```text
+Project
+```
+
+Project 保存跨 Room 共享的东西：
+
+```text
+全局 design token
+组件规范
+品牌语气
+共享规则
+团队模板
+多个 Room
+```
+
+### Project 示例
+
+```text
+Project: Acme SaaS Website
+
+Project-level Artifacts:
+- design-tokens.json
+- design-token-guide.md
+- component-guidelines.md
+- responsive-rules.md
+- brand-voice.md
+- shared-rules.md
+
+Rooms:
+- Home Page Room
+- Pricing Page Room
+- Features Page Room
+- Contact Page Room
+```
+
+---
+
+## 2.3 Room
+
+Room 是具体协作空间。
+
+一个 Room 可以对应：
+
+```text
+一个页面
+一个功能
+一个模块
+一个视频脚本
+一个设计探索
+一个测试流程
+```
+
+MVP 先聚焦：
+
+```text
+一个 Room = 一个页面开发空间
+```
+
+例如：
+
+```text
+Room: Pricing Page Room
+Goal: 开发 SaaS pricing page
+Template: Page Development Team
+Project: Acme SaaS Website
+```
+
+Room 内部包含：
+
+```text
+成员
+群聊事件流
+任务列表
+产物列表
+决策记录
+Agent Inbox
+Room Timeline
+```
+
+---
+
+## 2.4 Team Template
+
+Team Template 是角色配置的复用单元。
+
+例如：
+
+```text
+Page Development Team
+├── Facilitator Agent
+├── PM Agent
+├── UX Agent
+├── Design Token Agent
+├── UI Designer Agent
+├── Frontend Agent
+├── Backend API Agent
+├── SEO/GEO Agent
+├── QA Agent
+└── Code Reviewer Agent
+```
+
+Team Template 保存：
+
+```text
+角色列表
+每个角色 prompt
+每个角色职责
+每个角色可用动作
+默认 workflow
+RoomBus policy
+默认 context policy
+```
+
+它不保存：
+
+```text
+某个页面的聊天历史
+某个页面的 artifact
+某个页面的 task
+某个页面的 decision
+```
+
+---
+
+## 2.5 Project-level Design Token 文档
+
+Design Token 应该沉淀为 Project-level artifact。
+
+建议至少两份：
+
+```text
+design-tokens.json
+design-token-guide.md
+```
+
+`design-tokens.json` 给 Agent 和代码使用：
+
+```json
+{
+  "color": {
+    "background": "#FFFFFF",
+    "surface": "#F7F8FA",
+    "textPrimary": "#111827",
+    "textSecondary": "#6B7280",
+    "brandPrimary": "#2563EB"
+  },
+  "spacing": {
+    "xs": "4px",
+    "sm": "8px",
+    "md": "16px",
+    "lg": "24px",
+    "xl": "32px"
+  },
+  "radius": {
+    "sm": "6px",
+    "md": "10px",
+    "lg": "16px"
+  }
+}
+```
+
+`design-token-guide.md` 给 Agent 理解规则：
+
+```text
+所有页面必须使用 Project-level design tokens。
+不得硬编码颜色、spacing、radius。
+页面 Room 可以提出 token change request，但不能直接修改全局 token。
+```
+
+每个 Room 默认继承 Project-level artifacts，但不同 Agent 读取范围不同：
+
+```text
+UI Designer 读取 design token 和 component guidelines。
+Frontend 读取 design token、UI spec、API contract。
+QA 读取 design-token-guide 中的验收规则。
+Backend 默认不读取 design token。
+```
+
+---
+
+# 3. 上下文系统设计
+
+## 3.1 核心原则
+
+我们最终采用：
+
+> **Attention-driven Context**
+
+也就是：
+
+```text
+用 @ 和责任归属决定 Agent 的注意力。
+用 Artifact 和 Task 决定 Agent 的事实来源。
+用 Timeline 决定 Agent 的阶段感。
+```
+
+Agent 不读取完整群聊。  
+Agent 读取自己的 Context Pack。
+
+---
+
+## 3.2 Agent Context 公式
+
+每次 Agent 被调用时，它拿到的上下文是：
+
+```text
+Agent Context =
+Role Contract
++ Member Directory
++ Current Task
++ Required Artifacts
++ Direct Mentions
++ Assigned RoomBus Events
++ Owned Task / Artifact Updates
++ Dependency Updates
++ Relevant Decisions
++ Room Timeline
+```
+
+默认排除：
+
+```text
+Full Transcript
+Other Agents' Private Memory
+Unrelated Messages
+Unrelated Rooms
+Deprecated Artifacts
+Rejected Decisions
+Resolved Events Not Linked to Current Task
+```
+
+---
+
+## 3.3 @ 是核心上下文信号
+
+Agent 主要关注：
+
+```text
+@我的消息
+@我的角色的消息
+@all 消息
+@我负责的 task
+@我负责的 artifact
+```
+
+例如：
+
+```text
+@Frontend 请确认 annual toggle 的状态处理。
+```
+
+一定进入 Frontend Agent Inbox。
+
+```text
+@QA 请基于 ui-spec v2 生成测试用例。
+```
+
+一定进入 QA Agent Inbox。
+
+```text
+@all 所有页面必须使用 design-tokens.json@v3。
+```
+
+进入所有 Agent Inbox，并生成 Project-level Decision 或 Artifact Update。
+
+---
+
+## 3.4 @ 不是唯一信号
+
+除了显式 @，还要处理隐式责任关系。
+
+例如：
+
+```text
+api-contract-pricing.json 更新到 v3。
+```
+
+即使没有 @Frontend，只要 Frontend 当前 task 依赖这个 artifact，也应该进入 Frontend Inbox。
+
+最终规则：
+
+```text
+有 @ = 一定进入目标 Agent Inbox
+无 @ + 有 task / artifact / decision / dependency 关联 = 进入相关 Agent Inbox
+无 @ + 无关联 = 不进入 Agent Context
+```
+
+---
+
+## 3.5 Agent Inbox
+
+每个 Agent 都有自己的 Inbox。
+
+进入 Inbox 的内容包括：
+
+```text
+1. @我的消息
+2. @我的角色的消息
+3. @all 消息
+4. 发给我的 ask_agent
+5. 发给我的 request_review
+6. 指派给我的 blocker
+7. 指派给我的 handoff
+8. 针对我 artifact 的 review issue
+9. 我订阅的 artifact 更新
+10. 我的 task 状态变化
+11. 我发出但尚未 resolved 的 request
+```
+
+区分三个对象：
+
+```text
+Room Transcript = 全部群聊记录，主要给用户看
+Agent Inbox = 某个 Agent 需要关注的信息
+Context Pack = Agent 实际执行任务时读取的上下文
+```
+
+---
+
+## 3.6 Room Timeline
+
+总结机制保留，但定位要明确。
+
+它不作为事实来源，只作为时间线。
+
+```text
+Room Timeline:
+1. 用户提出 Pricing Page 开发需求。
+2. PM 和 UX 完成需求澄清。
+3. Backend 提供 api-contract-pricing.json@v2。
+4. UI Designer 提供 pricing-ui-spec.md@v2。
+5. Frontend 进入实现阶段。
+6. QA 提出 mobile overflow blocking issue。
+```
+
+Room Timeline 用来回答：
+
+```text
+现在走到哪一步？
+大概发生了什么？
+哪些阶段已经完成？
+当前卡在哪里？
+```
+
+事实来源仍然是：
+
+```text
+Artifact
+Task
+Decision
+RoomBus Event
+```
+
+不要让 Agent 只根据 Timeline 做具体判断。
+
+---
+
+## 3.7 Agent 缺少上下文时必须提问
+
+Agent 不应该猜。
+
+例如 Frontend Agent 缺少 API contract：
+
+```text
+Frontend Agent:
+我缺少 api-contract-pricing.json，无法实现 API integration。
+我将向 Backend API Agent 请求该 artifact。
+```
+
+生成 RoomBus event：
+
+```text
+Frontend → Backend [ask_agent]
+请提供 pricing API contract，包括 endpoint、字段、monthly/yearly price、enterprise CTA、错误状态和 mock data。
+```
+
+这是系统的核心行为规则之一。
+
+---
+
+## 3.8 用户必须能看到 Agent 读取了哪些上下文
+
+每次 Agent 回复旁边显示：
+
+```text
+Context Used
+```
+
+例如：
+
+```text
+Frontend Agent used:
+- RoleCard: Frontend Engineer
+- Task: Implement Pricing Page
+- Artifacts:
+  - pricing-ui-spec.md@v2
+  - design-tokens.json@v3
+  - api-contract-pricing.json@v2
+- Attention Events:
+  - @Frontend from UI Designer
+  - QA review issue: mobile overflow
+  - Backend answer: yearlyPrice added
+- Timeline:
+  - Current phase: Implementation
+```
+
+这能帮助用户判断 Agent 是否漏读了关键上下文。
+
+---
+
+# 4. Agent 容器设计
+
+每个 Agent 不是单纯一个 prompt，而是一个 Agent Container。
+
+## 4.1 Agent Container 包含
+
+```text
+RoleCard
+Session
+Inbox
+Local Memory
+Context Policy
+Allowed RoomBus Actions
+Tool Permissions
+Owned Tasks
+Owned Artifacts
+Subscriptions
+```
+
+---
+
+## 4.2 Agent Container 示例
+
+```text
+Frontend Agent Container
+├── RoleCard: Frontend Engineer
+├── Session: session_frontend_xxx
+├── Inbox: frontend_inbox
+├── Local Memory: frontend private working state
+├── Context Policy:
+│   ├── always include ui-spec
+│   ├── always include design-tokens
+│   ├── always include api-contract
+│   └── include QA issues when task is bug_fix
+├── Allowed RoomBus Actions:
+│   ├── ask_agent
+│   ├── raise_blocker
+│   ├── request_review
+│   ├── propose_change
+│   └── mark_task_done
+└── Subscriptions:
+    ├── UI spec updates
+    ├── design token updates
+    ├── API contract updates
+    └── QA issues assigned to frontend
+```
+
+---
+
+# 5. RoomBus 设计
+
+## 5.1 RoomBus 定义
+
+RoomBus 是 Agent-to-Agent 的中间节点。
+
+它负责：
+
+```text
+记录事件
+转发请求
+更新 Inbox
+更新 Task 状态
+更新 Timeline
+防止循环
+生成可观察日志
+```
+
+它不负责：
+
+```text
+判断请求内容是否合理
+替 Agent 做业务决策
+替用户做最终审批
+```
+
+---
+
+## 5.2 RoomBus 基础动作
+
+MVP 至少支持：
+
+```text
+ask_agent
+answer_agent
+raise_blocker
+resolve_blocker
+handoff_task
+request_review
+review_result
+propose_change
+artifact_update
+decision
+approval_request
+announcement
+```
+
+---
+
+## 5.3 RoomBus 事件示例
+
+```json
+{
+  "id": "event_001",
+  "roomId": "room_pricing_page",
+  "from": "frontend_agent",
+  "to": ["backend_api_agent"],
+  "type": "ask_agent",
+  "taskId": "task_frontend_pricing",
+  "artifactId": "api_contract_pricing",
+  "payload": {
+    "message": "api-contract v1 缺少 yearlyPrice，annual toggle 无法实现。",
+    "expectedOutput": "更新后的 API contract 或解释为什么不支持"
+  },
+  "status": "open",
+  "createdAt": "2026-07-02T10:00:00Z"
+}
+```
+
+---
+
+## 5.4 RoomBus 最小规则
+
+RoomBus 不做复杂语义判断，但必须做机械性约束：
+
+```text
+1. to 必须是存在的 Agent / Role / all / task / artifact
+2. event 必须有 type
+3. request 类事件必须有 expectedOutput
+4. 最好绑定 taskId 或 artifactId
+5. 每个 Agent 每轮最多发起 N 个请求
+6. event 有 TTL / max hops
+7. 不允许 A → B → A → B 无限循环
+8. 危险操作必须进入 approval_request
+```
+
+---
+
+# 6. 类型设计
+
+下面是建议的 TypeScript 风格核心类型。
+
+## 6.1 Project
+
+```ts
+type Project = {
+  id: string
+  name: string
+  description?: string
+  artifacts: ArtifactRef[]
+  teamTemplates: TeamTemplateRef[]
+  rooms: RoomRef[]
+  createdAt: string
+  updatedAt: string
+}
+```
+
+---
+
+## 6.2 Room
+
+```ts
+type Room = {
+  id: string
+  projectId: string
+  templateId?: string
+  name: string
+  goal: string
+  status: "draft" | "active" | "paused" | "completed" | "archived"
+  phase:
+    | "clarify"
+    | "plan"
+    | "foundation"
+    | "design"
+    | "implementation"
+    | "review"
+    | "fix"
+    | "deliver"
+  members: RoomMember[]
+  tasks: Task[]
+  artifacts: Artifact[]
+  decisions: Decision[]
+  events: RoomBusEvent[]
+  timeline: TimelineItem[]
+  createdAt: string
+  updatedAt: string
+}
+```
+
+---
+
+## 6.3 TeamTemplate
+
+```ts
+type TeamTemplate = {
+  id: string
+  projectId?: string
+  name: string
+  description?: string
+  roles: RoleCard[]
+  defaultWorkflow: WorkflowTemplate
+  roomBusPolicy: RoomBusPolicy
+  createdAt: string
+  updatedAt: string
+}
+```
+
+---
+
+## 6.4 RoleCard
+
+```ts
+type RoleCard = {
+  id: string
+  name: string
+  roleKey: string
+  mission: string
+  prompt: string
+  responsibilities: string[]
+  inputs: string[]
+  outputs: string[]
+  allowedActions: RoomBusActionType[]
+  forbiddenActions: string[]
+  doneCriteria: string[]
+  contextPolicy: ContextPolicy
+}
+```
+
+---
+
+## 6.5 RoomMember
+
+```ts
+type RoomMember = {
+  id: string
+  roomId: string
+  roleCardId: string
+  name: string
+  roleKey: string
+  sessionId: string
+  inboxId: string
+  status: "idle" | "working" | "blocked" | "waiting_review" | "done"
+  ownedTaskIds: string[]
+  ownedArtifactIds: string[]
+}
+```
+
+---
+
+## 6.6 AgentInbox
+
+```ts
+type AgentInbox = {
+  id: string
+  roomId: string
+  agentId: string
+  items: InboxItem[]
+}
+```
+
+```ts
+type InboxItem = {
+  id: string
+  eventId: string
+  type:
+    | "mention"
+    | "request"
+    | "review_request"
+    | "blocker"
+    | "handoff"
+    | "artifact_update"
+    | "task_update"
+    | "decision_update"
+    | "announcement"
+  status: "unread" | "read" | "handled" | "dismissed"
+  priority: "low" | "normal" | "high" | "blocking"
+  createdAt: string
+}
+```
+
+---
+
+## 6.7 Task
+
+```ts
+type Task = {
+  id: string
+  roomId: string
+  title: string
+  description: string
+  ownerAgentId: string
+  phase: Room["phase"]
+  status:
+    | "todo"
+    | "in_progress"
+    | "blocked"
+    | "waiting_review"
+    | "changes_requested"
+    | "done"
+  inputArtifactIds: string[]
+  outputArtifactIds: string[]
+  dependencyTaskIds: string[]
+  doneCriteria: string[]
+  createdAt: string
+  updatedAt: string
+}
+```
+
+---
+
+## 6.8 Artifact
+
+```ts
+type Artifact = {
+  id: string
+  projectId?: string
+  roomId?: string
+  taskId?: string
+  name: string
+  type:
+    | "requirements"
+    | "design_tokens"
+    | "design_guide"
+    | "component_guidelines"
+    | "ui_spec"
+    | "api_contract"
+    | "mock_data"
+    | "implementation"
+    | "test_plan"
+    | "qa_report"
+    | "seo_geo"
+    | "review_report"
+    | "shared_rules"
+    | "other"
+  scope: "project" | "room" | "task"
+  ownerAgentId?: string
+  version: number
+  status: "draft" | "approved" | "deprecated"
+  tags: string[]
+  sections?: ArtifactSection[]
+  contentRef: string
+  createdAt: string
+  updatedAt: string
+}
+```
+
+---
+
+## 6.9 RoomBusEvent
+
+```ts
+type RoomBusEvent = {
+  id: string
+  projectId: string
+  roomId: string
+  from: AgentId | "user" | "system"
+  to?: TargetRef[]
+  type: RoomBusActionType
+  taskId?: string
+  artifactId?: string
+  decisionId?: string
+  payload: Record<string, unknown>
+  status: "open" | "resolved" | "rejected" | "expired"
+  createdAt: string
+  resolvedAt?: string
+}
+```
+
+```ts
+type RoomBusActionType =
+  | "message"
+  | "ask_agent"
+  | "answer_agent"
+  | "raise_blocker"
+  | "resolve_blocker"
+  | "handoff_task"
+  | "request_review"
+  | "review_result"
+  | "propose_change"
+  | "artifact_update"
+  | "decision"
+  | "approval_request"
+  | "announcement"
+```
+
+---
+
+## 6.10 TargetRef
+
+```ts
+type TargetRef =
+  | { type: "agent"; id: string }
+  | { type: "role"; roleKey: string }
+  | { type: "all" }
+  | { type: "task"; id: string }
+  | { type: "artifact"; id: string }
+```
+
+---
+
+## 6.11 Decision
+
+```ts
+type Decision = {
+  id: string
+  projectId: string
+  roomId?: string
+  title: string
+  description: string
+  scope: "project" | "room" | "task"
+  status: "proposed" | "approved" | "rejected" | "superseded"
+  relatedTaskIds: string[]
+  relatedArtifactIds: string[]
+  createdBy: AgentId | "user" | "system"
+  approvedBy?: "user" | AgentId
+  createdAt: string
+  updatedAt: string
+}
+```
+
+---
+
+## 6.12 ContextPolicy
+
+```ts
+type ContextPolicy = {
+  alwaysInclude: ContextSourceType[]
+  requiredArtifactTypes: Artifact["type"][]
+  optionalArtifactTypes: Artifact["type"][]
+  includeEvents: RoomBusActionType[]
+  exclude: ContextExcludeRule[]
+  subscriptions: SubscriptionRule[]
+}
+```
+
+---
+
+## 6.13 ContextPack
+
+```ts
+type ContextPack = {
+  agentId: string
+  roomId: string
+  taskId?: string
+  triggerEventId?: string
+  roleContext: RoleCard
+  memberDirectory: RoomMemberSummary[]
+  currentTask?: Task
+  requiredArtifacts: ArtifactRef[]
+  relevantDecisions: Decision[]
+  attentionEvents: RoomBusEvent[]
+  inboxItems: InboxItem[]
+  timeline: TimelineItem[]
+  contextUsed: ContextUsedItem[]
+}
+```
+
+---
+
+## 6.14 TimelineItem
+
+```ts
+type TimelineItem = {
+  id: string
+  roomId: string
+  title: string
+  description: string
+  phase: Room["phase"]
+  sourceEventIds: string[]
+  sourceArtifactIds: string[]
+  sourceDecisionIds: string[]
+  createdAt: string
+}
+```
+
+---
+
+# 7. Room 创建方式
+
+最终确定四种方式。
+
+## 7.1 Create Room from Team Template
+
+从模板创建新 Room。
+
+继承：
+
+```text
+角色配置
+prompt
+默认 workflow
+RoomBus policy
+context policy
+工具权限
+```
+
+不继承：
+
+```text
+旧 Room 聊天
+旧 Room task
+旧 Room artifact
+旧 Room decision
+旧 Room inbox
+```
+
+适合：
+
+```text
+基于同一套页面开发团队开发新页面
+```
+
+---
+
+## 7.2 Duplicate Room Config
+
+复制已有 Room 的配置，但不复制工作历史。
+
+复制：
+
+```text
+角色
+prompt
+workflow
+context policy
+RoomBus policy
+```
+
+不复制：
+
+```text
+聊天历史
+任务状态
+产物
+决策
+inbox
+timeline
+```
+
+适合：
+
+```text
+A Room 调好了角色配置，希望 B Room 也沿用。
+```
+
+---
+
+## 7.3 Fork Room
+
+完整 fork 已有 Room。
+
+复制：
+
+```text
+角色配置
+聊天历史
+任务
+产物
+决策
+timeline
+上下文状态
+```
+
+适合：
+
+```text
+基于同一个页面探索另一个方案
+```
+
+例如：
+
+```text
+Pricing Page Room
+├── Fork A: Stripe 风格
+└── Fork B: Linear 风格
+```
+
+---
+
+## 7.4 Save Room as Team Template
+
+把当前 Room 的团队配置保存为模板。
+
+保存：
+
+```text
+角色配置
+prompt
+workflow
+context policy
+RoomBus policy
+```
+
+不保存：
+
+```text
+页面特定上下文
+聊天历史
+task
+artifact
+decision
+timeline
+```
+
+适合：
+
+```text
+把调好的团队沉淀成可复用模板。
+```
+
+---
+
+# 8. 默认页面开发流程
+
+MVP 默认使用 Page Development Team。
+
+## 8.1 默认角色
+
+```text
+Facilitator Agent
+PM Agent
+UX Agent
+Design Token Agent
+UI Designer Agent
+Frontend Agent
+Backend API Agent
+SEO/GEO Agent
+QA Agent
+Code Reviewer Agent
+```
+
+---
+
+## 8.2 默认阶段
+
+```text
+Phase 1: Clarify
+- PM / UX / Backend / SEO-GEO 参与需求澄清
+
+Phase 2: Plan
+- Facilitator 生成任务计划
+- 用户确认计划
+
+Phase 3: Foundation
+- Design Token Agent 确认设计规范
+- Backend API Agent 生成 API contract
+- SEO/GEO Agent 生成页面优化要求
+
+Phase 4: Design
+- UI Designer 生成 UI spec
+
+Phase 5: Implementation
+- Frontend Agent 实现页面
+- Backend Agent 补充 mock / integration notes
+
+Phase 6: Review
+- QA Agent 测试
+- UI Designer review 视觉
+- Code Reviewer review 代码
+- SEO/GEO Agent review 页面结构
+
+Phase 7: Fix
+- Frontend / Backend 根据 review 修复
+
+Phase 8: Deliver
+- Facilitator 汇总交付物
+```
+
+---
+
+# 9. UI Blueprint
+
+## 9.1 Project 页面
+
+Project 页面展示：
+
+```text
+Project Name
+Project-level Artifacts
+Team Templates
+Rooms
+Recent Timeline
+```
+
+主要操作：
+
+```text
+New Room
+New Team Template
+Upload / Create Project Artifact
+Open Room
+Duplicate Room Config
+Fork Room
+Save Room as Template
+```
+
+---
+
+## 9.2 Room 主界面
+
+采用三栏结构。
+
+```text
+左侧：Room Members / Agent Inbox / Task Status
+中间：Room Timeline + 群聊事件流
+右侧：Artifacts / Context Used / Decisions / Blockers / Reviews
+```
+
+---
+
+## 9.3 左侧：成员和 Inbox
+
+显示：
+
+```text
+Frontend Agent
+- Current task: Implement Pricing Page
+- 2 mentions
+- 1 blocker
+- 1 review request
+
+Backend Agent
+- Current task: API Contract
+- 1 request from Frontend
+
+QA Agent
+- Waiting for implementation
+```
+
+点击 Agent 可打开：
+
+```text
+Agent Inbox
+RoleCard
+Prompt
+Context Policy
+Owned Tasks
+Owned Artifacts
+```
+
+---
+
+## 9.4 中间：群聊事件流
+
+消息以群聊形式展示，但保留事件类型。
+
+例如：
+
+```text
+Frontend → Backend [ask_agent]
+api-contract v1 缺少 yearlyPrice，请补充。
+
+Backend → Frontend [answer_agent]
+已更新 api-contract v2。
+
+QA → Frontend [review_result]
+mobile pricing card overflow，severity: blocking。
+```
+
+支持：
+
+```text
+@Agent
+@Role
+@all
+@task
+@artifact
+```
+
+---
+
+## 9.5 右侧：Artifacts / Context Used
+
+右侧展示：
+
+```text
+Artifacts
+- requirements.md
+- design-tokens.json
+- ui-spec.md
+- api-contract.json
+- implementation-notes.md
+- qa-report.md
+
+Decisions
+- D-001 approved
+- D-002 pending
+
+Blockers
+- QA-004 mobile overflow
+
+Context Used
+- 当前选中 Agent 本轮读取了哪些内容
+```
+
+---
+
+# 10. 开发顺序建议
+
+## P0：数据模型和存储
+
+先实现：
+
+```text
+Project
+Room
+TeamTemplate
+RoleCard
+RoomMember
+Task
+Artifact
+Decision
+RoomBusEvent
+AgentInbox
+TimelineItem
+ContextPack
+```
+
+目标：
+
+```text
+Craft 原生知道 Room 和 Project 的存在。
+```
+
+---
+
+## P1：Room 创建和角色配置
+
+实现：
+
+```text
+Create Room from Template
+Duplicate Room Config
+Fork Room
+Save Room as Team Template
+Role Prompt Editor
+```
+
+目标：
+
+```text
+用户能创建 Room，并配置多个 Agent 角色。
+```
+
+---
+
+## P2：RoomBus 和 Agent Inbox
+
+实现：
+
+```text
+ask_agent
+answer_agent
+raise_blocker
+request_review
+review_result
+handoff_task
+artifact_update
+announcement
+```
+
+并让事件进入对应 Agent Inbox。
+
+目标：
+
+```text
+Agent 之间可以通过受控协议互相请求、提问、交接、评审。
+```
+
+---
+
+## P3：Attention Model 和 Context Resolver
+
+实现：
+
+```text
+@Agent
+@Role
+@all
+@task
+@artifact
+task owner matching
+artifact owner matching
+dependency update matching
+decision relevance matching
+```
+
+生成 Context Pack。
+
+目标：
+
+```text
+Agent 不再读取完整群聊，而是读取自己的上下文包。
+```
+
+---
+
+## P4：Artifact 和 Decision 系统
+
+实现：
+
+```text
+Project-level Artifact
+Room-level Artifact
+Task-level Artifact
+Artifact Version
+Decision Log
+Approved / Deprecated 状态
+```
+
+目标：
+
+```text
+Artifact 成为事实来源。
+```
+
+---
+
+## P5：Room Timeline
+
+实现：
+
+```text
+TimelineItem
+自动从 RoomBusEvent / Task / Artifact / Decision 生成阶段时间线
+```
+
+目标：
+
+```text
+总结机制以 Timeline 形式存在，只描述推进过程，不作为事实来源。
+```
+
+---
+
+## P6：UI 三栏视图
+
+实现：
+
+```text
+Project View
+Room View
+Member List
+Agent Inbox
+Room Event Stream
+Artifact Panel
+Context Used Panel
+Task / Blocker / Review Panel
+```
+
+目标：
+
+```text
+用户能看懂多 Agent 协作过程。
+```
+
+---
+
+# 11. 验收标准
+
+## 11.1 Project 验收标准
+
+必须满足：
+
+```text
+用户可以创建 Project
+用户可以在 Project 下创建多个 Room
+用户可以在 Project 下管理共享 Artifacts
+用户可以在 Project 下管理 Team Templates
+Room 可以继承 Project-level Artifacts
+```
+
+测试用例：
+
+```text
+创建 Project: Acme SaaS Website
+添加 design-tokens.json
+添加 component-guidelines.md
+创建 Pricing Page Room
+确认 Pricing Page Room 能引用 Project-level design-tokens.json
+```
+
+---
+
+## 11.2 Room 创建验收标准
+
+必须支持：
+
+```text
+Create Room from Team Template
+Duplicate Room Config
+Fork Room
+Save Room as Team Template
+```
+
+验收条件：
+
+```text
+从 Template 创建的新 Room 不包含旧 Room 聊天历史
+Duplicate Room Config 不复制旧 artifacts
+Fork Room 复制旧历史和 artifacts
+Save as Team Template 只保存角色和 workflow 配置
+```
+
+---
+
+## 11.3 Agent 成员目录验收标准
+
+每个 Agent 运行时必须知道：
+
+```text
+自己是谁
+房间里有哪些成员
+每个成员负责什么
+自己可以向哪些成员发起什么动作
+```
+
+测试用例：
+
+```text
+Frontend Agent 能识别 Backend API Agent 负责 API contract
+Frontend Agent 能向 Backend API Agent 发起 ask_agent
+QA Agent 能向 Frontend Agent 发起 review_result
+```
+
+---
+
+## 11.4 Agent Inbox 验收标准
+
+必须满足：
+
+```text
+@Agent 进入对应 Agent Inbox
+@Role 进入对应角色 Agent Inbox
+@all 进入所有 Agent Inbox
+@task 进入 task owner Inbox
+@artifact 进入 artifact owner / dependent task owner Inbox
+RoomBus request 进入目标 Agent Inbox
+Artifact dependency update 进入依赖该 artifact 的 Agent Inbox
+```
+
+测试用例：
+
+```text
+发送 @Frontend 消息
+Frontend Inbox 出现该消息
+Backend Inbox 不出现该消息
+
+更新 api-contract-pricing.json
+Frontend 当前 task 依赖该 artifact
+Frontend Inbox 收到 artifact_update
+```
+
+---
+
+## 11.5 Context Pack 验收标准
+
+每次 Agent 执行任务时，系统必须生成 Context Pack。
+
+Context Pack 必须包含：
+
+```text
+RoleCard
+Member Directory
+Current Task
+Required Artifacts
+Direct Mentions
+Assigned RoomBus Events
+Relevant Decisions
+Room Timeline
+```
+
+必须排除：
+
+```text
+完整群聊记录
+其他 Agent 私有记忆
+无关 Room 内容
+无关历史事件
+已废弃 artifacts
+被拒绝 decisions
+```
+
+测试用例：
+
+```text
+Frontend Agent 执行 Implement Pricing Page 任务
+Context Pack 包含 ui-spec、design-tokens、api-contract
+Context Pack 不包含 Backend 内部讨论全文
+Context Pack 不包含其他 Room 的页面内容
+```
+
+---
+
+## 11.6 Context Used 验收标准
+
+每次 Agent 回复时，用户都能查看：
+
+```text
+Agent 本轮读取了哪些 artifacts
+Agent 本轮读取了哪些 RoomBus events
+Agent 本轮使用了哪个 task
+Agent 本轮使用了哪些 decisions
+Agent 本轮使用了哪些 timeline items
+```
+
+测试用例：
+
+```text
+Frontend 回复后，展开 Context Used
+能看到 pricing-ui-spec.md@v2、design-tokens.json@v3、api-contract-pricing.json@v2
+```
+
+---
+
+## 11.7 RoomBus 验收标准
+
+RoomBus 必须记录：
+
+```text
+from
+to
+type
+taskId
+artifactId
+payload
+status
+createdAt
+resolvedAt
+```
+
+必须支持：
+
+```text
+ask_agent
+answer_agent
+raise_blocker
+resolve_blocker
+handoff_task
+request_review
+review_result
+artifact_update
+decision
+announcement
+```
+
+必须具备：
+
+```text
+目标存在校验
+事件类型校验
+request expectedOutput 校验
+TTL / max hops
+防止无限循环
+```
+
+---
+
+## 11.8 Timeline 验收标准
+
+Timeline 必须：
+
+```text
+按照时间记录 Room 推进过程
+引用 sourceEventIds / sourceArtifactIds / sourceDecisionIds
+不作为 Agent 的事实来源
+可以帮助用户理解当前阶段
+```
+
+测试用例：
+
+```text
+Backend 更新 API contract
+Timeline 出现 API Contract Ready 事件
+Timeline item 引用 artifact id 和 RoomBus event id
+```
+
+---
+
+## 11.9 Agent 缺少上下文验收标准
+
+Agent 缺少 required artifact 时，必须提问或 raise blocker，不得猜测。
+
+测试用例：
+
+```text
+Frontend task 缺少 api-contract
+Frontend 不直接实现 API integration
+Frontend 通过 RoomBus ask_agent 给 Backend
+Task 标记为 blocked 或 waiting_input
+```
+
+---
+
+## 11.10 Artifact 事实来源验收标准
+
+Agent 的关键判断必须基于 artifact / decision / task / RoomBus event，而不是纯 timeline summary。
+
+测试用例：
+
+```text
+Timeline 说 UI spec 已完成
+但 ui-spec.md artifact 不存在
+Frontend 不应开始实现
+Frontend 应该请求 UI Designer 提供 ui-spec artifact
+```
+
+---
+
+# 12. MVP 范围
+
+## 必做
+
+```text
+Project
+Room
+Team Template
+Role Prompt Editor
+RoomBus
+Agent Inbox
+Attention Model
+Context Pack
+Context Used
+Artifact Panel
+Room Timeline
+Create Room from Template
+Duplicate Room Config
+Fork Room
+Save Room as Template
+```
+
+## 可以后置
+
+```text
+复杂 DAG
+完全自动并行执行
+复杂权限系统
+跨 Project 复用
+智能判断请求是否合理
+多 Agent 自由 debate
+复杂 dashboard
+自动 PR / 发布流程
+```
+
+---
+
+# 13. 最终确定版原则
+
+这几个原则建议直接写进开发文档顶部。
+
+```text
+1. Project 是最高层对象。
+2. Room 是具体协作空间。
+3. Team Template 用于复用角色和 workflow。
+4. Agent 之间不自由互聊，而是通过 RoomBus 受控协作。
+5. 每个 Agent 都有自己的 Inbox。
+6. @ 是上下文分发的核心显式信号。
+7. Task / Artifact / Decision / Dependency 是上下文分发的隐式信号。
+8. Agent 不读取完整群聊，只读取 Context Pack。
+9. Artifact / Task / Decision / RoomBus Event 是事实来源。
+10. Timeline 只是流程总结，不是事实来源。
+11. Agent 缺上下文时必须提问，不得猜。
+12. 用户必须能看到 Agent 本轮读取了哪些上下文。
+13. Room 可以创建、复制配置、fork，也可以保存为模板。
+```
+
+---
+
+# 14. 开发蓝图结论
+
+最终开发目标可以这样写：
+
+> 在 Craft Agents 中新增原生 Project / Room / Team Template / RoomBus / Agent Inbox / Context Pack 能力。用户可以在 Project 下创建多个 Room，每个 Room 由多个可配置 Agent 组成。Agent 通过 RoomBus 以受控方式互相请求、提问、交接、评审和报告阻塞。系统基于 @、任务归属、产物归属、依赖更新和决策变化为每个 Agent 构建 Inbox，并在执行时生成 Context Pack。群聊界面展示协作过程，Timeline 展示流程进展，Artifact / Task / Decision / RoomBus Event 作为真实状态来源。用户可以复用 Team Template、复制 Room 配置、fork Room，并检查每个 Agent 本轮读取的上下文。

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -57,6 +57,7 @@
     "./search": "./src/search/index.ts",
     "./tools": "./src/tools/index.ts",
     "./mentions": "./src/mentions/index.ts",
+    "./native-agent-room": "./src/native-agent-room/index.ts",
     "./skills/types": "./src/skills/types.ts",
     "./automations": "./src/automations/index.ts",
     "./automations/resolve-config-path": "./src/automations/resolve-config-path.ts",

--- a/packages/shared/src/native-agent-room/__tests__/attention.test.ts
+++ b/packages/shared/src/native-agent-room/__tests__/attention.test.ts
@@ -1,0 +1,338 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { addProjectArtifact, createProject, createTeamTemplate, loadRoom, saveRoom } from '../storage.ts';
+import { createRoomFromTemplate } from '../room-operations.ts';
+import { publishRoomBusEvent } from '../room-bus.ts';
+import { resolveContextPack, resolveMentionTargets } from '../attention.ts';
+import type {
+  Artifact,
+  Decision,
+  RoleCard,
+  Room,
+  RoomBusPolicy,
+  Task,
+  TimelineItem,
+  WorkflowTemplate,
+} from '../types.ts';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeWorkspaceRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'native-agent-room-p3-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeRoleCard(id: string, roleKey: string, name: string, requiredArtifactTypes: Artifact['type'][] = []): RoleCard {
+  return {
+    id,
+    roleKey,
+    name,
+    mission: `${name} mission`,
+    prompt: `${name} prompt`,
+    responsibilities: [`${name} responsibility`],
+    inputs: [],
+    outputs: [],
+    allowedActions: ['ask_agent', 'answer_agent', 'request_review', 'review_result', 'artifact_update', 'announcement'],
+    forbiddenActions: [],
+    doneCriteria: ['Done'],
+    contextPolicy: {
+      alwaysInclude: ['role_contract', 'member_directory', 'current_task', 'required_artifacts'],
+      requiredArtifactTypes,
+      optionalArtifactTypes: [],
+      includeEvents: ['ask_agent', 'answer_agent', 'artifact_update', 'decision'],
+      exclude: ['full_transcript', 'other_agents_private_memory', 'unrelated_rooms', 'deprecated_artifacts', 'rejected_decisions'],
+      subscriptions: [],
+    },
+  };
+}
+
+function makeWorkflow(): WorkflowTemplate {
+  return {
+    phases: ['clarify', 'plan', 'foundation', 'design', 'implementation', 'review', 'deliver'],
+    steps: [],
+  };
+}
+
+function makePolicy(): RoomBusPolicy {
+  return {
+    allowedActions: ['message', 'ask_agent', 'answer_agent', 'request_review', 'review_result', 'artifact_update', 'decision', 'announcement'],
+    maxRequestsPerAgentTurn: 3,
+    defaultTtlMs: 24 * 60 * 60 * 1000,
+    maxHops: 4,
+  };
+}
+
+function setupRoom(workspaceRoot: string): Room {
+  const project = createProject(workspaceRoot, { name: 'Acme SaaS Website' });
+  addProjectArtifact(workspaceRoot, project.id, {
+    id: 'artifact_design_tokens',
+    projectId: project.id,
+    name: 'design-tokens.json',
+    type: 'design_tokens',
+    scope: 'project',
+    version: 3,
+    status: 'approved',
+    tags: ['design'],
+    contentRef: 'project/design-tokens.json',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  addProjectArtifact(workspaceRoot, project.id, {
+    id: 'artifact_deprecated_tokens',
+    projectId: project.id,
+    name: 'old-design-tokens.json',
+    type: 'design_tokens',
+    scope: 'project',
+    version: 1,
+    status: 'deprecated',
+    tags: ['design'],
+    contentRef: 'project/old-design-tokens.json',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+
+  const template = createTeamTemplate(workspaceRoot, {
+    projectId: project.id,
+    name: 'Page Development Team',
+    roles: [
+      makeRoleCard('role_frontend', 'frontend', 'Frontend Agent', ['ui_spec', 'design_tokens', 'api_contract']),
+      makeRoleCard('role_backend', 'backend', 'Backend API Agent', ['api_contract']),
+      makeRoleCard('role_qa', 'qa', 'QA Agent', ['ui_spec', 'test_plan']),
+    ],
+    defaultWorkflow: makeWorkflow(),
+    roomBusPolicy: makePolicy(),
+  });
+
+  return createRoomFromTemplate(workspaceRoot, {
+    projectId: project.id,
+    templateId: template.id,
+    name: 'Pricing Page Room',
+    goal: 'Develop SaaS pricing page',
+  });
+}
+
+function addContextFacts(room: Room): Room {
+  const frontend = room.members.find((member) => member.roleKey === 'frontend')!;
+  const backend = room.members.find((member) => member.roleKey === 'backend')!;
+  const now = Date.now();
+  const uiSpec: Artifact = {
+    id: 'artifact_ui_spec',
+    projectId: room.projectId,
+    roomId: room.id,
+    name: 'pricing-ui-spec.md',
+    type: 'ui_spec',
+    scope: 'room',
+    ownerAgentId: frontend.id,
+    version: 2,
+    status: 'approved',
+    tags: ['ui'],
+    contentRef: 'room/pricing-ui-spec.md',
+    createdAt: now,
+    updatedAt: now,
+  };
+  const apiContract: Artifact = {
+    id: 'artifact_api_contract',
+    projectId: room.projectId,
+    roomId: room.id,
+    name: 'api-contract-pricing.json',
+    type: 'api_contract',
+    scope: 'room',
+    ownerAgentId: backend.id,
+    version: 2,
+    status: 'approved',
+    tags: ['api'],
+    contentRef: 'room/api-contract-pricing.json',
+    createdAt: now,
+    updatedAt: now,
+  };
+  const deprecatedUiSpec: Artifact = {
+    ...uiSpec,
+    id: 'artifact_old_ui_spec',
+    name: 'old-pricing-ui-spec.md',
+    version: 1,
+    status: 'deprecated',
+    contentRef: 'room/old-pricing-ui-spec.md',
+  };
+  const task: Task = {
+    id: 'task_frontend_pricing',
+    roomId: room.id,
+    title: 'Implement Pricing Page',
+    description: 'Build pricing page from approved specs.',
+    ownerAgentId: frontend.id,
+    phase: 'implementation',
+    status: 'in_progress',
+    inputArtifactIds: [uiSpec.id, apiContract.id],
+    outputArtifactIds: [],
+    dependencyTaskIds: [],
+    doneCriteria: ['Implementation follows UI spec and API contract'],
+    createdAt: now,
+    updatedAt: now,
+  };
+  const approvedDecision: Decision = {
+    id: 'decision_billing_toggle',
+    projectId: room.projectId,
+    roomId: room.id,
+    title: 'Use monthly and annual billing toggle',
+    description: 'Pricing cards support monthly and annual billing.',
+    scope: 'room',
+    status: 'approved',
+    relatedTaskIds: [task.id],
+    relatedArtifactIds: [apiContract.id],
+    createdBy: 'user',
+    approvedBy: 'user',
+    createdAt: now,
+    updatedAt: now,
+  };
+  const rejectedDecision: Decision = {
+    ...approvedDecision,
+    id: 'decision_rejected_layout',
+    title: 'Rejected layout',
+    status: 'rejected',
+  };
+  const timeline: TimelineItem = {
+    id: 'timeline_implementation_started',
+    roomId: room.id,
+    title: 'Implementation started',
+    description: 'Frontend started implementation.',
+    phase: 'implementation',
+    sourceEventIds: [],
+    sourceArtifactIds: [uiSpec.id, apiContract.id],
+    sourceDecisionIds: [approvedDecision.id],
+    createdAt: now,
+  };
+
+  return {
+    ...room,
+    tasks: [task],
+    artifacts: [uiSpec, apiContract, deprecatedUiSpec],
+    decisions: [approvedDecision, rejectedDecision],
+    timeline: [timeline],
+  };
+}
+
+describe('native agent room attention and context resolver: P3', () => {
+  it('extracts @Agent, @Role, @all, @task, and @artifact targets', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const room = addContextFacts(setupRoom(workspaceRoot));
+
+    expect(resolveMentionTargets(room, '@Frontend please confirm').map((target) => target.type)).toEqual(['agent']);
+    expect(resolveMentionTargets(room, '@backend please answer')).toEqual([{ type: 'agent', id: room.members.find((member) => member.roleKey === 'backend')!.id }]);
+    expect(resolveMentionTargets(room, '@all sync')).toEqual([{ type: 'all' }]);
+    expect(resolveMentionTargets(room, '@task:task_frontend_pricing review')).toEqual([{ type: 'task', id: 'task_frontend_pricing' }]);
+    expect(resolveMentionTargets(room, '@artifact:artifact_api_contract updated')).toEqual([{ type: 'artifact', id: 'artifact_api_contract' }]);
+  });
+
+  it('routes explicit @ mentions into the matching agent inbox', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const room = setupRoom(workspaceRoot);
+    const frontend = room.members.find((member) => member.roleKey === 'frontend')!;
+    const backend = room.members.find((member) => member.roleKey === 'backend')!;
+
+    const event = publishRoomBusEvent(workspaceRoot, {
+      roomId: room.id,
+      from: 'user',
+      type: 'message',
+      payload: { message: '@Frontend please confirm annual toggle state handling.' },
+    });
+
+    const reloaded = loadRoom(workspaceRoot, room.id)!;
+    expect(reloaded.inboxes.find((inbox) => inbox.agentId === frontend.id)?.items[0]?.eventId).toBe(event.id);
+    expect(reloaded.inboxes.find((inbox) => inbox.agentId === backend.id)?.items).toEqual([]);
+  });
+
+  it('routes artifact updates to artifact owner and dependent task owner without explicit to', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const room = addContextFacts(setupRoom(workspaceRoot));
+    saveRoom(workspaceRoot, room);
+    const frontend = room.members.find((member) => member.roleKey === 'frontend')!;
+    const backend = room.members.find((member) => member.roleKey === 'backend')!;
+
+    const event = publishRoomBusEvent(workspaceRoot, {
+      roomId: room.id,
+      from: backend.id,
+      type: 'artifact_update',
+      artifactId: 'artifact_api_contract',
+      payload: { message: 'api-contract-pricing.json updated to v2.' },
+    });
+
+    const reloaded = loadRoom(workspaceRoot, room.id)!;
+    expect(reloaded.inboxes.find((inbox) => inbox.agentId === frontend.id)?.items.at(-1)?.eventId).toBe(event.id);
+    expect(reloaded.inboxes.find((inbox) => inbox.agentId === backend.id)?.items.at(-1)?.eventId).toBe(event.id);
+  });
+
+  it('routes decisions to related task and artifact owners', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const room = addContextFacts(setupRoom(workspaceRoot));
+    saveRoom(workspaceRoot, room);
+    const frontend = room.members.find((member) => member.roleKey === 'frontend')!;
+    const backend = room.members.find((member) => member.roleKey === 'backend')!;
+
+    const event = publishRoomBusEvent(workspaceRoot, {
+      roomId: room.id,
+      from: 'user',
+      type: 'decision',
+      decisionId: 'decision_billing_toggle',
+      payload: { message: 'Decision approved: monthly and annual billing toggle.' },
+    });
+
+    const reloaded = loadRoom(workspaceRoot, room.id)!;
+    expect(reloaded.inboxes.find((inbox) => inbox.agentId === frontend.id)?.items.at(-1)?.eventId).toBe(event.id);
+    expect(reloaded.inboxes.find((inbox) => inbox.agentId === backend.id)?.items.at(-1)?.eventId).toBe(event.id);
+  });
+
+  it('builds a Context Pack with required facts and without unrelated transcript facts', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const room = addContextFacts(setupRoom(workspaceRoot));
+    saveRoom(workspaceRoot, room);
+    const frontend = room.members.find((member) => member.roleKey === 'frontend')!;
+    const backend = room.members.find((member) => member.roleKey === 'backend')!;
+    const qa = room.members.find((member) => member.roleKey === 'qa')!;
+
+    const relevant = publishRoomBusEvent(workspaceRoot, {
+      roomId: room.id,
+      from: backend.id,
+      type: 'artifact_update',
+      artifactId: 'artifact_api_contract',
+      payload: { message: 'api-contract-pricing.json updated to v2.' },
+    });
+    const unrelated = publishRoomBusEvent(workspaceRoot, {
+      roomId: room.id,
+      from: qa.id,
+      to: [{ type: 'agent', id: backend.id }],
+      type: 'message',
+      payload: { message: 'Internal QA note for backend only.' },
+    });
+
+    const pack = resolveContextPack(workspaceRoot, {
+      roomId: room.id,
+      agentId: frontend.id,
+      taskId: 'task_frontend_pricing',
+      triggerEventId: relevant.id,
+    });
+
+    expect(pack.roleContext.roleKey).toBe('frontend');
+    expect(pack.memberDirectory.map((member) => member.roleKey).sort()).toEqual(['backend', 'frontend', 'qa']);
+    expect(pack.currentTask?.id).toBe('task_frontend_pricing');
+    expect(pack.requiredArtifacts.map((artifact) => artifact.name).sort()).toEqual([
+      'api-contract-pricing.json',
+      'design-tokens.json',
+      'pricing-ui-spec.md',
+    ]);
+    expect(pack.requiredArtifacts.some((artifact) => artifact.status === 'deprecated')).toBe(false);
+    expect(pack.relevantDecisions.map((decision) => decision.id)).toEqual(['decision_billing_toggle']);
+    expect(pack.attentionEvents.map((event) => event.id)).toContain(relevant.id);
+    expect(pack.attentionEvents.map((event) => event.id)).not.toContain(unrelated.id);
+    expect(pack.timeline.map((item) => item.id)).toEqual(['timeline_implementation_started']);
+    expect(pack.contextUsed.some((item) => item.type === 'artifact' && item.label === 'api-contract-pricing.json@v2')).toBe(true);
+    expect(pack.contextUsed.some((item) => item.type === 'decision' && item.id === 'decision_billing_toggle')).toBe(true);
+  });
+});

--- a/packages/shared/src/native-agent-room/__tests__/room-bus.test.ts
+++ b/packages/shared/src/native-agent-room/__tests__/room-bus.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createProject, createTeamTemplate, loadRoom, saveRoom } from '../storage.ts';
+import { createRoomFromTemplate } from '../room-operations.ts';
+import { publishRoomBusEvent, resolveRoomBusTargets } from '../room-bus.ts';
+import type { Artifact, RoleCard, Room, RoomBusEvent, RoomBusPolicy, Task, WorkflowTemplate } from '../types.ts';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeWorkspaceRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'native-agent-room-p2-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeRoleCard(id: string, roleKey: string, name: string): RoleCard {
+  return {
+    id,
+    roleKey,
+    name,
+    mission: `${name} mission`,
+    prompt: `${name} prompt`,
+    responsibilities: [`${name} responsibility`],
+    inputs: [],
+    outputs: [],
+    allowedActions: ['ask_agent', 'answer_agent', 'raise_blocker', 'request_review', 'review_result', 'handoff_task', 'artifact_update', 'announcement'],
+    forbiddenActions: [],
+    doneCriteria: ['Done'],
+    contextPolicy: {
+      alwaysInclude: ['role_contract', 'member_directory', 'current_task'],
+      requiredArtifactTypes: [],
+      optionalArtifactTypes: [],
+      includeEvents: ['ask_agent', 'answer_agent', 'artifact_update'],
+      exclude: ['full_transcript', 'other_agents_private_memory'],
+      subscriptions: [],
+    },
+  };
+}
+
+function makeWorkflow(): WorkflowTemplate {
+  return {
+    phases: ['clarify', 'plan', 'implementation', 'review', 'deliver'],
+    steps: [],
+  };
+}
+
+function makePolicy(): RoomBusPolicy {
+  return {
+    allowedActions: ['ask_agent', 'answer_agent', 'raise_blocker', 'request_review', 'review_result', 'handoff_task', 'artifact_update', 'announcement'],
+    maxRequestsPerAgentTurn: 3,
+    defaultTtlMs: 24 * 60 * 60 * 1000,
+    maxHops: 2,
+  };
+}
+
+function setupRoom(workspaceRoot: string): Room {
+  const project = createProject(workspaceRoot, { name: 'Acme SaaS Website' });
+  const template = createTeamTemplate(workspaceRoot, {
+    projectId: project.id,
+    name: 'Page Development Team',
+    roles: [
+      makeRoleCard('role_frontend', 'frontend', 'Frontend Agent'),
+      makeRoleCard('role_backend', 'backend', 'Backend API Agent'),
+      makeRoleCard('role_qa', 'qa', 'QA Agent'),
+    ],
+    defaultWorkflow: makeWorkflow(),
+    roomBusPolicy: makePolicy(),
+  });
+  return createRoomFromTemplate(workspaceRoot, {
+    projectId: project.id,
+    templateId: template.id,
+    name: 'Pricing Page Room',
+    goal: 'Develop SaaS pricing page',
+  });
+}
+
+function addTaskAndArtifact(room: Room): Room {
+  const frontend = room.members.find((member) => member.roleKey === 'frontend')!;
+  const backend = room.members.find((member) => member.roleKey === 'backend')!;
+  const now = Date.now();
+  const artifact: Artifact = {
+    id: 'artifact_api_contract',
+    projectId: room.projectId,
+    roomId: room.id,
+    name: 'api-contract-pricing.json',
+    type: 'api_contract',
+    scope: 'room',
+    ownerAgentId: backend.id,
+    version: 1,
+    status: 'approved',
+    tags: ['api'],
+    contentRef: 'room/api-contract-pricing.json',
+    createdAt: now,
+    updatedAt: now,
+  };
+  const task: Task = {
+    id: 'task_frontend_pricing',
+    roomId: room.id,
+    title: 'Implement Pricing Page',
+    description: 'Build pricing UI.',
+    ownerAgentId: frontend.id,
+    phase: 'implementation',
+    status: 'in_progress',
+    inputArtifactIds: [artifact.id],
+    outputArtifactIds: [],
+    dependencyTaskIds: [],
+    doneCriteria: ['Implemented'],
+    createdAt: now,
+    updatedAt: now,
+  };
+  return {
+    ...room,
+    tasks: [task],
+    artifacts: [artifact],
+  };
+}
+
+describe('native agent room bus: P2', () => {
+  it('records ask_agent and routes it to target and sender inboxes', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const room = setupRoom(workspaceRoot);
+    const frontend = room.members.find((member) => member.roleKey === 'frontend')!;
+    const backend = room.members.find((member) => member.roleKey === 'backend')!;
+
+    const event = publishRoomBusEvent(workspaceRoot, {
+      roomId: room.id,
+      from: frontend.id,
+      to: [{ type: 'agent', id: backend.id }],
+      type: 'ask_agent',
+      payload: {
+        message: 'api-contract v1 is missing yearlyPrice.',
+        expectedOutput: 'Updated API contract or explanation.',
+      },
+    });
+
+    const reloaded = loadRoom(workspaceRoot, room.id)!;
+    expect(reloaded.events).toHaveLength(1);
+    expect(reloaded.events[0]).toMatchObject({
+      id: event.id,
+      from: frontend.id,
+      type: 'ask_agent',
+      status: 'open',
+    });
+    expect(reloaded.inboxes.find((inbox) => inbox.agentId === backend.id)?.items[0]).toMatchObject({
+      eventId: event.id,
+      type: 'request',
+      status: 'unread',
+      priority: 'normal',
+    });
+    expect(reloaded.inboxes.find((inbox) => inbox.agentId === frontend.id)?.items[0]?.eventId).toBe(event.id);
+  });
+
+  it('routes role, all, task, and artifact targets to matching agent inboxes', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const room = addTaskAndArtifact(setupRoom(workspaceRoot));
+    saveRoom(workspaceRoot, room);
+    const frontend = room.members.find((member) => member.roleKey === 'frontend')!;
+    const backend = room.members.find((member) => member.roleKey === 'backend')!;
+    const qa = room.members.find((member) => member.roleKey === 'qa')!;
+
+    expect(resolveRoomBusTargets(room, [{ type: 'role', roleKey: 'backend' }])).toEqual([backend.id]);
+    expect(resolveRoomBusTargets(room, [{ type: 'task', id: 'task_frontend_pricing' }])).toEqual([frontend.id]);
+    expect(resolveRoomBusTargets(room, [{ type: 'artifact', id: 'artifact_api_contract' }]).sort()).toEqual([
+      backend.id,
+      frontend.id,
+    ].sort());
+
+    const event = publishRoomBusEvent(workspaceRoot, {
+      roomId: room.id,
+      from: 'system',
+      to: [{ type: 'all' }],
+      type: 'announcement',
+      payload: { message: 'Use design tokens for all page rooms.' },
+    });
+
+    const reloaded = loadRoom(workspaceRoot, room.id)!;
+    expect(reloaded.inboxes.find((inbox) => inbox.agentId === frontend.id)?.items.at(-1)?.eventId).toBe(event.id);
+    expect(reloaded.inboxes.find((inbox) => inbox.agentId === backend.id)?.items.at(-1)?.eventId).toBe(event.id);
+    expect(reloaded.inboxes.find((inbox) => inbox.agentId === qa.id)?.items.at(-1)?.eventId).toBe(event.id);
+  });
+
+  it('rejects request events without expectedOutput', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const room = setupRoom(workspaceRoot);
+    const frontend = room.members.find((member) => member.roleKey === 'frontend')!;
+    const backend = room.members.find((member) => member.roleKey === 'backend')!;
+
+    expect(() => publishRoomBusEvent(workspaceRoot, {
+      roomId: room.id,
+      from: frontend.id,
+      to: [{ type: 'agent', id: backend.id }],
+      type: 'ask_agent',
+      payload: { message: 'What is the API contract?' },
+    })).toThrow('requires payload.expectedOutput');
+  });
+
+  it('updates task status for blocker and review request events', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const room = addTaskAndArtifact(setupRoom(workspaceRoot));
+    saveRoom(workspaceRoot, room);
+    const frontend = room.members.find((member) => member.roleKey === 'frontend')!;
+    const qa = room.members.find((member) => member.roleKey === 'qa')!;
+
+    publishRoomBusEvent(workspaceRoot, {
+      roomId: room.id,
+      from: frontend.id,
+      to: [{ type: 'agent', id: qa.id }],
+      type: 'request_review',
+      taskId: 'task_frontend_pricing',
+      payload: {
+        message: 'Please review pricing page implementation.',
+        expectedOutput: 'Review result with blocking issues if any.',
+      },
+    });
+
+    expect(loadRoom(workspaceRoot, room.id)?.tasks[0]?.status).toBe('waiting_review');
+
+    publishRoomBusEvent(workspaceRoot, {
+      roomId: room.id,
+      from: qa.id,
+      to: [{ type: 'agent', id: frontend.id }],
+      type: 'review_result',
+      taskId: 'task_frontend_pricing',
+      payload: {
+        message: 'Mobile pricing card overflows.',
+        severity: 'blocking',
+      },
+    });
+
+    expect(loadRoom(workspaceRoot, room.id)?.tasks[0]?.status).toBe('changes_requested');
+  });
+
+  it('resolves parent request when answer_agent replies', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const room = setupRoom(workspaceRoot);
+    const frontend = room.members.find((member) => member.roleKey === 'frontend')!;
+    const backend = room.members.find((member) => member.roleKey === 'backend')!;
+
+    const request = publishRoomBusEvent(workspaceRoot, {
+      roomId: room.id,
+      from: frontend.id,
+      to: [{ type: 'agent', id: backend.id }],
+      type: 'ask_agent',
+      payload: {
+        message: 'Please provide yearlyPrice.',
+        expectedOutput: 'Updated API contract.',
+      },
+    });
+
+    publishRoomBusEvent(workspaceRoot, {
+      roomId: room.id,
+      from: backend.id,
+      to: [{ type: 'agent', id: frontend.id }],
+      type: 'answer_agent',
+      parentEventId: request.id,
+      payload: { message: 'yearlyPrice added.' },
+    });
+
+    const reloaded = loadRoom(workspaceRoot, room.id)!;
+    expect(reloaded.events.find((event) => event.id === request.id)?.status).toBe('resolved');
+    expect(reloaded.events.find((event) => event.id === request.id)?.resolvedAt).toBeNumber();
+  });
+
+  it('prevents repeated parent-chain loops', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const room = setupRoom(workspaceRoot);
+    const frontend = room.members.find((member) => member.roleKey === 'frontend')!;
+    const backend = room.members.find((member) => member.roleKey === 'backend')!;
+
+    const first = publishRoomBusEvent(workspaceRoot, {
+      roomId: room.id,
+      from: frontend.id,
+      to: [{ type: 'agent', id: backend.id }],
+      type: 'ask_agent',
+      payload: {
+        message: 'Need API contract.',
+        expectedOutput: 'API contract.',
+      },
+    });
+    const second = publishRoomBusEvent(workspaceRoot, {
+      roomId: room.id,
+      from: backend.id,
+      to: [{ type: 'agent', id: frontend.id }],
+      type: 'ask_agent',
+      parentEventId: first.id,
+      payload: {
+        message: 'Need UI requirements first.',
+        expectedOutput: 'UI requirements.',
+      },
+    });
+
+    expect(() => publishRoomBusEvent(workspaceRoot, {
+      roomId: room.id,
+      from: frontend.id,
+      to: [{ type: 'agent', id: backend.id }],
+      type: 'ask_agent',
+      parentEventId: second.id,
+      payload: {
+        message: 'Still need API contract.',
+        expectedOutput: 'API contract.',
+      },
+    })).toThrow('RoomBus loop detected');
+  });
+});

--- a/packages/shared/src/native-agent-room/__tests__/room-operations.test.ts
+++ b/packages/shared/src/native-agent-room/__tests__/room-operations.test.ts
@@ -1,0 +1,344 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  createProject,
+  createTeamTemplate,
+  loadRoom,
+  loadTeamTemplate,
+  saveRoom,
+} from '../storage.ts';
+import {
+  createRoomFromTemplate,
+  duplicateRoomConfig,
+  forkRoom,
+  saveRoomAsTeamTemplate,
+  updateRoomRolePrompt,
+} from '../room-operations.ts';
+import type {
+  Artifact,
+  Decision,
+  InboxItem,
+  RoleCard,
+  Room,
+  RoomBusEvent,
+  RoomBusPolicy,
+  Task,
+  TeamTemplate,
+  TimelineItem,
+  WorkflowTemplate,
+} from '../types.ts';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeWorkspaceRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'native-agent-room-p1-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeRoleCard(id: string, roleKey: string, name: string): RoleCard {
+  return {
+    id,
+    roleKey,
+    name,
+    mission: `${name} mission`,
+    prompt: `${name} prompt`,
+    responsibilities: [`${name} responsibility`],
+    inputs: [],
+    outputs: [],
+    allowedActions: ['ask_agent', 'answer_agent', 'request_review', 'review_result', 'artifact_update'],
+    forbiddenActions: [],
+    doneCriteria: ['Done'],
+    contextPolicy: {
+      alwaysInclude: ['role_contract', 'member_directory', 'current_task'],
+      requiredArtifactTypes: [],
+      optionalArtifactTypes: [],
+      includeEvents: ['ask_agent', 'answer_agent', 'artifact_update'],
+      exclude: ['full_transcript', 'other_agents_private_memory'],
+      subscriptions: [],
+    },
+  };
+}
+
+function makeWorkflow(): WorkflowTemplate {
+  return {
+    phases: ['clarify', 'plan', 'implementation', 'review', 'deliver'],
+    steps: [
+      {
+        id: 'step_implementation',
+        phase: 'implementation',
+        title: 'Implement page',
+        roleKeys: ['frontend'],
+      },
+    ],
+  };
+}
+
+function makePolicy(): RoomBusPolicy {
+  return {
+    allowedActions: ['ask_agent', 'answer_agent', 'request_review', 'review_result', 'artifact_update'],
+    maxRequestsPerAgentTurn: 3,
+    defaultTtlMs: 24 * 60 * 60 * 1000,
+    maxHops: 4,
+  };
+}
+
+function setupTemplate(workspaceRoot: string): { projectId: string; template: TeamTemplate } {
+  const project = createProject(workspaceRoot, { name: 'Acme SaaS Website' });
+  const template = createTeamTemplate(workspaceRoot, {
+    projectId: project.id,
+    name: 'Page Development Team',
+    roles: [
+      makeRoleCard('role_frontend', 'frontend', 'Frontend Agent'),
+      makeRoleCard('role_backend', 'backend', 'Backend API Agent'),
+    ],
+    defaultWorkflow: makeWorkflow(),
+    roomBusPolicy: makePolicy(),
+  });
+  return { projectId: project.id, template };
+}
+
+function addRoomHistory(room: Room): Room {
+  const frontend = room.members.find((member) => member.roleKey === 'frontend')!;
+  const backend = room.members.find((member) => member.roleKey === 'backend')!;
+  const now = Date.now();
+  const task: Task = {
+    id: 'task_frontend_pricing',
+    roomId: room.id,
+    title: 'Implement Pricing Page',
+    description: 'Build the pricing page UI.',
+    ownerAgentId: frontend.id,
+    phase: 'implementation',
+    status: 'in_progress',
+    inputArtifactIds: ['artifact_api_contract'],
+    outputArtifactIds: ['artifact_implementation'],
+    dependencyTaskIds: [],
+    doneCriteria: ['Pricing page implemented'],
+    createdAt: now,
+    updatedAt: now,
+  };
+  const artifact: Artifact = {
+    id: 'artifact_api_contract',
+    projectId: room.projectId,
+    roomId: room.id,
+    taskId: task.id,
+    name: 'api-contract-pricing.json',
+    type: 'api_contract',
+    scope: 'task',
+    ownerAgentId: backend.id,
+    version: 1,
+    status: 'approved',
+    tags: ['api'],
+    contentRef: 'room/api-contract-pricing.json',
+    createdAt: now,
+    updatedAt: now,
+  };
+  const decision: Decision = {
+    id: 'decision_billing_period',
+    projectId: room.projectId,
+    roomId: room.id,
+    title: 'Use monthly and annual billing toggle',
+    description: 'Pricing page supports monthly and annual billing.',
+    scope: 'room',
+    status: 'approved',
+    relatedTaskIds: [task.id],
+    relatedArtifactIds: [artifact.id],
+    createdBy: frontend.id,
+    approvedBy: 'user',
+    createdAt: now,
+    updatedAt: now,
+  };
+  const event: RoomBusEvent = {
+    id: 'event_api_request',
+    projectId: room.projectId,
+    roomId: room.id,
+    from: frontend.id,
+    to: [{ type: 'agent', id: backend.id }],
+    type: 'ask_agent',
+    taskId: task.id,
+    artifactId: artifact.id,
+    payload: {
+      message: 'Please provide pricing API fields.',
+      expectedOutput: 'Updated API contract.',
+    },
+    status: 'open',
+    createdAt: now,
+  };
+  const inboxItem: InboxItem = {
+    id: 'inbox_item_api_request',
+    eventId: event.id,
+    type: 'request',
+    status: 'unread',
+    priority: 'normal',
+    createdAt: now,
+  };
+  const timelineItem: TimelineItem = {
+    id: 'timeline_api_request',
+    roomId: room.id,
+    title: 'Frontend requested API contract',
+    description: 'Frontend asked Backend for pricing API fields.',
+    phase: 'implementation',
+    sourceEventIds: [event.id],
+    sourceArtifactIds: [artifact.id],
+    sourceDecisionIds: [decision.id],
+    createdAt: now,
+  };
+
+  frontend.ownedTaskIds = [task.id];
+  backend.ownedArtifactIds = [artifact.id];
+
+  return {
+    ...room,
+    tasks: [task],
+    artifacts: [artifact],
+    decisions: [decision],
+    events: [event],
+    inboxes: room.inboxes.map((inbox) =>
+      inbox.agentId === backend.id ? { ...inbox, items: [inboxItem] } : inbox
+    ),
+    timeline: [timelineItem],
+  };
+}
+
+describe('native agent room operations: P1', () => {
+  it('creates a room from a team template with role members and inboxes', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const { projectId, template } = setupTemplate(workspaceRoot);
+
+    const room = createRoomFromTemplate(workspaceRoot, {
+      projectId,
+      templateId: template.id,
+      name: 'Pricing Page Room',
+      goal: 'Develop SaaS pricing page',
+    });
+
+    expect(room.templateId).toBe(template.id);
+    expect(room.roleCards.map((role) => role.roleKey)).toEqual(['frontend', 'backend']);
+    expect(room.members.map((member) => member.roleKey)).toEqual(['frontend', 'backend']);
+    expect(room.inboxes).toHaveLength(2);
+    expect(room.workflow).toEqual(template.defaultWorkflow);
+    expect(room.roomBusPolicy).toEqual(template.roomBusPolicy);
+  });
+
+  it('duplicates room config without copying room history or artifacts', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const { projectId, template } = setupTemplate(workspaceRoot);
+    const source = createRoomFromTemplate(workspaceRoot, {
+      projectId,
+      templateId: template.id,
+      name: 'Pricing Page Room',
+      goal: 'Develop SaaS pricing page',
+    });
+    const sourceWithHistory = addRoomHistory(source);
+    saveRoom(workspaceRoot, sourceWithHistory);
+
+    const duplicate = duplicateRoomConfig(workspaceRoot, {
+      sourceRoomId: source.id,
+      name: 'Features Page Room',
+      goal: 'Develop features page',
+    });
+
+    expect(duplicate.id).not.toBe(source.id);
+    expect(duplicate.roleCards).toEqual(source.roleCards);
+    expect(duplicate.workflow).toEqual(source.workflow);
+    expect(duplicate.roomBusPolicy).toEqual(source.roomBusPolicy);
+    expect(duplicate.members).toHaveLength(source.members.length);
+    expect(duplicate.tasks).toEqual([]);
+    expect(duplicate.artifacts).toEqual([]);
+    expect(duplicate.decisions).toEqual([]);
+    expect(duplicate.events).toEqual([]);
+    expect(duplicate.timeline).toEqual([]);
+    expect(duplicate.inboxes.every((inbox) => inbox.items.length === 0)).toBe(true);
+  });
+
+  it('forks a room with history and remapped room-scoped ids', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const { projectId, template } = setupTemplate(workspaceRoot);
+    const source = createRoomFromTemplate(workspaceRoot, {
+      projectId,
+      templateId: template.id,
+      name: 'Pricing Page Room',
+      goal: 'Develop SaaS pricing page',
+    });
+    const sourceWithHistory = addRoomHistory(source);
+    saveRoom(workspaceRoot, sourceWithHistory);
+
+    const forked = forkRoom(workspaceRoot, {
+      sourceRoomId: source.id,
+      name: 'Pricing Page Room - Variant A',
+    });
+
+    expect(forked.id).not.toBe(source.id);
+    expect(forked.forkedFromRoomId).toBe(source.id);
+    expect(forked.tasks).toHaveLength(1);
+    expect(forked.artifacts).toHaveLength(1);
+    expect(forked.decisions).toHaveLength(1);
+    expect(forked.events).toHaveLength(1);
+    expect(forked.timeline).toHaveLength(1);
+    expect(forked.tasks[0]!.id).not.toBe(sourceWithHistory.tasks[0]!.id);
+    expect(forked.tasks[0]!.roomId).toBe(forked.id);
+    expect(forked.artifacts[0]!.roomId).toBe(forked.id);
+    expect(forked.events[0]!.roomId).toBe(forked.id);
+    expect(forked.timeline[0]!.roomId).toBe(forked.id);
+    expect(forked.inboxes.some((inbox) => inbox.items.length === 1)).toBe(true);
+  });
+
+  it('saves room configuration as a team template without room history', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const { projectId, template } = setupTemplate(workspaceRoot);
+    const room = createRoomFromTemplate(workspaceRoot, {
+      projectId,
+      templateId: template.id,
+      name: 'Pricing Page Room',
+      goal: 'Develop SaaS pricing page',
+    });
+    saveRoom(workspaceRoot, addRoomHistory(room));
+
+    const savedTemplate = saveRoomAsTeamTemplate(workspaceRoot, {
+      roomId: room.id,
+      name: 'Saved Page Team',
+      description: 'Reusable page development team',
+    });
+
+    const reloaded = loadTeamTemplate(workspaceRoot, savedTemplate.id)!;
+    expect(reloaded.name).toBe('Saved Page Team');
+    expect(reloaded.roles.map((role) => role.roleKey)).toEqual(['frontend', 'backend']);
+    expect(reloaded.defaultWorkflow).toEqual(room.workflow!);
+    expect(reloaded.roomBusPolicy).toEqual(room.roomBusPolicy!);
+    expect('tasks' in reloaded).toBe(false);
+    expect('artifacts' in reloaded).toBe(false);
+  });
+
+  it('updates a room role prompt without changing the source template', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const { projectId, template } = setupTemplate(workspaceRoot);
+    const room = createRoomFromTemplate(workspaceRoot, {
+      projectId,
+      templateId: template.id,
+      name: 'Pricing Page Room',
+      goal: 'Develop SaaS pricing page',
+    });
+
+    const updated = updateRoomRolePrompt(
+      workspaceRoot,
+      room.id,
+      'role_frontend',
+      'Use the approved pricing artifacts before implementation.'
+    );
+
+    expect(updated.roleCards.find((role) => role.id === 'role_frontend')?.prompt)
+      .toBe('Use the approved pricing artifacts before implementation.');
+    expect(loadRoom(workspaceRoot, room.id)?.roleCards.find((role) => role.id === 'role_frontend')?.prompt)
+      .toBe('Use the approved pricing artifacts before implementation.');
+    expect(loadTeamTemplate(workspaceRoot, template.id)?.roles.find((role) => role.id === 'role_frontend')?.prompt)
+      .toBe('Frontend Agent prompt');
+  });
+});

--- a/packages/shared/src/native-agent-room/__tests__/storage.test.ts
+++ b/packages/shared/src/native-agent-room/__tests__/storage.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  addProjectArtifact,
+  createProject,
+  createRoomRecord,
+  createTeamTemplate,
+  listProjects,
+  listRoomAvailableArtifacts,
+  listRooms,
+  listTeamTemplates,
+  loadProject,
+  loadRoom,
+  loadTeamTemplate,
+} from '../storage.ts';
+import type { Artifact, CreateTeamTemplateInput, RoleCard } from '../types.ts';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeWorkspaceRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'native-agent-room-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeRoleCard(overrides: Partial<RoleCard> = {}): RoleCard {
+  return {
+    id: 'role_frontend',
+    name: 'Frontend Agent',
+    roleKey: 'frontend',
+    mission: 'Implement page UI',
+    prompt: 'Build from approved artifacts.',
+    responsibilities: ['Implement UI'],
+    inputs: ['ui_spec', 'api_contract'],
+    outputs: ['implementation'],
+    allowedActions: ['ask_agent', 'request_review', 'artifact_update'],
+    forbiddenActions: [],
+    doneCriteria: ['Implementation matches approved artifacts'],
+    contextPolicy: {
+      alwaysInclude: ['role_contract', 'member_directory', 'current_task', 'required_artifacts'],
+      requiredArtifactTypes: ['ui_spec', 'design_tokens', 'api_contract'],
+      optionalArtifactTypes: [],
+      includeEvents: ['ask_agent', 'answer_agent', 'artifact_update'],
+      exclude: ['full_transcript', 'other_agents_private_memory', 'deprecated_artifacts'],
+      subscriptions: [{ type: 'artifact_type', artifactType: 'api_contract' }],
+    },
+    ...overrides,
+  };
+}
+
+function makeTemplateInput(projectId: string): CreateTeamTemplateInput {
+  return {
+    projectId,
+    name: 'Page Development Team',
+    roles: [makeRoleCard()],
+    defaultWorkflow: {
+      phases: ['clarify', 'plan', 'foundation', 'design', 'implementation', 'review', 'fix', 'deliver'],
+      steps: [
+        {
+          id: 'step_implementation',
+          phase: 'implementation',
+          title: 'Implement page',
+          roleKeys: ['frontend'],
+        },
+      ],
+    },
+    roomBusPolicy: {
+      allowedActions: ['ask_agent', 'answer_agent', 'request_review', 'review_result', 'artifact_update'],
+      maxRequestsPerAgentTurn: 3,
+      defaultTtlMs: 24 * 60 * 60 * 1000,
+      maxHops: 4,
+    },
+  };
+}
+
+function makeArtifact(overrides: Partial<Artifact> = {}): Artifact {
+  const now = Date.now();
+  return {
+    id: 'artifact_design_tokens',
+    name: 'design-tokens.json',
+    type: 'design_tokens',
+    scope: 'project',
+    version: 1,
+    status: 'approved',
+    tags: ['design'],
+    contentRef: 'project/design-tokens.json',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe('native agent room storage: P0', () => {
+  it('persists projects, team templates, and rooms', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+
+    const project = createProject(workspaceRoot, {
+      name: 'Acme SaaS Website',
+      artifacts: [makeArtifact()],
+    });
+    const template = createTeamTemplate(workspaceRoot, makeTemplateInput(project.id));
+    const room = createRoomRecord(workspaceRoot, {
+      projectId: project.id,
+      templateId: template.id,
+      name: 'Pricing Page Room',
+      goal: 'Develop SaaS pricing page',
+      roleCards: template.roles,
+    });
+
+    expect(loadProject(workspaceRoot, project.id)?.name).toBe('Acme SaaS Website');
+    expect(loadTeamTemplate(workspaceRoot, template.id)?.roles).toHaveLength(1);
+    expect(loadRoom(workspaceRoot, room.id)?.goal).toBe('Develop SaaS pricing page');
+    expect(listProjects(workspaceRoot)).toHaveLength(1);
+    expect(listTeamTemplates(workspaceRoot, project.id)).toHaveLength(1);
+    expect(listRooms(workspaceRoot, project.id)).toHaveLength(1);
+
+    const reloadedProject = loadProject(workspaceRoot, project.id);
+    expect(reloadedProject?.teamTemplateIds).toEqual([template.id]);
+    expect(reloadedProject?.roomIds).toEqual([room.id]);
+  });
+
+  it('lets a room reference project-level artifacts', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const project = createProject(workspaceRoot, { name: 'Acme SaaS Website' });
+    const designTokens = makeArtifact();
+    const componentGuidelines = makeArtifact({
+      id: 'artifact_component_guidelines',
+      name: 'component-guidelines.md',
+      type: 'component_guidelines',
+      contentRef: 'project/component-guidelines.md',
+    });
+    addProjectArtifact(workspaceRoot, project.id, designTokens);
+    addProjectArtifact(workspaceRoot, project.id, componentGuidelines);
+
+    const room = createRoomRecord(workspaceRoot, {
+      projectId: project.id,
+      name: 'Pricing Page Room',
+      goal: 'Develop SaaS pricing page',
+    });
+
+    const artifacts = listRoomAvailableArtifacts(workspaceRoot, room.id);
+    expect(artifacts.projectArtifacts.map((artifact) => artifact.name).sort()).toEqual([
+      'component-guidelines.md',
+      'design-tokens.json',
+    ]);
+    expect(artifacts.roomArtifacts).toEqual([]);
+    expect(artifacts.taskArtifacts).toEqual([]);
+  });
+
+  it('excludes deprecated project artifacts from available room artifacts', () => {
+    const workspaceRoot = makeWorkspaceRoot();
+    const project = createProject(workspaceRoot, {
+      name: 'Acme SaaS Website',
+      artifacts: [
+        makeArtifact(),
+        makeArtifact({
+          id: 'artifact_old_tokens',
+          name: 'old-design-tokens.json',
+          status: 'deprecated',
+          contentRef: 'project/old-design-tokens.json',
+        }),
+      ],
+    });
+    const room = createRoomRecord(workspaceRoot, {
+      projectId: project.id,
+      name: 'Pricing Page Room',
+      goal: 'Develop SaaS pricing page',
+    });
+
+    const artifacts = listRoomAvailableArtifacts(workspaceRoot, room.id);
+    expect(artifacts.projectArtifacts.map((artifact) => artifact.name)).toEqual(['design-tokens.json']);
+  });
+});

--- a/packages/shared/src/native-agent-room/attention.ts
+++ b/packages/shared/src/native-agent-room/attention.ts
@@ -1,0 +1,340 @@
+import { loadProject, loadRoom } from './storage.ts';
+import type {
+  Artifact,
+  ContextPack,
+  ContextUsedItem,
+  Decision,
+  Room,
+  RoomBusEvent,
+  RoomMember,
+  RoomMemberSummary,
+  TargetRef,
+  Task,
+} from './types.ts';
+
+export interface ResolveContextPackInput {
+  roomId: string;
+  agentId: string;
+  taskId?: string;
+  triggerEventId?: string;
+}
+
+type EventLike = Pick<RoomBusEvent, 'type' | 'from' | 'to' | 'taskId' | 'artifactId' | 'decisionId' | 'payload' | 'status'>;
+
+function normalizeToken(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function payloadMessage(payload: Record<string, unknown>): string {
+  return typeof payload.message === 'string' ? payload.message : '';
+}
+
+function unique<T>(items: T[]): T[] {
+  return [...new Set(items)];
+}
+
+function targetToAgentIds(room: Room, target: TargetRef): string[] {
+  if (target.type === 'all') {
+    return room.members.map((member) => member.id);
+  }
+
+  if (target.type === 'agent') {
+    return room.members.some((member) => member.id === target.id) ? [target.id] : [];
+  }
+
+  if (target.type === 'role') {
+    return room.members
+      .filter((member) => member.roleKey === target.roleKey)
+      .map((member) => member.id);
+  }
+
+  if (target.type === 'task') {
+    const task = room.tasks.find((item) => item.id === target.id);
+    return task ? [task.ownerAgentId] : [];
+  }
+
+  const artifact = room.artifacts.find((item) => item.id === target.id);
+  if (!artifact) return [];
+
+  const agentIds = new Set<string>();
+  if (artifact.ownerAgentId) {
+    agentIds.add(artifact.ownerAgentId);
+  }
+  for (const task of room.tasks) {
+    if (task.inputArtifactIds.includes(artifact.id)) {
+      agentIds.add(task.ownerAgentId);
+    }
+  }
+  return [...agentIds];
+}
+
+function findAgentOrRoleTarget(room: Room, token: string): TargetRef | null {
+  const normalized = normalizeToken(token);
+  const member = room.members.find((item) =>
+    normalizeToken(item.id) === normalized ||
+    normalizeToken(item.name) === normalized ||
+    normalizeToken(item.roleKey) === normalized
+  );
+  if (member) {
+    return { type: 'agent', id: member.id };
+  }
+
+  const role = room.roleCards.find((item) =>
+    normalizeToken(item.id) === normalized ||
+    normalizeToken(item.name) === normalized ||
+    normalizeToken(item.roleKey) === normalized
+  );
+  if (role) {
+    return { type: 'role', roleKey: role.roleKey };
+  }
+
+  return null;
+}
+
+export function resolveMentionTargets(room: Room, message: string): TargetRef[] {
+  const targets: TargetRef[] = [];
+  const mentionRegex = /@([A-Za-z0-9_-]+)(?::([A-Za-z0-9_-]+))?/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = mentionRegex.exec(message)) !== null) {
+    const mentionType = match[1]!;
+    const mentionValue = match[2];
+    const normalizedType = normalizeToken(mentionType);
+
+    if (normalizedType === 'all') {
+      targets.push({ type: 'all' });
+      continue;
+    }
+
+    if (normalizedType === 'task' && mentionValue) {
+      if (room.tasks.some((task) => task.id === mentionValue)) {
+        targets.push({ type: 'task', id: mentionValue });
+      }
+      continue;
+    }
+
+    if (normalizedType === 'artifact' && mentionValue) {
+      if (room.artifacts.some((artifact) => artifact.id === mentionValue)) {
+        targets.push({ type: 'artifact', id: mentionValue });
+      }
+      continue;
+    }
+
+    const agentOrRole = findAgentOrRoleTarget(room, mentionType);
+    if (agentOrRole) {
+      targets.push(agentOrRole);
+    }
+  }
+
+  return targets;
+}
+
+export function resolveEventAttentionAgentIds(room: Room, event: EventLike): string[] {
+  const agentIds = new Set<string>();
+  const targets = [
+    ...(event.to ?? []),
+    ...resolveMentionTargets(room, payloadMessage(event.payload)),
+  ];
+
+  if (event.type === 'announcement' && targets.length === 0) {
+    targets.push({ type: 'all' });
+  }
+
+  for (const target of targets) {
+    for (const agentId of targetToAgentIds(room, target)) {
+      agentIds.add(agentId);
+    }
+  }
+
+  if (event.taskId) {
+    const task = room.tasks.find((item) => item.id === event.taskId);
+    if (task) {
+      agentIds.add(task.ownerAgentId);
+    }
+  }
+
+  if (event.artifactId) {
+    for (const agentId of targetToAgentIds(room, { type: 'artifact', id: event.artifactId })) {
+      agentIds.add(agentId);
+    }
+  }
+
+  if (event.decisionId) {
+    const decision = room.decisions.find((item) => item.id === event.decisionId);
+    if (decision) {
+      for (const taskId of decision.relatedTaskIds) {
+        for (const agentId of targetToAgentIds(room, { type: 'task', id: taskId })) {
+          agentIds.add(agentId);
+        }
+      }
+      for (const artifactId of decision.relatedArtifactIds) {
+        for (const agentId of targetToAgentIds(room, { type: 'artifact', id: artifactId })) {
+          agentIds.add(agentId);
+        }
+      }
+    }
+  }
+
+  return [...agentIds];
+}
+
+function buildMemberSummary(room: Room, member: RoomMember): RoomMemberSummary {
+  const role = room.roleCards.find((item) => item.id === member.roleCardId);
+  return {
+    id: member.id,
+    name: member.name,
+    roleKey: member.roleKey,
+    status: member.status,
+    responsibilities: role?.responsibilities ?? [],
+    allowedActions: role?.allowedActions ?? [],
+  };
+}
+
+function findCurrentTask(room: Room, agentId: string, taskId?: string): Task | undefined {
+  if (taskId) {
+    return room.tasks.find((task) => task.id === taskId && task.ownerAgentId === agentId);
+  }
+
+  return room.tasks.find((task) =>
+    task.ownerAgentId === agentId && !['done'].includes(task.status)
+  ) ?? room.tasks.find((task) => task.ownerAgentId === agentId);
+}
+
+function artifactMatchesRoleOrTask(artifact: Artifact, roleRequiredTypes: string[], currentTask?: Task): boolean {
+  if (artifact.status === 'deprecated') return false;
+  if (currentTask?.inputArtifactIds.includes(artifact.id)) return true;
+  if (currentTask?.outputArtifactIds.includes(artifact.id)) return true;
+  return roleRequiredTypes.includes(artifact.type);
+}
+
+function selectRequiredArtifacts(room: Room, projectArtifacts: Artifact[], roleRequiredTypes: string[], currentTask?: Task): Artifact[] {
+  const artifacts = [...projectArtifacts, ...room.artifacts];
+  const byId = new Map<string, Artifact>();
+
+  for (const artifact of artifacts) {
+    if (artifactMatchesRoleOrTask(artifact, roleRequiredTypes, currentTask)) {
+      byId.set(artifact.id, artifact);
+    }
+  }
+
+  return [...byId.values()];
+}
+
+function isDecisionRelevant(decision: Decision, currentTask: Task | undefined, requiredArtifacts: Artifact[]): boolean {
+  if (decision.status === 'rejected') return false;
+  if (!currentTask) return decision.scope === 'project' || decision.scope === 'room';
+  if (decision.relatedTaskIds.includes(currentTask.id)) return true;
+
+  const artifactIds = new Set(requiredArtifacts.map((artifact) => artifact.id));
+  return decision.relatedArtifactIds.some((artifactId) => artifactIds.has(artifactId));
+}
+
+function isEventRelevant(room: Room, event: RoomBusEvent, agentId: string, currentTask: Task | undefined, triggerEventId?: string): boolean {
+  if (event.id === triggerEventId) return true;
+  if (resolveEventAttentionAgentIds(room, event).includes(agentId)) return true;
+  if (event.from === agentId && event.status === 'open') return true;
+  if (currentTask && event.taskId === currentTask.id) return true;
+  return false;
+}
+
+function contextUsedFromPack(parts: {
+  roleId: string;
+  memberDirectory: RoomMemberSummary[];
+  currentTask?: Task;
+  artifacts: Artifact[];
+  events: RoomBusEvent[];
+  decisions: Decision[];
+  timeline: ContextPack['timeline'];
+  inboxItems: ContextPack['inboxItems'];
+}): ContextUsedItem[] {
+  const items: ContextUsedItem[] = [
+    { type: 'role', id: parts.roleId, label: 'RoleCard' },
+    { type: 'member_directory', id: 'member_directory', label: `${parts.memberDirectory.length} room members` },
+  ];
+
+  if (parts.currentTask) {
+    items.push({ type: 'task', id: parts.currentTask.id, label: parts.currentTask.title });
+  }
+
+  for (const artifact of parts.artifacts) {
+    items.push({ type: 'artifact', id: artifact.id, label: `${artifact.name}@v${artifact.version}` });
+  }
+  for (const event of parts.events) {
+    items.push({ type: 'event', id: event.id, label: event.type });
+  }
+  for (const decision of parts.decisions) {
+    items.push({ type: 'decision', id: decision.id, label: decision.title });
+  }
+  for (const item of parts.timeline) {
+    items.push({ type: 'timeline', id: item.id, label: item.title });
+  }
+  for (const item of parts.inboxItems) {
+    items.push({ type: 'inbox', id: item.id, label: item.type });
+  }
+
+  return items;
+}
+
+export function resolveContextPack(
+  workspaceRootPath: string,
+  input: ResolveContextPackInput
+): ContextPack {
+  const room = loadRoom(workspaceRootPath, input.roomId);
+  if (!room) {
+    throw new Error(`Room not found: ${input.roomId}`);
+  }
+
+  const member = room.members.find((item) => item.id === input.agentId);
+  if (!member) {
+    throw new Error(`Agent not found in room: ${input.agentId}`);
+  }
+
+  const role = room.roleCards.find((item) => item.id === member.roleCardId);
+  if (!role) {
+    throw new Error(`Role card not found in room: ${member.roleCardId}`);
+  }
+
+  const project = loadProject(workspaceRootPath, room.projectId);
+  const projectArtifacts = project?.artifacts.filter((artifact) => artifact.status !== 'deprecated') ?? [];
+  const currentTask = findCurrentTask(room, member.id, input.taskId);
+  const requiredArtifacts = selectRequiredArtifacts(
+    room,
+    projectArtifacts,
+    role.contextPolicy.requiredArtifactTypes,
+    currentTask
+  );
+  const relevantDecisions = room.decisions
+    .filter((decision) => isDecisionRelevant(decision, currentTask, requiredArtifacts));
+  const attentionEvents = room.events
+    .filter((event) => isEventRelevant(room, event, member.id, currentTask, input.triggerEventId));
+  const inboxItems = room.inboxes
+    .find((inbox) => inbox.agentId === member.id)
+    ?.items.filter((item) => item.status !== 'dismissed') ?? [];
+  const memberDirectory = room.members.map((item) => buildMemberSummary(room, item));
+  const timeline = room.timeline.slice(-20);
+
+  return {
+    agentId: member.id,
+    roomId: room.id,
+    taskId: currentTask?.id,
+    triggerEventId: input.triggerEventId,
+    roleContext: role,
+    memberDirectory,
+    currentTask,
+    requiredArtifacts,
+    relevantDecisions,
+    attentionEvents,
+    inboxItems,
+    timeline,
+    contextUsed: contextUsedFromPack({
+      roleId: role.id,
+      memberDirectory,
+      currentTask,
+      artifacts: requiredArtifacts,
+      events: attentionEvents,
+      decisions: relevantDecisions,
+      timeline,
+      inboxItems,
+    }),
+  };
+}

--- a/packages/shared/src/native-agent-room/index.ts
+++ b/packages/shared/src/native-agent-room/index.ts
@@ -1,0 +1,110 @@
+export type {
+  AgentId,
+  AgentInbox,
+  Artifact,
+  ArtifactRef,
+  ArtifactScope,
+  ArtifactSection,
+  ArtifactStatus,
+  ArtifactType,
+  ContextExcludeRule,
+  ContextPack,
+  ContextPolicy,
+  ContextSourceType,
+  ContextUsedItem,
+  CreateProjectInput,
+  CreateRoomRecordInput,
+  CreateTeamTemplateInput,
+  Decision,
+  DecisionScope,
+  DecisionStatus,
+  InboxItem,
+  InboxItemPriority,
+  InboxItemStatus,
+  InboxItemType,
+  Project,
+  RoleCard,
+  Room,
+  RoomAvailableArtifacts,
+  RoomBusActionType,
+  RoomBusEvent,
+  RoomBusPolicy,
+  RoomMember,
+  RoomMemberSummary,
+  RoomPhase,
+  RoomRef,
+  RoomStatus,
+  SubscriptionRule,
+  TargetRef,
+  Task,
+  TaskStatus,
+  TeamTemplate,
+  TeamTemplateRef,
+  TimelineItem,
+  TimestampMs,
+  WorkflowTemplate,
+  WorkflowTemplateStep,
+} from './types.ts';
+
+export {
+  resolveContextPack,
+  resolveEventAttentionAgentIds,
+  resolveMentionTargets,
+} from './attention.ts';
+
+export type {
+  ResolveContextPackInput,
+} from './attention.ts';
+
+export {
+  publishRoomBusEvent,
+  resolveRoomBusTargets,
+} from './room-bus.ts';
+
+export type {
+  PublishRoomBusEventInput,
+} from './room-bus.ts';
+
+export {
+  createRoomFromTemplate,
+  duplicateRoomConfig,
+  forkRoom,
+  saveRoomAsTeamTemplate,
+  updateRoomRolePrompt,
+} from './room-operations.ts';
+
+export type {
+  CreateRoomFromTemplateInput,
+  DuplicateRoomConfigInput,
+  ForkRoomInput,
+  SaveRoomAsTeamTemplateInput,
+} from './room-operations.ts';
+
+export {
+  addProjectArtifact,
+  createNativeAgentRoomId,
+  createProject,
+  createRoomRecord,
+  createTeamTemplate,
+  deleteProject,
+  deleteRoom,
+  deleteTeamTemplate,
+  ensureNativeAgentRoomDir,
+  getNativeAgentRoomPath,
+  getNativeAgentRoomProjectsPath,
+  getNativeAgentRoomRoomsPath,
+  getNativeAgentRoomTeamTemplatesPath,
+  getProjectPath,
+  getRoomPath,
+  getTeamTemplatePath,
+  listProjects,
+  listRoomAvailableArtifacts,
+  listRooms,
+  listTeamTemplates,
+  loadProject,
+  loadRoom,
+  loadTeamTemplate,
+  saveProject,
+  saveRoom,
+  saveTeamTemplate,
+} from './storage.ts';

--- a/packages/shared/src/native-agent-room/room-bus.ts
+++ b/packages/shared/src/native-agent-room/room-bus.ts
@@ -1,0 +1,313 @@
+import { createNativeAgentRoomId, loadRoom, saveRoom } from './storage.ts';
+import { resolveEventAttentionAgentIds, resolveMentionTargets } from './attention.ts';
+import type {
+  AgentInbox,
+  InboxItem,
+  InboxItemPriority,
+  InboxItemType,
+  Room,
+  RoomBusActionType,
+  RoomBusEvent,
+  TargetRef,
+} from './types.ts';
+
+export interface PublishRoomBusEventInput {
+  roomId: string;
+  from: RoomBusEvent['from'];
+  to?: TargetRef[];
+  type: RoomBusActionType;
+  taskId?: string;
+  artifactId?: string;
+  decisionId?: string;
+  payload: Record<string, unknown>;
+  parentEventId?: string;
+  ttlMs?: number;
+  maxHops?: number;
+}
+
+const ROOM_BUS_ACTIONS = new Set<RoomBusActionType>([
+  'message',
+  'ask_agent',
+  'answer_agent',
+  'raise_blocker',
+  'resolve_blocker',
+  'handoff_task',
+  'request_review',
+  'review_result',
+  'propose_change',
+  'artifact_update',
+  'decision',
+  'approval_request',
+  'announcement',
+]);
+
+const REQUEST_ACTIONS = new Set<RoomBusActionType>([
+  'ask_agent',
+  'handoff_task',
+  'request_review',
+  'approval_request',
+]);
+
+function eventTargetKey(targets: TargetRef[] | undefined): string {
+  return (targets ?? [])
+    .map((target) => {
+      if (target.type === 'role') return `role:${target.roleKey}`;
+      if (target.type === 'all') return 'all';
+      return `${target.type}:${target.id}`;
+    })
+    .sort()
+    .join('|');
+}
+
+function assertExpectedOutput(input: PublishRoomBusEventInput): void {
+  if (!REQUEST_ACTIONS.has(input.type)) return;
+
+  const expectedOutput = input.payload.expectedOutput;
+  if (typeof expectedOutput !== 'string' || expectedOutput.trim().length === 0) {
+    throw new Error(`${input.type} requires payload.expectedOutput`);
+  }
+}
+
+function assertKnownEventType(type: RoomBusActionType): void {
+  if (!ROOM_BUS_ACTIONS.has(type)) {
+    throw new Error(`Unsupported RoomBus event type: ${type}`);
+  }
+}
+
+function resolveTarget(room: Room, target: TargetRef): string[] {
+  if (target.type === 'all') {
+    return room.members.map((member) => member.id);
+  }
+
+  if (target.type === 'agent') {
+    if (!room.members.some((member) => member.id === target.id)) {
+      throw new Error(`RoomBus target agent not found: ${target.id}`);
+    }
+    return [target.id];
+  }
+
+  if (target.type === 'role') {
+    const members = room.members.filter((member) => member.roleKey === target.roleKey);
+    if (members.length === 0) {
+      throw new Error(`RoomBus target role not found: ${target.roleKey}`);
+    }
+    return members.map((member) => member.id);
+  }
+
+  if (target.type === 'task') {
+    const task = room.tasks.find((item) => item.id === target.id);
+    if (!task) {
+      throw new Error(`RoomBus target task not found: ${target.id}`);
+    }
+    return [task.ownerAgentId];
+  }
+
+  const artifact = room.artifacts.find((item) => item.id === target.id);
+  if (!artifact) {
+    throw new Error(`RoomBus target artifact not found: ${target.id}`);
+  }
+
+  const agentIds = new Set<string>();
+  if (artifact.ownerAgentId) {
+    agentIds.add(artifact.ownerAgentId);
+  }
+  for (const task of room.tasks) {
+    if (task.inputArtifactIds.includes(artifact.id)) {
+      agentIds.add(task.ownerAgentId);
+    }
+  }
+  return [...agentIds];
+}
+
+export function resolveRoomBusTargets(room: Room, targets: TargetRef[] | undefined): string[] {
+  if (!targets || targets.length === 0) return [];
+
+  const agentIds = new Set<string>();
+  for (const target of targets) {
+    for (const agentId of resolveTarget(room, target)) {
+      agentIds.add(agentId);
+    }
+  }
+  return [...agentIds];
+}
+
+function getParentChain(room: Room, parentEventId: string | undefined): RoomBusEvent[] {
+  const chain: RoomBusEvent[] = [];
+  let currentId = parentEventId;
+  const seen = new Set<string>();
+
+  while (currentId && !seen.has(currentId)) {
+    seen.add(currentId);
+    const event = room.events.find((item) => item.id === currentId);
+    if (!event) break;
+    chain.push(event);
+    currentId = event.parentEventId;
+  }
+
+  return chain;
+}
+
+function assertLoopSafety(room: Room, input: PublishRoomBusEventInput, maxHops: number): number {
+  const chain = getParentChain(room, input.parentEventId);
+  const hopCount = chain.length > 0 ? (chain[0]!.hopCount ?? 0) + 1 : 0;
+  if (hopCount > maxHops) {
+    throw new Error(`RoomBus max hops exceeded: ${hopCount}/${maxHops}`);
+  }
+
+  const signature = `${input.type}:${input.from}:${eventTargetKey(input.to)}`;
+  if (chain.some((event) => `${event.type}:${event.from}:${eventTargetKey(event.to)}` === signature)) {
+    throw new Error('RoomBus loop detected');
+  }
+
+  return hopCount;
+}
+
+function inboxTypeForEvent(type: RoomBusActionType): InboxItemType {
+  if (type === 'request_review' || type === 'review_result') return 'review_request';
+  if (type === 'raise_blocker' || type === 'resolve_blocker') return 'blocker';
+  if (type === 'handoff_task') return 'handoff';
+  if (type === 'artifact_update') return 'artifact_update';
+  if (type === 'decision') return 'decision_update';
+  if (type === 'announcement') return 'announcement';
+  return 'request';
+}
+
+function priorityForEvent(event: RoomBusEvent): InboxItemPriority {
+  if (event.type === 'raise_blocker') return 'blocking';
+  if (event.type === 'review_result' && event.payload.severity === 'blocking') return 'blocking';
+  if (event.type === 'request_review' || event.type === 'handoff_task') return 'high';
+  if (event.type === 'announcement') return 'low';
+  return 'normal';
+}
+
+function ensureInbox(room: Room, agentId: string): AgentInbox {
+  const existing = room.inboxes.find((inbox) => inbox.agentId === agentId);
+  if (existing) return existing;
+
+  const member = room.members.find((item) => item.id === agentId);
+  if (!member) {
+    throw new Error(`Agent inbox owner not found: ${agentId}`);
+  }
+
+  const inbox: AgentInbox = {
+    id: member.inboxId,
+    roomId: room.id,
+    agentId,
+    items: [],
+  };
+  room.inboxes.push(inbox);
+  return inbox;
+}
+
+function addInboxItem(room: Room, agentId: string, event: RoomBusEvent): void {
+  const inbox = ensureInbox(room, agentId);
+  if (inbox.items.some((item) => item.eventId === event.id)) return;
+
+  const item: InboxItem = {
+    id: createNativeAgentRoomId('inbox_item'),
+    eventId: event.id,
+    type: inboxTypeForEvent(event.type),
+    status: 'unread',
+    priority: priorityForEvent(event),
+    createdAt: event.createdAt,
+  };
+  inbox.items.push(item);
+}
+
+function updateTaskStatusFromEvent(room: Room, event: RoomBusEvent): void {
+  if (!event.taskId) return;
+  const task = room.tasks.find((item) => item.id === event.taskId);
+  if (!task) return;
+
+  if (event.type === 'raise_blocker') {
+    task.status = 'blocked';
+  } else if (event.type === 'request_review') {
+    task.status = 'waiting_review';
+  } else if (event.type === 'review_result' && event.payload.severity === 'blocking') {
+    task.status = 'changes_requested';
+  } else {
+    return;
+  }
+
+  task.updatedAt = event.createdAt;
+}
+
+function resolveParentIfNeeded(room: Room, event: RoomBusEvent): void {
+  if (!event.parentEventId) return;
+  if (!['answer_agent', 'resolve_blocker', 'review_result'].includes(event.type)) return;
+
+  const parent = room.events.find((item) => item.id === event.parentEventId);
+  if (!parent || parent.status !== 'open') return;
+
+  parent.status = 'resolved';
+  parent.resolvedAt = event.createdAt;
+}
+
+export function publishRoomBusEvent(
+  workspaceRootPath: string,
+  input: PublishRoomBusEventInput
+): RoomBusEvent {
+  const room = loadRoom(workspaceRootPath, input.roomId);
+  if (!room) {
+    throw new Error(`Room not found: ${input.roomId}`);
+  }
+
+  assertKnownEventType(input.type);
+  assertExpectedOutput(input);
+
+  const mentionTargets = input.to && input.to.length > 0
+    ? []
+    : resolveMentionTargets(room, typeof input.payload.message === 'string' ? input.payload.message : '');
+  const eventTargets = input.to ?? (mentionTargets.length > 0 ? mentionTargets : undefined);
+  const maxHops = input.maxHops ?? room.roomBusPolicy?.maxHops ?? 4;
+  const hopCount = assertLoopSafety(room, { ...input, to: eventTargets }, maxHops);
+  const targetAgentIds = resolveEventAttentionAgentIds(room, {
+    ...input,
+    to: eventTargets,
+    status: 'open',
+  });
+
+  if (input.type !== 'announcement' && targetAgentIds.length === 0) {
+    throw new Error('RoomBus event requires at least one resolvable target');
+  }
+
+  const now = Date.now();
+  const ttlMs = input.ttlMs ?? room.roomBusPolicy?.defaultTtlMs ?? 24 * 60 * 60 * 1000;
+  const event: RoomBusEvent = {
+    id: createNativeAgentRoomId('event'),
+    projectId: room.projectId,
+    roomId: room.id,
+    from: input.from,
+    to: eventTargets,
+    type: input.type,
+    taskId: input.taskId,
+    artifactId: input.artifactId,
+    decisionId: input.decisionId,
+    payload: input.payload,
+    status: 'open',
+    createdAt: now,
+    parentEventId: input.parentEventId,
+    expiresAt: now + ttlMs,
+    hopCount,
+    maxHops,
+  };
+
+  room.events.push(event);
+  updateTaskStatusFromEvent(room, event);
+  resolveParentIfNeeded(room, event);
+
+  const inboxTargetIds = event.type === 'announcement'
+    ? room.members.map((member) => member.id)
+    : targetAgentIds;
+
+  for (const agentId of inboxTargetIds) {
+    addInboxItem(room, agentId, event);
+  }
+
+  if (REQUEST_ACTIONS.has(event.type) && room.members.some((member) => member.id === event.from)) {
+    addInboxItem(room, event.from, event);
+  }
+
+  saveRoom(workspaceRootPath, room);
+  return event;
+}

--- a/packages/shared/src/native-agent-room/room-operations.ts
+++ b/packages/shared/src/native-agent-room/room-operations.ts
@@ -1,0 +1,361 @@
+import { loadRoom, loadTeamTemplate, saveRoom, createRoomRecord, createTeamTemplate, createNativeAgentRoomId } from './storage.ts';
+import type {
+  AgentInbox,
+  CreateTeamTemplateInput,
+  InboxItem,
+  RoleCard,
+  Room,
+  RoomBusActionType,
+  RoomBusPolicy,
+  RoomMember,
+  TargetRef,
+  TeamTemplate,
+  TimelineItem,
+  WorkflowTemplate,
+} from './types.ts';
+
+export interface CreateRoomFromTemplateInput {
+  projectId: string;
+  templateId: string;
+  name: string;
+  goal: string;
+}
+
+export interface DuplicateRoomConfigInput {
+  sourceRoomId: string;
+  name: string;
+  goal?: string;
+  projectId?: string;
+}
+
+export interface ForkRoomInput {
+  sourceRoomId: string;
+  name: string;
+  goal?: string;
+}
+
+export interface SaveRoomAsTeamTemplateInput {
+  roomId: string;
+  name: string;
+  description?: string;
+}
+
+const DEFAULT_PHASES: WorkflowTemplate['phases'] = [
+  'clarify',
+  'plan',
+  'foundation',
+  'design',
+  'implementation',
+  'review',
+  'fix',
+  'deliver',
+];
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function createMemberForRole(roomId: string, role: RoleCard): RoomMember {
+  const memberId = createNativeAgentRoomId('agent');
+  return {
+    id: memberId,
+    roomId,
+    roleCardId: role.id,
+    name: role.name,
+    roleKey: role.roleKey,
+    sessionId: createNativeAgentRoomId('session'),
+    inboxId: createNativeAgentRoomId('inbox'),
+    status: 'idle',
+    ownedTaskIds: [],
+    ownedArtifactIds: [],
+  };
+}
+
+function createInboxForMember(roomId: string, member: RoomMember): AgentInbox {
+  return {
+    id: member.inboxId,
+    roomId,
+    agentId: member.id,
+    items: [],
+  };
+}
+
+function createMembersAndInboxes(roomId: string, roles: RoleCard[]): {
+  members: RoomMember[];
+  inboxes: AgentInbox[];
+} {
+  const members = roles.map((role) => createMemberForRole(roomId, role));
+  return {
+    members,
+    inboxes: members.map((member) => createInboxForMember(roomId, member)),
+  };
+}
+
+function defaultWorkflow(): WorkflowTemplate {
+  return {
+    phases: [...DEFAULT_PHASES],
+    steps: [],
+  };
+}
+
+function defaultRoomBusPolicy(roles: RoleCard[]): RoomBusPolicy {
+  const allowedActions = new Set<RoomBusActionType>();
+  for (const role of roles) {
+    for (const action of role.allowedActions) {
+      allowedActions.add(action);
+    }
+  }
+
+  return {
+    allowedActions: allowedActions.size > 0
+      ? [...allowedActions]
+      : ['ask_agent', 'answer_agent', 'request_review', 'review_result', 'artifact_update', 'announcement'],
+    maxRequestsPerAgentTurn: 3,
+    defaultTtlMs: 24 * 60 * 60 * 1000,
+    maxHops: 4,
+  };
+}
+
+export function createRoomFromTemplate(
+  workspaceRootPath: string,
+  input: CreateRoomFromTemplateInput
+): Room {
+  const template = loadTeamTemplate(workspaceRootPath, input.templateId);
+  if (!template) {
+    throw new Error(`Team template not found: ${input.templateId}`);
+  }
+
+  const roleCards = clone(template.roles);
+  const room = createRoomRecord(workspaceRootPath, {
+    projectId: input.projectId,
+    templateId: template.id,
+    name: input.name,
+    goal: input.goal,
+    workflow: clone(template.defaultWorkflow),
+    roomBusPolicy: clone(template.roomBusPolicy),
+    roleCards,
+  });
+
+  const { members, inboxes } = createMembersAndInboxes(room.id, roleCards);
+  const nextRoom: Room = {
+    ...room,
+    members,
+    inboxes,
+  };
+  saveRoom(workspaceRootPath, nextRoom);
+  return nextRoom;
+}
+
+export function duplicateRoomConfig(
+  workspaceRootPath: string,
+  input: DuplicateRoomConfigInput
+): Room {
+  const source = loadRoom(workspaceRootPath, input.sourceRoomId);
+  if (!source) {
+    throw new Error(`Room not found: ${input.sourceRoomId}`);
+  }
+
+  const roleCards = clone(source.roleCards);
+  const room = createRoomRecord(workspaceRootPath, {
+    projectId: input.projectId ?? source.projectId,
+    templateId: source.templateId,
+    name: input.name,
+    goal: input.goal ?? source.goal,
+    status: 'draft',
+    phase: source.phase,
+    workflow: clone(source.workflow ?? defaultWorkflow()),
+    roomBusPolicy: clone(source.roomBusPolicy ?? defaultRoomBusPolicy(roleCards)),
+    roleCards,
+  });
+
+  const { members, inboxes } = createMembersAndInboxes(room.id, roleCards);
+  const nextRoom: Room = {
+    ...room,
+    members,
+    inboxes,
+  };
+  saveRoom(workspaceRootPath, nextRoom);
+  return nextRoom;
+}
+
+function remapTarget(target: TargetRef, maps: {
+  memberIds: Map<string, string>;
+  taskIds: Map<string, string>;
+  artifactIds: Map<string, string>;
+}): TargetRef {
+  if (target.type === 'agent') {
+    return { type: 'agent', id: maps.memberIds.get(target.id) ?? target.id };
+  }
+  if (target.type === 'task') {
+    return { type: 'task', id: maps.taskIds.get(target.id) ?? target.id };
+  }
+  if (target.type === 'artifact') {
+    return { type: 'artifact', id: maps.artifactIds.get(target.id) ?? target.id };
+  }
+  return target;
+}
+
+export function forkRoom(workspaceRootPath: string, input: ForkRoomInput): Room {
+  const source = loadRoom(workspaceRootPath, input.sourceRoomId);
+  if (!source) {
+    throw new Error(`Room not found: ${input.sourceRoomId}`);
+  }
+
+  const baseRoom = createRoomRecord(workspaceRootPath, {
+    projectId: source.projectId,
+    templateId: source.templateId,
+    name: input.name,
+    goal: input.goal ?? source.goal,
+  });
+
+  const memberIds = new Map(source.members.map((member) => [member.id, createNativeAgentRoomId('agent')]));
+  const inboxIds = new Map(source.inboxes.map((inbox) => [inbox.id, createNativeAgentRoomId('inbox')]));
+  const taskIds = new Map(source.tasks.map((task) => [task.id, createNativeAgentRoomId('task')]));
+  const artifactIds = new Map(source.artifacts.map((artifact) => [artifact.id, createNativeAgentRoomId('artifact')]));
+  const decisionIds = new Map(source.decisions.map((decision) => [decision.id, createNativeAgentRoomId('decision')]));
+  const eventIds = new Map(source.events.map((event) => [event.id, createNativeAgentRoomId('event')]));
+  const timelineIds = new Map(source.timeline.map((item) => [item.id, createNativeAgentRoomId('timeline')]));
+  const inboxItemIds = new Map<string, string>();
+
+  for (const inbox of source.inboxes) {
+    for (const item of inbox.items) {
+      inboxItemIds.set(item.id, createNativeAgentRoomId('inbox_item'));
+    }
+  }
+
+  const members = source.members.map((member) => ({
+    ...clone(member),
+    id: memberIds.get(member.id)!,
+    roomId: baseRoom.id,
+    sessionId: createNativeAgentRoomId('session'),
+    inboxId: inboxIds.get(member.inboxId) ?? createNativeAgentRoomId('inbox'),
+    ownedTaskIds: member.ownedTaskIds.map((id) => taskIds.get(id) ?? id),
+    ownedArtifactIds: member.ownedArtifactIds.map((id) => artifactIds.get(id) ?? id),
+  }));
+
+  const tasks = source.tasks.map((task) => ({
+    ...clone(task),
+    id: taskIds.get(task.id)!,
+    roomId: baseRoom.id,
+    ownerAgentId: memberIds.get(task.ownerAgentId) ?? task.ownerAgentId,
+    inputArtifactIds: task.inputArtifactIds.map((id) => artifactIds.get(id) ?? id),
+    outputArtifactIds: task.outputArtifactIds.map((id) => artifactIds.get(id) ?? id),
+    dependencyTaskIds: task.dependencyTaskIds.map((id) => taskIds.get(id) ?? id),
+  }));
+
+  const artifacts = source.artifacts.map((artifact) => ({
+    ...clone(artifact),
+    id: artifactIds.get(artifact.id)!,
+    roomId: baseRoom.id,
+    taskId: artifact.taskId ? taskIds.get(artifact.taskId) ?? artifact.taskId : undefined,
+    ownerAgentId: artifact.ownerAgentId ? memberIds.get(artifact.ownerAgentId) ?? artifact.ownerAgentId : undefined,
+  }));
+
+  const decisions = source.decisions.map((decision) => ({
+    ...clone(decision),
+    id: decisionIds.get(decision.id)!,
+    roomId: baseRoom.id,
+    relatedTaskIds: decision.relatedTaskIds.map((id) => taskIds.get(id) ?? id),
+    relatedArtifactIds: decision.relatedArtifactIds.map((id) => artifactIds.get(id) ?? id),
+    createdBy: memberIds.get(decision.createdBy) ?? decision.createdBy,
+    approvedBy: decision.approvedBy && decision.approvedBy !== 'user'
+      ? memberIds.get(decision.approvedBy) ?? decision.approvedBy
+      : decision.approvedBy,
+  }));
+
+  const maps = { memberIds, taskIds, artifactIds };
+  const events = source.events.map((event) => ({
+    ...clone(event),
+    id: eventIds.get(event.id)!,
+    roomId: baseRoom.id,
+    from: memberIds.get(event.from) ?? event.from,
+    to: event.to?.map((target) => remapTarget(target, maps)),
+    taskId: event.taskId ? taskIds.get(event.taskId) ?? event.taskId : undefined,
+    artifactId: event.artifactId ? artifactIds.get(event.artifactId) ?? event.artifactId : undefined,
+    decisionId: event.decisionId ? decisionIds.get(event.decisionId) ?? event.decisionId : undefined,
+    parentEventId: event.parentEventId ? eventIds.get(event.parentEventId) ?? event.parentEventId : undefined,
+  }));
+
+  const inboxes = source.inboxes.map((inbox) => ({
+    ...clone(inbox),
+    id: inboxIds.get(inbox.id)!,
+    roomId: baseRoom.id,
+    agentId: memberIds.get(inbox.agentId) ?? inbox.agentId,
+    items: inbox.items.map((item): InboxItem => ({
+      ...clone(item),
+      id: inboxItemIds.get(item.id)!,
+      eventId: eventIds.get(item.eventId) ?? item.eventId,
+    })),
+  }));
+
+  const timeline = source.timeline.map((item): TimelineItem => ({
+    ...clone(item),
+    id: timelineIds.get(item.id)!,
+    roomId: baseRoom.id,
+    sourceEventIds: item.sourceEventIds.map((id) => eventIds.get(id) ?? id),
+    sourceArtifactIds: item.sourceArtifactIds.map((id) => artifactIds.get(id) ?? id),
+    sourceDecisionIds: item.sourceDecisionIds.map((id) => decisionIds.get(id) ?? id),
+  }));
+
+  const forked: Room = {
+    ...baseRoom,
+    forkedFromRoomId: source.id,
+    status: source.status,
+    phase: source.phase,
+    workflow: clone(source.workflow ?? defaultWorkflow()),
+    roomBusPolicy: clone(source.roomBusPolicy ?? defaultRoomBusPolicy(source.roleCards)),
+    roleCards: clone(source.roleCards),
+    members,
+    tasks,
+    artifacts,
+    decisions,
+    events,
+    inboxes,
+    timeline,
+  };
+
+  saveRoom(workspaceRootPath, forked);
+  return forked;
+}
+
+export function saveRoomAsTeamTemplate(
+  workspaceRootPath: string,
+  input: SaveRoomAsTeamTemplateInput
+): TeamTemplate {
+  const room = loadRoom(workspaceRootPath, input.roomId);
+  if (!room) {
+    throw new Error(`Room not found: ${input.roomId}`);
+  }
+
+  const templateInput: CreateTeamTemplateInput = {
+    projectId: room.projectId,
+    name: input.name,
+    description: input.description,
+    roles: clone(room.roleCards),
+    defaultWorkflow: clone(room.workflow ?? defaultWorkflow()),
+    roomBusPolicy: clone(room.roomBusPolicy ?? defaultRoomBusPolicy(room.roleCards)),
+  };
+
+  return createTeamTemplate(workspaceRootPath, templateInput);
+}
+
+export function updateRoomRolePrompt(
+  workspaceRootPath: string,
+  roomId: string,
+  roleCardId: string,
+  prompt: string
+): Room {
+  const room = loadRoom(workspaceRootPath, roomId);
+  if (!room) {
+    throw new Error(`Room not found: ${roomId}`);
+  }
+
+  const role = room.roleCards.find((item) => item.id === roleCardId);
+  if (!role) {
+    throw new Error(`Role card not found in room: ${roleCardId}`);
+  }
+
+  role.prompt = prompt;
+  saveRoom(workspaceRootPath, room);
+  return loadRoom(workspaceRootPath, roomId)!;
+}

--- a/packages/shared/src/native-agent-room/storage.ts
+++ b/packages/shared/src/native-agent-room/storage.ts
@@ -1,0 +1,335 @@
+import { existsSync, mkdirSync, readdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+import { atomicWriteFileSync, readJsonFileSync } from '../utils/files.ts';
+import type {
+  Artifact,
+  CreateProjectInput,
+  CreateRoomRecordInput,
+  CreateTeamTemplateInput,
+  Project,
+  Room,
+  RoomAvailableArtifacts,
+  TeamTemplate,
+} from './types.ts';
+
+const NATIVE_AGENT_ROOM_DIR = 'native-agent-room';
+const PROJECTS_DIR = 'projects';
+const TEAM_TEMPLATES_DIR = 'team-templates';
+const ROOMS_DIR = 'rooms';
+
+export function createNativeAgentRoomId(prefix: string): string {
+  return `${prefix}_${randomUUID().replace(/-/g, '').slice(0, 12)}`;
+}
+
+function assertSafeId(id: string): void {
+  if (!/^[A-Za-z0-9_-]+$/.test(id)) {
+    throw new Error(`Invalid Native Agent Room id: ${id}`);
+  }
+}
+
+function readJsonOrNull<T>(path: string): T | null {
+  if (!existsSync(path)) return null;
+  try {
+    return readJsonFileSync<T>(path);
+  } catch {
+    return null;
+  }
+}
+
+function writeJson(path: string, value: unknown): void {
+  atomicWriteFileSync(path, JSON.stringify(value, null, 2));
+}
+
+function listJsonFiles<T>(dir: string): T[] {
+  if (!existsSync(dir)) return [];
+
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => readJsonOrNull<T>(join(dir, entry.name)))
+    .filter((item): item is T => item !== null);
+}
+
+export function getNativeAgentRoomPath(workspaceRootPath: string): string {
+  return join(workspaceRootPath, NATIVE_AGENT_ROOM_DIR);
+}
+
+export function getNativeAgentRoomProjectsPath(workspaceRootPath: string): string {
+  return join(getNativeAgentRoomPath(workspaceRootPath), PROJECTS_DIR);
+}
+
+export function getNativeAgentRoomTeamTemplatesPath(workspaceRootPath: string): string {
+  return join(getNativeAgentRoomPath(workspaceRootPath), TEAM_TEMPLATES_DIR);
+}
+
+export function getNativeAgentRoomRoomsPath(workspaceRootPath: string): string {
+  return join(getNativeAgentRoomPath(workspaceRootPath), ROOMS_DIR);
+}
+
+export function ensureNativeAgentRoomDir(workspaceRootPath: string): string {
+  const root = getNativeAgentRoomPath(workspaceRootPath);
+  mkdirSync(getNativeAgentRoomProjectsPath(workspaceRootPath), { recursive: true });
+  mkdirSync(getNativeAgentRoomTeamTemplatesPath(workspaceRootPath), { recursive: true });
+  mkdirSync(getNativeAgentRoomRoomsPath(workspaceRootPath), { recursive: true });
+  return root;
+}
+
+export function getProjectPath(workspaceRootPath: string, projectId: string): string {
+  assertSafeId(projectId);
+  return join(getNativeAgentRoomProjectsPath(workspaceRootPath), `${projectId}.json`);
+}
+
+export function getTeamTemplatePath(workspaceRootPath: string, templateId: string): string {
+  assertSafeId(templateId);
+  return join(getNativeAgentRoomTeamTemplatesPath(workspaceRootPath), `${templateId}.json`);
+}
+
+export function getRoomPath(workspaceRootPath: string, roomId: string): string {
+  assertSafeId(roomId);
+  return join(getNativeAgentRoomRoomsPath(workspaceRootPath), `${roomId}.json`);
+}
+
+export function createProject(workspaceRootPath: string, input: CreateProjectInput): Project {
+  ensureNativeAgentRoomDir(workspaceRootPath);
+
+  const now = Date.now();
+  const projectId = createNativeAgentRoomId('project');
+  const artifacts = (input.artifacts ?? []).map((artifact) => ({
+    ...artifact,
+    projectId,
+    scope: 'project' as const,
+    updatedAt: artifact.updatedAt ?? now,
+    createdAt: artifact.createdAt ?? now,
+  }));
+
+  const project: Project = {
+    id: projectId,
+    name: input.name,
+    description: input.description,
+    artifacts,
+    teamTemplateIds: [],
+    roomIds: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  saveProject(workspaceRootPath, project);
+  return project;
+}
+
+export function saveProject(workspaceRootPath: string, project: Project): void {
+  ensureNativeAgentRoomDir(workspaceRootPath);
+  writeJson(getProjectPath(workspaceRootPath, project.id), {
+    ...project,
+    updatedAt: Date.now(),
+  });
+}
+
+export function loadProject(workspaceRootPath: string, projectId: string): Project | null {
+  return readJsonOrNull<Project>(getProjectPath(workspaceRootPath, projectId));
+}
+
+export function listProjects(workspaceRootPath: string): Project[] {
+  return listJsonFiles<Project>(getNativeAgentRoomProjectsPath(workspaceRootPath))
+    .sort((a, b) => a.createdAt - b.createdAt);
+}
+
+export function deleteProject(workspaceRootPath: string, projectId: string): void {
+  const project = loadProject(workspaceRootPath, projectId);
+  if (!project) return;
+
+  for (const roomId of project.roomIds) {
+    deleteRoom(workspaceRootPath, roomId);
+  }
+
+  for (const templateId of project.teamTemplateIds) {
+    deleteTeamTemplate(workspaceRootPath, templateId);
+  }
+
+  rmSync(getProjectPath(workspaceRootPath, projectId), { force: true });
+}
+
+export function addProjectArtifact(workspaceRootPath: string, projectId: string, artifact: Artifact): Project {
+  const project = loadProject(workspaceRootPath, projectId);
+  if (!project) {
+    throw new Error(`Project not found: ${projectId}`);
+  }
+
+  const now = Date.now();
+  const nextArtifact: Artifact = {
+    ...artifact,
+    projectId,
+    scope: 'project',
+    createdAt: artifact.createdAt ?? now,
+    updatedAt: artifact.updatedAt ?? now,
+  };
+
+  project.artifacts = [
+    ...project.artifacts.filter((item) => item.id !== nextArtifact.id),
+    nextArtifact,
+  ];
+  saveProject(workspaceRootPath, project);
+  return loadProject(workspaceRootPath, projectId)!;
+}
+
+export function createTeamTemplate(workspaceRootPath: string, input: CreateTeamTemplateInput): TeamTemplate {
+  ensureNativeAgentRoomDir(workspaceRootPath);
+
+  if (input.projectId && !loadProject(workspaceRootPath, input.projectId)) {
+    throw new Error(`Project not found: ${input.projectId}`);
+  }
+
+  const now = Date.now();
+  const template: TeamTemplate = {
+    id: createNativeAgentRoomId('template'),
+    projectId: input.projectId,
+    name: input.name,
+    description: input.description,
+    roles: input.roles,
+    defaultWorkflow: input.defaultWorkflow,
+    roomBusPolicy: input.roomBusPolicy,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  saveTeamTemplate(workspaceRootPath, template);
+
+  if (template.projectId) {
+    const project = loadProject(workspaceRootPath, template.projectId)!;
+    if (!project.teamTemplateIds.includes(template.id)) {
+      project.teamTemplateIds.push(template.id);
+      saveProject(workspaceRootPath, project);
+    }
+  }
+
+  return template;
+}
+
+export function saveTeamTemplate(workspaceRootPath: string, template: TeamTemplate): void {
+  ensureNativeAgentRoomDir(workspaceRootPath);
+  writeJson(getTeamTemplatePath(workspaceRootPath, template.id), {
+    ...template,
+    updatedAt: Date.now(),
+  });
+}
+
+export function loadTeamTemplate(workspaceRootPath: string, templateId: string): TeamTemplate | null {
+  return readJsonOrNull<TeamTemplate>(getTeamTemplatePath(workspaceRootPath, templateId));
+}
+
+export function listTeamTemplates(workspaceRootPath: string, projectId?: string): TeamTemplate[] {
+  return listJsonFiles<TeamTemplate>(getNativeAgentRoomTeamTemplatesPath(workspaceRootPath))
+    .filter((template) => !projectId || template.projectId === projectId)
+    .sort((a, b) => a.createdAt - b.createdAt);
+}
+
+export function deleteTeamTemplate(workspaceRootPath: string, templateId: string): void {
+  const template = loadTeamTemplate(workspaceRootPath, templateId);
+  if (template?.projectId) {
+    const project = loadProject(workspaceRootPath, template.projectId);
+    if (project) {
+      project.teamTemplateIds = project.teamTemplateIds.filter((id) => id !== templateId);
+      saveProject(workspaceRootPath, project);
+    }
+  }
+
+  rmSync(getTeamTemplatePath(workspaceRootPath, templateId), { force: true });
+}
+
+export function createRoomRecord(workspaceRootPath: string, input: CreateRoomRecordInput): Room {
+  ensureNativeAgentRoomDir(workspaceRootPath);
+
+  const project = loadProject(workspaceRootPath, input.projectId);
+  if (!project) {
+    throw new Error(`Project not found: ${input.projectId}`);
+  }
+
+  if (input.templateId && !loadTeamTemplate(workspaceRootPath, input.templateId)) {
+    throw new Error(`Team template not found: ${input.templateId}`);
+  }
+
+  const now = Date.now();
+  const room: Room = {
+    id: createNativeAgentRoomId('room'),
+    projectId: input.projectId,
+    templateId: input.templateId,
+    name: input.name,
+    goal: input.goal,
+    status: input.status ?? 'draft',
+    phase: input.phase ?? 'clarify',
+    workflow: input.workflow,
+    roomBusPolicy: input.roomBusPolicy,
+    roleCards: input.roleCards ?? [],
+    members: input.members ?? [],
+    tasks: input.tasks ?? [],
+    artifacts: input.artifacts ?? [],
+    decisions: input.decisions ?? [],
+    events: input.events ?? [],
+    inboxes: input.inboxes ?? [],
+    timeline: input.timeline ?? [],
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  saveRoom(workspaceRootPath, room);
+
+  if (!project.roomIds.includes(room.id)) {
+    project.roomIds.push(room.id);
+    saveProject(workspaceRootPath, project);
+  }
+
+  return room;
+}
+
+export function saveRoom(workspaceRootPath: string, room: Room): void {
+  ensureNativeAgentRoomDir(workspaceRootPath);
+  writeJson(getRoomPath(workspaceRootPath, room.id), {
+    ...room,
+    updatedAt: Date.now(),
+  });
+}
+
+export function loadRoom(workspaceRootPath: string, roomId: string): Room | null {
+  return readJsonOrNull<Room>(getRoomPath(workspaceRootPath, roomId));
+}
+
+export function listRooms(workspaceRootPath: string, projectId?: string): Room[] {
+  return listJsonFiles<Room>(getNativeAgentRoomRoomsPath(workspaceRootPath))
+    .filter((room) => !projectId || room.projectId === projectId)
+    .sort((a, b) => a.createdAt - b.createdAt);
+}
+
+export function deleteRoom(workspaceRootPath: string, roomId: string): void {
+  const room = loadRoom(workspaceRootPath, roomId);
+  if (room) {
+    const project = loadProject(workspaceRootPath, room.projectId);
+    if (project) {
+      project.roomIds = project.roomIds.filter((id) => id !== roomId);
+      saveProject(workspaceRootPath, project);
+    }
+  }
+
+  rmSync(getRoomPath(workspaceRootPath, roomId), { force: true });
+}
+
+export function listRoomAvailableArtifacts(workspaceRootPath: string, roomId: string): RoomAvailableArtifacts {
+  const room = loadRoom(workspaceRootPath, roomId);
+  if (!room) {
+    throw new Error(`Room not found: ${roomId}`);
+  }
+
+  const project = loadProject(workspaceRootPath, room.projectId);
+  const projectArtifacts = project?.artifacts.filter((artifact) => artifact.status !== 'deprecated') ?? [];
+  const roomArtifacts = room.artifacts.filter((artifact) =>
+    artifact.scope === 'room' && artifact.status !== 'deprecated'
+  );
+  const taskArtifacts = room.artifacts.filter((artifact) =>
+    artifact.scope === 'task' && artifact.status !== 'deprecated'
+  );
+
+  return {
+    projectArtifacts,
+    roomArtifacts,
+    taskArtifacts,
+  };
+}

--- a/packages/shared/src/native-agent-room/types.ts
+++ b/packages/shared/src/native-agent-room/types.ts
@@ -1,0 +1,405 @@
+export type TimestampMs = number;
+export type AgentId = string;
+
+export type RoomStatus = 'draft' | 'active' | 'paused' | 'completed' | 'archived';
+
+export type RoomPhase =
+  | 'clarify'
+  | 'plan'
+  | 'foundation'
+  | 'design'
+  | 'implementation'
+  | 'review'
+  | 'fix'
+  | 'deliver';
+
+export type TaskStatus =
+  | 'todo'
+  | 'in_progress'
+  | 'blocked'
+  | 'waiting_review'
+  | 'changes_requested'
+  | 'done';
+
+export type ArtifactType =
+  | 'requirements'
+  | 'design_tokens'
+  | 'design_guide'
+  | 'component_guidelines'
+  | 'ui_spec'
+  | 'api_contract'
+  | 'mock_data'
+  | 'implementation'
+  | 'test_plan'
+  | 'qa_report'
+  | 'seo_geo'
+  | 'review_report'
+  | 'shared_rules'
+  | 'other';
+
+export type ArtifactScope = 'project' | 'room' | 'task';
+export type ArtifactStatus = 'draft' | 'approved' | 'deprecated';
+export type DecisionScope = 'project' | 'room' | 'task';
+export type DecisionStatus = 'proposed' | 'approved' | 'rejected' | 'superseded';
+
+export type RoomBusActionType =
+  | 'message'
+  | 'ask_agent'
+  | 'answer_agent'
+  | 'raise_blocker'
+  | 'resolve_blocker'
+  | 'handoff_task'
+  | 'request_review'
+  | 'review_result'
+  | 'propose_change'
+  | 'artifact_update'
+  | 'decision'
+  | 'approval_request'
+  | 'announcement';
+
+export type InboxItemType =
+  | 'mention'
+  | 'request'
+  | 'review_request'
+  | 'blocker'
+  | 'handoff'
+  | 'artifact_update'
+  | 'task_update'
+  | 'decision_update'
+  | 'announcement';
+
+export type InboxItemStatus = 'unread' | 'read' | 'handled' | 'dismissed';
+export type InboxItemPriority = 'low' | 'normal' | 'high' | 'blocking';
+
+export type ContextSourceType =
+  | 'role_contract'
+  | 'member_directory'
+  | 'current_task'
+  | 'required_artifacts'
+  | 'direct_mentions'
+  | 'assigned_room_bus_events'
+  | 'owned_task_updates'
+  | 'owned_artifact_updates'
+  | 'dependency_updates'
+  | 'relevant_decisions'
+  | 'room_timeline';
+
+export type ContextExcludeRule =
+  | 'full_transcript'
+  | 'other_agents_private_memory'
+  | 'unrelated_messages'
+  | 'unrelated_rooms'
+  | 'deprecated_artifacts'
+  | 'rejected_decisions'
+  | 'unrelated_resolved_events';
+
+export type SubscriptionRule =
+  | { type: 'artifact_type'; artifactType: ArtifactType }
+  | { type: 'artifact'; artifactId: string }
+  | { type: 'task'; taskId: string }
+  | { type: 'decision_scope'; scope: DecisionScope };
+
+export interface ArtifactRef {
+  id: string;
+  name: string;
+  type: ArtifactType;
+  scope: ArtifactScope;
+  version: number;
+  status: ArtifactStatus;
+}
+
+export interface TeamTemplateRef {
+  id: string;
+  name: string;
+}
+
+export interface RoomRef {
+  id: string;
+  name: string;
+  status: RoomStatus;
+  phase: RoomPhase;
+}
+
+export interface Project {
+  id: string;
+  name: string;
+  description?: string;
+  artifacts: Artifact[];
+  teamTemplateIds: string[];
+  roomIds: string[];
+  createdAt: TimestampMs;
+  updatedAt: TimestampMs;
+}
+
+export interface WorkflowTemplateStep {
+  id: string;
+  phase: RoomPhase;
+  title: string;
+  roleKeys: string[];
+}
+
+export interface WorkflowTemplate {
+  phases: RoomPhase[];
+  steps: WorkflowTemplateStep[];
+}
+
+export interface RoomBusPolicy {
+  allowedActions: RoomBusActionType[];
+  maxRequestsPerAgentTurn: number;
+  defaultTtlMs: number;
+  maxHops: number;
+}
+
+export interface TeamTemplate {
+  id: string;
+  projectId?: string;
+  name: string;
+  description?: string;
+  roles: RoleCard[];
+  defaultWorkflow: WorkflowTemplate;
+  roomBusPolicy: RoomBusPolicy;
+  createdAt: TimestampMs;
+  updatedAt: TimestampMs;
+}
+
+export interface ContextPolicy {
+  alwaysInclude: ContextSourceType[];
+  requiredArtifactTypes: ArtifactType[];
+  optionalArtifactTypes: ArtifactType[];
+  includeEvents: RoomBusActionType[];
+  exclude: ContextExcludeRule[];
+  subscriptions: SubscriptionRule[];
+}
+
+export interface RoleCard {
+  id: string;
+  name: string;
+  roleKey: string;
+  mission: string;
+  prompt: string;
+  responsibilities: string[];
+  inputs: string[];
+  outputs: string[];
+  allowedActions: RoomBusActionType[];
+  forbiddenActions: string[];
+  doneCriteria: string[];
+  contextPolicy: ContextPolicy;
+}
+
+export interface RoomMember {
+  id: string;
+  roomId: string;
+  roleCardId: string;
+  name: string;
+  roleKey: string;
+  sessionId: string;
+  inboxId: string;
+  status: 'idle' | 'working' | 'blocked' | 'waiting_review' | 'done';
+  ownedTaskIds: string[];
+  ownedArtifactIds: string[];
+}
+
+export interface InboxItem {
+  id: string;
+  eventId: string;
+  type: InboxItemType;
+  status: InboxItemStatus;
+  priority: InboxItemPriority;
+  createdAt: TimestampMs;
+}
+
+export interface AgentInbox {
+  id: string;
+  roomId: string;
+  agentId: string;
+  items: InboxItem[];
+}
+
+export interface Task {
+  id: string;
+  roomId: string;
+  title: string;
+  description: string;
+  ownerAgentId: string;
+  phase: RoomPhase;
+  status: TaskStatus;
+  inputArtifactIds: string[];
+  outputArtifactIds: string[];
+  dependencyTaskIds: string[];
+  doneCriteria: string[];
+  createdAt: TimestampMs;
+  updatedAt: TimestampMs;
+}
+
+export interface ArtifactSection {
+  id: string;
+  title: string;
+  contentRef: string;
+}
+
+export interface Artifact {
+  id: string;
+  projectId?: string;
+  roomId?: string;
+  taskId?: string;
+  name: string;
+  type: ArtifactType;
+  scope: ArtifactScope;
+  ownerAgentId?: string;
+  version: number;
+  status: ArtifactStatus;
+  tags: string[];
+  sections?: ArtifactSection[];
+  contentRef: string;
+  createdAt: TimestampMs;
+  updatedAt: TimestampMs;
+}
+
+export type TargetRef =
+  | { type: 'agent'; id: string }
+  | { type: 'role'; roleKey: string }
+  | { type: 'all' }
+  | { type: 'task'; id: string }
+  | { type: 'artifact'; id: string };
+
+export interface RoomBusEvent {
+  id: string;
+  projectId: string;
+  roomId: string;
+  from: AgentId | 'user' | 'system';
+  to?: TargetRef[];
+  type: RoomBusActionType;
+  taskId?: string;
+  artifactId?: string;
+  decisionId?: string;
+  payload: Record<string, unknown>;
+  status: 'open' | 'resolved' | 'rejected' | 'expired';
+  createdAt: TimestampMs;
+  resolvedAt?: TimestampMs;
+  parentEventId?: string;
+  expiresAt?: TimestampMs;
+  hopCount?: number;
+  maxHops?: number;
+}
+
+export interface Decision {
+  id: string;
+  projectId: string;
+  roomId?: string;
+  title: string;
+  description: string;
+  scope: DecisionScope;
+  status: DecisionStatus;
+  relatedTaskIds: string[];
+  relatedArtifactIds: string[];
+  createdBy: AgentId | 'user' | 'system';
+  approvedBy?: 'user' | AgentId;
+  createdAt: TimestampMs;
+  updatedAt: TimestampMs;
+}
+
+export interface TimelineItem {
+  id: string;
+  roomId: string;
+  title: string;
+  description: string;
+  phase: RoomPhase;
+  sourceEventIds: string[];
+  sourceArtifactIds: string[];
+  sourceDecisionIds: string[];
+  createdAt: TimestampMs;
+}
+
+export interface Room {
+  id: string;
+  projectId: string;
+  templateId?: string;
+  forkedFromRoomId?: string;
+  name: string;
+  goal: string;
+  status: RoomStatus;
+  phase: RoomPhase;
+  workflow?: WorkflowTemplate;
+  roomBusPolicy?: RoomBusPolicy;
+  roleCards: RoleCard[];
+  members: RoomMember[];
+  tasks: Task[];
+  artifacts: Artifact[];
+  decisions: Decision[];
+  events: RoomBusEvent[];
+  inboxes: AgentInbox[];
+  timeline: TimelineItem[];
+  createdAt: TimestampMs;
+  updatedAt: TimestampMs;
+}
+
+export interface RoomMemberSummary {
+  id: string;
+  name: string;
+  roleKey: string;
+  status: RoomMember['status'];
+  responsibilities: string[];
+  allowedActions: RoomBusActionType[];
+}
+
+export interface ContextUsedItem {
+  type: 'role' | 'member_directory' | 'task' | 'artifact' | 'event' | 'decision' | 'timeline' | 'inbox';
+  id: string;
+  label: string;
+}
+
+export interface ContextPack {
+  agentId: string;
+  roomId: string;
+  taskId?: string;
+  triggerEventId?: string;
+  roleContext: RoleCard;
+  memberDirectory: RoomMemberSummary[];
+  currentTask?: Task;
+  requiredArtifacts: Artifact[];
+  relevantDecisions: Decision[];
+  attentionEvents: RoomBusEvent[];
+  inboxItems: InboxItem[];
+  timeline: TimelineItem[];
+  contextUsed: ContextUsedItem[];
+}
+
+export interface CreateProjectInput {
+  name: string;
+  description?: string;
+  artifacts?: Artifact[];
+}
+
+export interface CreateTeamTemplateInput {
+  projectId?: string;
+  name: string;
+  description?: string;
+  roles: RoleCard[];
+  defaultWorkflow: WorkflowTemplate;
+  roomBusPolicy: RoomBusPolicy;
+}
+
+export interface CreateRoomRecordInput {
+  projectId: string;
+  templateId?: string;
+  name: string;
+  goal: string;
+  status?: RoomStatus;
+  phase?: RoomPhase;
+  workflow?: WorkflowTemplate;
+  roomBusPolicy?: RoomBusPolicy;
+  roleCards?: RoleCard[];
+  members?: RoomMember[];
+  tasks?: Task[];
+  artifacts?: Artifact[];
+  decisions?: Decision[];
+  events?: RoomBusEvent[];
+  inboxes?: AgentInbox[];
+  timeline?: TimelineItem[];
+}
+
+export interface RoomAvailableArtifacts {
+  projectArtifacts: Artifact[];
+  roomArtifacts: Artifact[];
+  taskArtifacts: Artifact[];
+}


### PR DESCRIPTION
## Summary

Adds the Native Agent Room shared business layer for the first four blueprint milestones:

- P0: Project, Room, TeamTemplate, RoleCard, Task, Artifact, Decision, RoomBusEvent, AgentInbox, Timeline, and ContextPack types with workspace-scoped JSON persistence.
- P1: Room creation from templates, duplicate room config, fork room, save room as team template, and room role prompt updates.
- P2: RoomBus event publishing, mechanical validation, target resolution, simple loop protection, and Agent Inbox routing.
- P3: Attention routing for explicit @ mentions and implicit task/artifact/decision relevance, plus ContextPack generation and Context Used tracking.

The implementation is intentionally scoped to `packages/shared/src/native-agent-room` and does not add polished UI, complex DAG scheduling, automatic parallel execution, or P4+ artifact/timeline hardening.

## Validation

- `bun test packages/shared/src/native-agent-room/__tests__/storage.test.ts packages/shared/src/native-agent-room/__tests__/room-operations.test.ts packages/shared/src/native-agent-room/__tests__/room-bus.test.ts packages/shared/src/native-agent-room/__tests__/attention.test.ts`
- `bun run typecheck:shared`

Both passed locally.
