### PR TITLE
Pin spawned Claude Code CLI to compiled-in feature-gate defaults

### DIFF
--- a/packages/shared/src/agent/options.ts
+++ b/packages/shared/src/agent/options.ts
@@ -200,6 +200,23 @@ export function buildClaudeSubprocessEnv(
     delete env.AWS_BEARER_TOKEN_BEDROCK;
     delete env.ANTHROPIC_BEDROCK_BASE_URL;
 
+    // Pin the spawned CLI to its compiled-in feature-gate defaults so remote
+    // config cannot silently change subprocess behavior between runs. In
+    // particular, whether a Task subagent launches synchronously (blocking) or
+    // asynchronously (fire-and-forget) is gated by a remote GrowthBook flag
+    // (`tengu_amber_heron`, compiled default off). When that gate flips on,
+    // subagents launch async by default even without `run_in_background: true`;
+    // such launches die with the SDK subprocess and are invisible to callers
+    // that track only explicitly-backgrounded tasks. Setting DISABLE_GROWTHBOOK
+    // makes the CLI resolve every gate to its compiled default, so behavior is
+    // reproducible and cannot change mid-flight via remote config. Explicit
+    // `run_in_background: true` still works, unlike the blunter
+    // CLAUDE_CODE_DISABLE_BACKGROUND_TASKS which removes the parameter entirely.
+    // An existing value (from the environment or envOverrides) is respected.
+    if (env.DISABLE_GROWTHBOOK === undefined) {
+        env.DISABLE_GROWTHBOOK = '1';
+    }
+
     return env;
 }
 

--- a/packages/shared/tests/claude-subprocess-feature-gates.test.ts
+++ b/packages/shared/tests/claude-subprocess-feature-gates.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Tests for the feature-gate pin in buildClaudeSubprocessEnv (agent/options.ts)
+ *
+ * The spawned Claude Code CLI is pinned to its compiled-in feature-gate
+ * defaults via DISABLE_GROWTHBOOK so remote config cannot silently change
+ * subprocess behavior (e.g. blocking vs async Task subagent launches) between
+ * or during runs. An explicit value already present in the environment or
+ * passed via envOverrides is respected.
+ */
+import { describe, it, expect, afterEach } from 'bun:test';
+import { buildClaudeSubprocessEnv } from '../src/agent/options.ts';
+
+const saved = process.env.DISABLE_GROWTHBOOK;
+
+afterEach(() => {
+  if (saved === undefined) delete process.env.DISABLE_GROWTHBOOK;
+  else process.env.DISABLE_GROWTHBOOK = saved;
+});
+
+describe('buildClaudeSubprocessEnv feature-gate pin', () => {
+  it('pins DISABLE_GROWTHBOOK=1 so feature gates resolve to compiled defaults', () => {
+    delete process.env.DISABLE_GROWTHBOOK;
+    const env = buildClaudeSubprocessEnv();
+    expect(env.DISABLE_GROWTHBOOK).toBe('1');
+  });
+
+  it('respects a DISABLE_GROWTHBOOK value already present in the environment', () => {
+    process.env.DISABLE_GROWTHBOOK = 'preset';
+    const env = buildClaudeSubprocessEnv();
+    expect(env.DISABLE_GROWTHBOOK).toBe('preset');
+  });
+
+  it('respects a DISABLE_GROWTHBOOK value passed via envOverrides', () => {
+    delete process.env.DISABLE_GROWTHBOOK;
+    const env = buildClaudeSubprocessEnv({ DISABLE_GROWTHBOOK: 'override' });
+    expect(env.DISABLE_GROWTHBOOK).toBe('override');
+  });
+});


### PR DESCRIPTION
## Problem

The spawned Claude Code CLI resolves feature gates through a remote GrowthBook config. One of those gates (`tengu_amber_heron`, compiled default **off**) controls whether a Task subagent launches **synchronously** (blocking until the child finishes) or **asynchronously** (fire-and-forget).

The launch decision reduces to:

```
isAsync = isRemote
  || run_in_background === true
  || agentDef.background === true
  || teamsMode || tasksMode
  || (!isTeammate && run_in_background !== false && featureGate("tengu_amber_heron", false))
```

When that remote gate flips on, subagents launch async **by default** even when `run_in_background` was never set. Async launches live inside the SDK subprocess and are torn down when it is disposed/recreated, and callers that only track *explicitly* backgrounded tasks never see them. The net effect: spawned-CLI behavior can change mid-flight — between two runs of the same code, same CLI version — purely because a remote flag was toggled. That is a reproducibility hazard for any host that relies on blocking subagent semantics.

## Fix

Set `DISABLE_GROWTHBOOK` in `buildClaudeSubprocessEnv()` so the spawned CLI resolves **every** feature gate to its compiled-in default. Behavior becomes deterministic and independent of remote config; the async-launch gate stays at its compiled default (off) and cannot silently flip.

Notes:
- Explicit `run_in_background: true` still works — this only pins the *default*. It is deliberately narrower than `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS`, which removes the `run_in_background` parameter from the tool schemas entirely.
- An existing `DISABLE_GROWTHBOOK` value (from the environment or `envOverrides`) is respected, so operators can opt back into remote gates.
- More broadly, this removes remote-config influence over spawned-CLI behavior — the subprocess behaves the same offline as online.

## Test plan

Adds `packages/shared/tests/claude-subprocess-feature-gates.test.ts`:

- `pins DISABLE_GROWTHBOOK=1 so feature gates resolve to compiled defaults`.
- `respects a DISABLE_GROWTHBOOK value already present in the environment`.
- `respects a DISABLE_GROWTHBOOK value passed via envOverrides`.

Validation:
- `bun test tests/claude-subprocess-feature-gates.test.ts` in `packages/shared` → 3 pass, 0 fail.
- `tsc --noEmit` on `packages/shared` → 0 errors.
