### PR TITLE
Strip CLAUDECODE from the Claude Code subprocess env

### DIFF
--- a/packages/shared/src/agent/options.ts
+++ b/packages/shared/src/agent/options.ts
@@ -193,6 +193,12 @@ export function buildClaudeSubprocessEnv(
         CRAFT_DEBUG: (process.argv.includes('--debug') || process.env.CRAFT_DEBUG === '1') ? '1' : '0',
     };
 
+    // Strip CLAUDECODE from the subprocess env to prevent nested-session detection.
+    // The Claude Code CLI refuses to start when CLAUDECODE is set, interpreting it as
+    // an attempt to nest sessions. When the host process itself runs inside a Claude
+    // Code session this variable is inherited, so we remove it for standalone use.
+    delete env.CLAUDECODE;
+
     // Bedrock must never be routed through the Claude SDK path.
     // Strip only Claude-specific Bedrock routing vars here; keep generic AWS_*
     // untouched so user shell/tooling behavior inside the subprocess remains intact.

--- a/packages/shared/tests/claude-subprocess-env.test.ts
+++ b/packages/shared/tests/claude-subprocess-env.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for buildClaudeSubprocessEnv in agent/options.ts
+ *
+ * Guards the environment contract for the spawned Claude Code CLI:
+ * - CLAUDECODE is stripped so the CLI does not refuse to start when the host
+ *   process is itself running inside a Claude Code session.
+ * - Claude-specific Bedrock routing vars are stripped so Bedrock is never
+ *   routed through the Claude SDK path.
+ */
+import { describe, it, expect, afterEach } from 'bun:test';
+import { buildClaudeSubprocessEnv } from '../src/agent/options.ts';
+
+const TOUCHED_VARS = [
+  'CLAUDECODE',
+  'CLAUDE_CODE_USE_BEDROCK',
+  'AWS_BEARER_TOKEN_BEDROCK',
+  'ANTHROPIC_BEDROCK_BASE_URL',
+] as const;
+
+const saved: Record<string, string | undefined> = {};
+for (const key of TOUCHED_VARS) saved[key] = process.env[key];
+
+afterEach(() => {
+  for (const key of TOUCHED_VARS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+describe('buildClaudeSubprocessEnv', () => {
+  it('strips CLAUDECODE from the subprocess env', () => {
+    process.env.CLAUDECODE = '1';
+    const env = buildClaudeSubprocessEnv();
+    expect(env.CLAUDECODE).toBeUndefined();
+  });
+
+  it('strips Claude-specific Bedrock routing vars', () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+    process.env.AWS_BEARER_TOKEN_BEDROCK = 'token';
+    process.env.ANTHROPIC_BEDROCK_BASE_URL = 'https://bedrock.example';
+    const env = buildClaudeSubprocessEnv();
+    expect(env.CLAUDE_CODE_USE_BEDROCK).toBeUndefined();
+    expect(env.AWS_BEARER_TOKEN_BEDROCK).toBeUndefined();
+    expect(env.ANTHROPIC_BEDROCK_BASE_URL).toBeUndefined();
+  });
+
+  it('preserves unrelated environment variables', () => {
+    const env = buildClaudeSubprocessEnv({ ANTHROPIC_BASE_URL: 'https://example.test' });
+    expect(env.ANTHROPIC_BASE_URL).toBe('https://example.test');
+  });
+});


### PR DESCRIPTION
## Problem

The Claude Code CLI refuses to start when the `CLAUDECODE` environment variable is set, treating it as an attempt to nest a session inside another Claude Code session. When the host process that calls `buildClaudeSubprocessEnv()` is *itself* launched from inside a Claude Code session, it inherits `CLAUDECODE` from its own environment. That value is then spread into the spawned CLI's env, so the subprocess sees `CLAUDECODE` set, interprets it as a nested-session attempt, and never comes up — the SDK transport gets no valid handshake.

This affects anyone running the app from inside a Claude Code session (a common development and automation setup).

## Fix

Delete `CLAUDECODE` from the subprocess environment in `buildClaudeSubprocessEnv()`, right after the base environment is assembled and before it is handed to the SDK. The host's own session context no longer leaks into spawned CLIs; standalone spawns are unaffected.

The change is one line plus an explanatory comment, adjacent to the existing Bedrock-routing strips in the same function.

## Test plan

Adds `packages/shared/tests/claude-subprocess-env.test.ts`:

- `strips CLAUDECODE from the subprocess env` — sets `process.env.CLAUDECODE` and asserts the built env omits it.
- `strips Claude-specific Bedrock routing vars` — regression guard for the existing Bedrock strips (previously untested).
- `preserves unrelated environment variables` — confirms the strip is surgical and `envOverrides` pass through.

Validation:
- `bun test tests/claude-subprocess-env.test.ts` in `packages/shared` → 3 pass, 0 fail.
- `tsc --noEmit` on `packages/shared` → 0 errors.
