### PR TITLE
fix: recognize percent-encoded octets in bare file-path links

### DIFF
--- a/packages/ui/src/components/markdown/__tests__/linkify.test.ts
+++ b/packages/ui/src/components/markdown/__tests__/linkify.test.ts
@@ -273,4 +273,16 @@ describe('isFilePathTarget', () => {
   it('rejects non-file strings', () => {
     expect(isFilePathTarget('not a link at all')).toBe(false)
   })
+
+  it('accepts absolute paths with a percent-encoded space (#944)', () => {
+    expect(isFilePathTarget('/Users/chris/My%20Documents/report.md')).toBe(true)
+  })
+
+  it('accepts paths with multiple percent-encoded octets', () => {
+    expect(isFilePathTarget('/Users/chris/Q3%20Report%20%28Draft%29.pdf')).toBe(true)
+  })
+
+  it('rejects a bare unescaped percent sign', () => {
+    expect(isFilePathTarget('/Users/chris/50%off.md')).toBe(false)
+  })
 })

--- a/packages/ui/src/components/markdown/__tests__/markdown-link-routing.test.ts
+++ b/packages/ui/src/components/markdown/__tests__/markdown-link-routing.test.ts
@@ -41,6 +41,13 @@ describe('resolveMarkdownLinkTarget', () => {
     })
   })
 
+  it('decodes percent-encoded bare file paths (#944)', () => {
+    expect(resolveMarkdownLinkTarget('/Users/tester/report%20final.pdf')).toEqual({
+      kind: 'file',
+      path: '/Users/tester/report final.pdf',
+    })
+  })
+
   it('normalizes windows drive-letter file URLs to local paths', () => {
     expect(resolveMarkdownLinkTarget('file:///C:/Users/Tester/Deck.pptx')).toEqual({
       kind: 'file',
@@ -120,6 +127,10 @@ describe('classifyMarkdownLinkTarget', () => {
 
   it('classifies file URLs as file', () => {
     expect(classifyMarkdownLinkTarget('file:///Users/tester/report.xlsx')).toBe('file')
+  })
+
+  it('classifies bare file paths with percent-encoded spaces as file', () => {
+    expect(classifyMarkdownLinkTarget('/Users/tester/My%20Documents/report.xlsx')).toBe('file')
   })
 
   it('classifies https links as url', () => {

--- a/packages/ui/src/components/markdown/link-target.ts
+++ b/packages/ui/src/components/markdown/link-target.ts
@@ -45,7 +45,14 @@ export function resolveMarkdownLinkTarget(target: string): ResolvedMarkdownLinkT
   }
 
   if (isFilePathTarget(trimmed)) {
-    return { kind: 'file', path: trimmed }
+    // Bare paths may carry percent-encoded octets (e.g. %20 for a space) since
+    // that's the only CommonMark-valid way to fit one in an unbracketed link
+    // destination — decode before handing off, mirroring resolveFileUrlPath above.
+    try {
+      return { kind: 'file', path: decodeURIComponent(trimmed) }
+    } catch {
+      return { kind: 'file', path: trimmed }
+    }
   }
 
   return { kind: 'url', url: trimmed }

--- a/packages/ui/src/components/markdown/linkify.ts
+++ b/packages/ui/src/components/markdown/linkify.ts
@@ -11,17 +11,23 @@ import { FILE_EXTENSIONS_PATTERN } from '../../lib/file-classification'
 // Initialize linkify-it with default settings (fuzzy URLs, emails enabled)
 const linkify = new LinkifyIt()
 
+// A single path-segment unit: a normal file-path character, or a percent-encoded
+// octet (%XX). The %XX form is the only CommonMark-valid way to carry a literal
+// space (or other reserved character) inside a bare, non-angle-bracketed link
+// destination, so real-world paths with spaces rely on it (see #944).
+const PATH_CHAR = `(?:[\\w\\-./@]|%[0-9A-Fa-f]{2})`
+
 // File path regex - detects absolute/home/explicit-relative/bare-relative paths with common extensions
 // Examples: /Users/foo.ts, ~/src/app.tsx, ./README.md, ../guide.md, apps/electron/src/main.ts
 // Extensions derived from file-classification.ts to stay in sync with preview support
-const FILE_PATH_REGEX_SOURCE = `(?:^|[\\s([\\{<])((?:/|~/|\\./|\\.\\./|[A-Za-z0-9_][\\w\\-./@]*)[\\w\\-./@]*\\.(?:${FILE_EXTENSIONS_PATTERN}))(?=[\\s)\\]}\\.,:;!?>]|$)`
+const FILE_PATH_REGEX_SOURCE = `(?:^|[\\s([\\{<])((?:/|~/|\\./|\\.\\./|[A-Za-z0-9_]${PATH_CHAR}*)${PATH_CHAR}*\\.(?:${FILE_EXTENSIONS_PATTERN}))(?=[\\s)\\]}\\.,:;!?>]|$)`
 const FILE_PATH_REGEX = new RegExp(FILE_PATH_REGEX_SOURCE, 'gi')
 const FILE_PATH_PRETEST_REGEX = new RegExp(FILE_PATH_REGEX_SOURCE, 'i')
 
 // File-path regex for markdown anchor targets (entire href/text value)
 // Used by Markdown.tsx click handler to route file links to onFileClick.
 const FILE_PATH_TARGET_REGEX = new RegExp(
-  `^(?!https?://|mailto:|ftp://|data:)(?:/|~/|\./|\.\./|[A-Za-z0-9_][\\w\\-./@]*)[\\w\\-./@]*\\.(?:${FILE_EXTENSIONS_PATTERN})$`,
+  `^(?!https?://|mailto:|ftp://|data:)(?:/|~/|\./|\.\./|[A-Za-z0-9_]${PATH_CHAR}*)${PATH_CHAR}*\\.(?:${FILE_EXTENSIONS_PATTERN})$`,
   'i'
 )
 


### PR DESCRIPTION
## Summary

Fixes #944. Bare (non-`file://`) markdown links to local files fail whenever the path contains a space, because percent-encoding (`%20`) is the only CommonMark-valid way to represent a space in an unbracketed link destination, and `FILE_PATH_TARGET_REGEX`'s character class didn't include `%`. The link falls through to being classified as a generic URL, where `new URL()` throws on a schemeless absolute path — producing `Failed to open URL: URL blocked. URL is malformed and cannot be parsed.` instead of opening the file.

- Adds a shared `PATH_CHAR` fragment in `linkify.ts` that accepts either a normal path character or a percent-encoded octet (`%XX`), used in both `FILE_PATH_TARGET_REGEX` and the sibling `FILE_PATH_REGEX` (the auto-linkify pass for bare paths in plain text — same gap existed there).
- Decodes the matched path in `resolveMarkdownLinkTarget` (`link-target.ts`) before handing it to the file-open handler, mirroring the decode step `resolveFileUrlPath` already performs for `file://` targets.
- `%` alone (not followed by two hex digits) is still rejected — the fix matches valid percent-encoding grammar rather than loosening the character class to accept any `%`.

Explicit `file:///...` links are unaffected by this bug (already correct before this change) and continue to work the same way.

## Test plan

- [x] Added regression tests: percent-encoded space, multiple octets in one path, decode-and-classify round trip via `resolveMarkdownLinkTarget`/`classifyMarkdownLinkTarget`, and a negative case confirming a bare unescaped `%` is still rejected.
- [x] `bun test src/components/markdown/__tests__/` in `packages/ui` — 158 pass, 0 fail (full markdown suite, no regressions).
- [x] `bun run tsc --noEmit` in `packages/ui` — clean.