### PR TITLE
Fix abandoned browser OAuth leaving onboarding stuck

### DIFF
--- a/apps/electron/src/preload/bootstrap.ts
+++ b/apps/electron/src/preload/bootstrap.ts
@@ -25,6 +25,11 @@ import { CHANNEL_MAP } from '../transport/channel-map'
 import { createCallbackServer } from '@craft-agent/shared/auth/callback-server'
 import { CHATGPT_OAUTH_CONFIG } from '@craft-agent/shared/auth/chatgpt-oauth-config'
 import {
+  isOAuthFlowCancelledError,
+  OAuthFlowTimedOutError,
+  waitForOAuthCallback,
+} from './oauth-wait'
+import {
   CLIENT_OPEN_EXTERNAL,
   CLIENT_OPEN_PATH,
   CLIENT_SHOW_IN_FOLDER,
@@ -190,6 +195,9 @@ client.handleCapability(CLIENT_BROWSER_INVOKE, async (req: BrowserCapabilityRequ
 // ---------------------------------------------------------------------------
 
 const api = buildClientApi(client, CHANNEL_MAP, (ch) => client.isChannelAvailable(ch))
+
+let cancelPendingChatGptOAuth: (() => void) | null = null
+let pendingChatGptOAuthState: string | undefined
 
 ;(api as any).getRuntimeEnvironment = (): 'electron' | 'web' => 'electron'
 
@@ -359,10 +367,15 @@ client.onConnectionStateChanged((state) => {
   connectionSlug: string,
 ): Promise<{ success: boolean; error?: string }> => {
   let callbackServer: Awaited<ReturnType<typeof createCallbackServer>> | null = null
+  const abortController = new AbortController()
   let flowId: string | undefined
   let state: string | undefined
 
   try {
+    cancelPendingChatGptOAuth = () => {
+      abortController.abort()
+    }
+
     // 1. Start callback server on ChatGPT's fixed port with /auth/callback path
     callbackServer = await createCallbackServer({
       appType: 'electron',
@@ -374,12 +387,23 @@ client.onConnectionStateChanged((state) => {
     const startResult = await client.invoke('chatgpt:startOAuth', connectionSlug)
     flowId = startResult.flowId
     state = startResult.state
+    pendingChatGptOAuthState = state
+
+    if (abortController.signal.aborted) {
+      await client.invoke('chatgpt:cancelOAuth', { state })
+      throw new Error('ChatGPT authentication cancelled')
+    }
 
     // 3. Open browser for user consent
     await shell.openExternal(startResult.authUrl)
 
     // 4. Wait for OpenAI to redirect to our callback server
-    const callback = await callbackServer.promise
+    const callback = await waitForOAuthCallback(callbackServer.promise, {
+      timeoutMs: CHATGPT_OAUTH_CONFIG.FLOW_TIMEOUT_MS,
+      signal: abortController.signal,
+      timeoutMessage: 'ChatGPT authentication timed out. Please try again.',
+      cancelMessage: 'ChatGPT authentication cancelled',
+    })
 
     // 5. Check for errors from the provider
     if (callback.query.error) {
@@ -401,13 +425,31 @@ client.onConnectionStateChanged((state) => {
     if (state) {
       client.invoke('chatgpt:cancelOAuth', { state }).catch(() => {})
     }
+    if (isOAuthFlowCancelledError(err) || (err instanceof Error && err.message === 'ChatGPT authentication cancelled')) {
+      return { success: false, error: 'ChatGPT authentication cancelled' }
+    }
+    if (err instanceof OAuthFlowTimedOutError) {
+      return { success: false, error: err.message }
+    }
     return {
       success: false,
       error: err instanceof Error ? err.message : 'ChatGPT OAuth flow failed',
     }
   } finally {
+    cancelPendingChatGptOAuth = null
+    pendingChatGptOAuthState = undefined
     callbackServer?.close()
   }
+}
+
+;(api as any).cancelChatGptOAuth = async (): Promise<{ success: boolean }> => {
+  cancelPendingChatGptOAuth?.()
+
+  if (pendingChatGptOAuthState) {
+    return client.invoke('chatgpt:cancelOAuth', { state: pendingChatGptOAuthState })
+  }
+
+  return { success: true }
 }
 
 // App lifecycle — direct IPC (not WS RPC) since it restarts the server itself

--- a/apps/electron/src/preload/oauth-wait.test.ts
+++ b/apps/electron/src/preload/oauth-wait.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  isOAuthFlowCancelledError,
+  OAuthFlowTimedOutError,
+  waitForOAuthCallback,
+} from './oauth-wait'
+
+describe('waitForOAuthCallback', () => {
+  it('resolves when the callback arrives before timeout', async () => {
+    const result = await waitForOAuthCallback(
+      Promise.resolve({ code: 'ok' }),
+      { timeoutMs: 100 },
+    )
+
+    expect(result).toEqual({ code: 'ok' })
+  })
+
+  it('rejects with a timeout when no callback arrives', async () => {
+    const promise = waitForOAuthCallback(
+      new Promise<never>(() => {}),
+      { timeoutMs: 5, timeoutMessage: 'Timed out waiting for OAuth callback' },
+    )
+
+    await expect(promise).rejects.toBeInstanceOf(OAuthFlowTimedOutError)
+    await expect(promise).rejects.toHaveProperty('message', 'Timed out waiting for OAuth callback')
+  })
+
+  it('rejects when the flow is cancelled', async () => {
+    const controller = new AbortController()
+    const promise = waitForOAuthCallback(
+      new Promise<never>(() => {}),
+      { timeoutMs: 100, signal: controller.signal, cancelMessage: 'Authentication cancelled' },
+    )
+
+    controller.abort()
+
+    const error = await promise.catch((value) => value)
+    expect(isOAuthFlowCancelledError(error)).toBe(true)
+    expect(error).toHaveProperty('message', 'Authentication cancelled')
+  })
+})

--- a/apps/electron/src/preload/oauth-wait.ts
+++ b/apps/electron/src/preload/oauth-wait.ts
@@ -1,0 +1,76 @@
+export class OAuthFlowCancelledError extends Error {
+  constructor(message = 'OAuth flow cancelled') {
+    super(message)
+    this.name = 'OAuthFlowCancelledError'
+  }
+}
+
+export class OAuthFlowTimedOutError extends Error {
+  constructor(message = 'OAuth flow timed out') {
+    super(message)
+    this.name = 'OAuthFlowTimedOutError'
+  }
+}
+
+interface WaitForOAuthCallbackOptions {
+  timeoutMs: number
+  signal?: AbortSignal
+  timeoutMessage?: string
+  cancelMessage?: string
+}
+
+export function waitForOAuthCallback<T>(
+  callbackPromise: Promise<T>,
+  options: WaitForOAuthCallbackOptions,
+): Promise<T> {
+  const {
+    timeoutMs,
+    signal,
+    timeoutMessage = 'OAuth flow timed out',
+    cancelMessage = 'OAuth flow cancelled',
+  } = options
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false
+    let timeoutId: ReturnType<typeof setTimeout> | null = null
+
+    const cleanup = () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+        timeoutId = null
+      }
+      signal?.removeEventListener('abort', onAbort)
+    }
+
+    const settle = (fn: () => void) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      fn()
+    }
+
+    const onAbort = () => {
+      settle(() => reject(new OAuthFlowCancelledError(cancelMessage)))
+    }
+
+    if (signal?.aborted) {
+      onAbort()
+      return
+    }
+
+    signal?.addEventListener('abort', onAbort, { once: true })
+
+    timeoutId = setTimeout(() => {
+      settle(() => reject(new OAuthFlowTimedOutError(timeoutMessage)))
+    }, timeoutMs)
+
+    callbackPromise.then(
+      (value) => settle(() => resolve(value)),
+      (error) => settle(() => reject(error)),
+    )
+  })
+}
+
+export function isOAuthFlowCancelledError(error: unknown): error is OAuthFlowCancelledError {
+  return error instanceof OAuthFlowCancelledError
+}

--- a/apps/electron/src/renderer/App.tsx
+++ b/apps/electron/src/renderer/App.tsx
@@ -2003,6 +2003,7 @@ export default function App() {
             onStartOAuth={onboarding.handleStartOAuth}
             onFinish={onboarding.handleFinish}
             isWaitingForCode={onboarding.isWaitingForCode}
+            isProviderOAuthPending={onboarding.isProviderOAuthPending}
             onSubmitAuthCode={onboarding.handleSubmitAuthCode}
             onCancelOAuth={onboarding.handleCancelOAuth}
             copilotDeviceCode={onboarding.copilotDeviceCode}

--- a/apps/electron/src/renderer/components/onboarding/CredentialsStep.tsx
+++ b/apps/electron/src/renderer/components/onboarding/CredentialsStep.tsx
@@ -30,6 +30,7 @@ interface CredentialsStepProps {
   onBack: () => void
   // Two-step OAuth flow
   isWaitingForCode?: boolean
+  isProviderOAuthPending?: boolean
   onSubmitAuthCode?: (code: string) => void
   onCancelOAuth?: () => void
   // Device flow (Copilot)
@@ -53,6 +54,7 @@ export function CredentialsStep({
   onStartOAuth,
   onBack,
   isWaitingForCode,
+  isProviderOAuthPending,
   onSubmitAuthCode,
   onCancelOAuth,
   copilotDeviceCode,
@@ -98,7 +100,11 @@ export function CredentialsStep({
         description={t("onboarding.credentials.connectChatGPTDesc")}
         actions={
           <>
-            <BackButton onClick={onBack} disabled={status === 'validating'} />
+            {isProviderOAuthPending ? (
+              <BackButton onClick={onCancelOAuth}>{t("common.cancel")}</BackButton>
+            ) : (
+              <BackButton onClick={onBack} disabled={status === 'validating'} />
+            )}
             <ContinueButton
               onClick={() => onStartOAuth?.()}
               className="gap-2"
@@ -138,7 +144,11 @@ export function CredentialsStep({
         description={t("onboarding.credentials.connectGitHubDesc")}
         actions={
           <>
-            <BackButton onClick={onBack} disabled={status === 'validating'} />
+            {isProviderOAuthPending ? (
+              <BackButton onClick={onCancelOAuth}>{t("common.cancel")}</BackButton>
+            ) : (
+              <BackButton onClick={onBack} disabled={status === 'validating'} />
+            )}
             <ContinueButton
               onClick={() => onStartOAuth?.()}
               className="gap-2"

--- a/apps/electron/src/renderer/components/onboarding/OnboardingWizard.tsx
+++ b/apps/electron/src/renderer/components/onboarding/OnboardingWizard.tsx
@@ -46,6 +46,7 @@ interface OnboardingWizardProps {
 
   // Claude OAuth (two-step flow)
   isWaitingForCode?: boolean
+  isProviderOAuthPending?: boolean
   onSubmitAuthCode?: (code: string) => void
   onCancelOAuth?: () => void
 
@@ -98,6 +99,7 @@ export function OnboardingWizard({
   onFinish,
   // Two-step OAuth flow
   isWaitingForCode,
+  isProviderOAuthPending,
   onSubmitAuthCode,
   onCancelOAuth,
   // Copilot device flow
@@ -169,6 +171,7 @@ export function OnboardingWizard({
             onStartOAuth={onStartOAuth}
             onBack={onBack}
             isWaitingForCode={isWaitingForCode}
+            isProviderOAuthPending={isProviderOAuthPending}
             onSubmitAuthCode={onSubmitAuthCode}
             editInitialValues={editInitialValues}
             onCancelOAuth={onCancelOAuth}

--- a/apps/electron/src/renderer/hooks/__tests__/oauth-cancel.test.ts
+++ b/apps/electron/src/renderer/hooks/__tests__/oauth-cancel.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, mock } from 'bun:test'
+import { cancelOnboardingOAuth, isProviderManagedOAuthMethod } from '../oauth-cancel'
+
+function createApi() {
+  return {
+    clearClaudeOAuthState: mock(async () => ({ success: true })),
+    cancelChatGptOAuth: mock(async () => ({ success: true })),
+    cancelCopilotOAuth: mock(async () => ({ success: true })),
+  }
+}
+
+describe('cancelOnboardingOAuth', () => {
+  it('cancels Claude OAuth through the Claude state cleanup path', async () => {
+    const api = createApi()
+    await cancelOnboardingOAuth('claude_oauth', api)
+
+    expect(api.clearClaudeOAuthState).toHaveBeenCalledTimes(1)
+    expect(api.cancelChatGptOAuth).not.toHaveBeenCalled()
+    expect(api.cancelCopilotOAuth).not.toHaveBeenCalled()
+  })
+
+  it('cancels ChatGPT OAuth through the ChatGPT cancel API', async () => {
+    const api = createApi()
+    await cancelOnboardingOAuth('pi_chatgpt_oauth', api)
+
+    expect(api.cancelChatGptOAuth).toHaveBeenCalledTimes(1)
+    expect(api.clearClaudeOAuthState).not.toHaveBeenCalled()
+    expect(api.cancelCopilotOAuth).not.toHaveBeenCalled()
+  })
+
+  it('cancels Copilot OAuth through the Copilot cancel API', async () => {
+    const api = createApi()
+    await cancelOnboardingOAuth('pi_copilot_oauth', api)
+
+    expect(api.cancelCopilotOAuth).toHaveBeenCalledTimes(1)
+    expect(api.clearClaudeOAuthState).not.toHaveBeenCalled()
+    expect(api.cancelChatGptOAuth).not.toHaveBeenCalled()
+  })
+})
+
+describe('isProviderManagedOAuthMethod', () => {
+  it('identifies external provider OAuth methods', () => {
+    expect(isProviderManagedOAuthMethod('pi_chatgpt_oauth')).toBe(true)
+    expect(isProviderManagedOAuthMethod('pi_copilot_oauth')).toBe(true)
+    expect(isProviderManagedOAuthMethod('claude_oauth')).toBe(false)
+    expect(isProviderManagedOAuthMethod('anthropic_api_key')).toBe(false)
+  })
+})

--- a/apps/electron/src/renderer/hooks/oauth-cancel.ts
+++ b/apps/electron/src/renderer/hooks/oauth-cancel.ts
@@ -1,0 +1,29 @@
+import type { ApiSetupMethod } from '@/components/onboarding'
+import type { ElectronAPI } from '../../shared/types'
+
+type OAuthCancelApi = Pick<ElectronAPI, 'clearClaudeOAuthState' | 'cancelChatGptOAuth' | 'cancelCopilotOAuth'>
+
+export function isProviderManagedOAuthMethod(
+  method: ApiSetupMethod | null,
+): method is 'pi_chatgpt_oauth' | 'pi_copilot_oauth' {
+  return method === 'pi_chatgpt_oauth' || method === 'pi_copilot_oauth'
+}
+
+export async function cancelOnboardingOAuth(
+  method: ApiSetupMethod | null,
+  api: OAuthCancelApi,
+): Promise<void> {
+  switch (method) {
+    case 'claude_oauth':
+      await api.clearClaudeOAuthState()
+      return
+    case 'pi_chatgpt_oauth':
+      await api.cancelChatGptOAuth()
+      return
+    case 'pi_copilot_oauth':
+      await api.cancelCopilotOAuth()
+      return
+    default:
+      return
+  }
+}

--- a/apps/electron/src/renderer/hooks/useOnboarding.ts
+++ b/apps/electron/src/renderer/hooks/useOnboarding.ts
@@ -9,7 +9,7 @@
  * 4. Credentials (API Key or Claude OAuth)
  * 5. Complete
  */
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import type {
   OnboardingState,
   OnboardingStep,
@@ -20,6 +20,7 @@ import type { LocalModelSubmitData } from '@/components/onboarding/LocalModelSte
 import type { ApiKeySubmitData } from '@/components/apisetup'
 import type { CustomEndpointConfig } from '@config/llm-connections'
 import type { SetupNeeds, LlmConnectionSetup, ClaudeOAuthIdentityDto } from '../../shared/types'
+import { cancelOnboardingOAuth, isProviderManagedOAuthMethod } from './oauth-cancel'
 
 interface UseOnboardingOptions {
   /** Called when onboarding is complete */
@@ -64,6 +65,7 @@ interface UseOnboardingReturn {
 
   // Claude OAuth (two-step flow)
   isWaitingForCode: boolean
+  isProviderOAuthPending: boolean
   handleSubmitAuthCode: (code: string) => void
   handleCancelOAuth: () => void
 
@@ -521,6 +523,9 @@ export function useOnboarding({
 
   // Two-step OAuth flow state
   const [isWaitingForCode, setIsWaitingForCode] = useState(false)
+  const [activeProviderOAuthMethod, setActiveProviderOAuthMethod] = useState<ApiSetupMethod | null>(null)
+  const oauthAttemptIdRef = useRef(0)
+  const cancelledOAuthAttemptIdRef = useRef<number | null>(null)
 
   // Copilot device code (displayed during device flow)
   const [copilotDeviceCode, setCopilotDeviceCode] = useState<{ userCode: string; verificationUri: string } | undefined>()
@@ -553,25 +558,36 @@ export function useOnboarding({
     try {
       // ChatGPT OAuth (single-step flow - opens browser, captures tokens automatically)
       if (effectiveMethod === 'pi_chatgpt_oauth') {
+        const attemptId = ++oauthAttemptIdRef.current
+        cancelledOAuthAttemptIdRef.current = null
+        setActiveProviderOAuthMethod(effectiveMethod)
         const effectiveEditingSlug = connectionSlugOverride ?? editingSlug
         const isReauth = !!effectiveEditingSlug
         const connectionSlug = apiSetupMethodToConnectionSetup(effectiveMethod, {}, effectiveEditingSlug, existingSlugs).slug
-        const result = await window.electronAPI.startChatGptOAuth(connectionSlug)
+        try {
+          const result = await window.electronAPI.startChatGptOAuth(connectionSlug)
+          if (attemptId !== oauthAttemptIdRef.current || cancelledOAuthAttemptIdRef.current === attemptId) return
 
-        if (result.success) {
-          await saveAndValidateConnection(connectionSlug, effectiveMethod, undefined, isReauth)
-        } else {
-          setState(s => ({
-            ...s,
-            credentialStatus: 'error',
-            errorMessage: result.error || 'ChatGPT authentication failed',
-          }))
+          if (result.success) {
+            await saveAndValidateConnection(connectionSlug, effectiveMethod, undefined, isReauth)
+          } else {
+            setState(s => ({
+              ...s,
+              credentialStatus: 'error',
+              errorMessage: result.error || 'ChatGPT authentication failed',
+            }))
+          }
+        } finally {
+          setActiveProviderOAuthMethod(current => current === effectiveMethod ? null : current)
         }
         return
       }
 
       // Copilot OAuth (device flow — polls for token after user enters code on GitHub)
       if (effectiveMethod === 'pi_copilot_oauth') {
+        const attemptId = ++oauthAttemptIdRef.current
+        cancelledOAuthAttemptIdRef.current = null
+        setActiveProviderOAuthMethod(effectiveMethod)
         const effectiveEditingSlug = connectionSlugOverride ?? editingSlug
         const isReauth = !!effectiveEditingSlug
         const connectionSlug = apiSetupMethodToConnectionSetup(effectiveMethod, {}, effectiveEditingSlug, existingSlugs).slug
@@ -583,6 +599,7 @@ export function useOnboarding({
 
         try {
           const result = await window.electronAPI.startCopilotOAuth(connectionSlug)
+          if (attemptId !== oauthAttemptIdRef.current || cancelledOAuthAttemptIdRef.current === attemptId) return
 
           if (result.success) {
             await saveAndValidateConnection(connectionSlug, effectiveMethod, undefined, isReauth)
@@ -594,6 +611,7 @@ export function useOnboarding({
             }))
           }
         } finally {
+          setActiveProviderOAuthMethod(current => current === effectiveMethod ? null : current)
           cleanup()
           setCopilotDeviceCode(undefined)
         }
@@ -729,11 +747,15 @@ export function useOnboarding({
 
   // Cancel OAuth flow
   const handleCancelOAuth = useCallback(async () => {
+    cancelledOAuthAttemptIdRef.current = oauthAttemptIdRef.current
+    const methodToCancel = isWaitingForCode ? 'claude_oauth' : activeProviderOAuthMethod
+
     setIsWaitingForCode(false)
+    setActiveProviderOAuthMethod(null)
+    setCopilotDeviceCode(undefined)
     setState(s => ({ ...s, credentialStatus: 'idle', errorMessage: undefined }))
-    // Clear OAuth state on backend
-    await window.electronAPI.clearClaudeOAuthState()
-  }, [])
+    await cancelOnboardingOAuth(methodToCancel, window.electronAPI)
+  }, [activeProviderOAuthMethod, isWaitingForCode])
 
   // Git Bash handlers (Windows only)
   const handleBrowseGitBash = useCallback(async () => {
@@ -795,6 +817,9 @@ export function useOnboarding({
 
   // Cancel onboarding
   const handleCancel = useCallback(() => {
+    setActiveProviderOAuthMethod(null)
+    setIsWaitingForCode(false)
+    setCopilotDeviceCode(undefined)
     setState(s => ({ ...s, step: 'welcome' }))
   }, [])
 
@@ -811,6 +836,10 @@ export function useOnboarding({
 
   // Reset onboarding to initial state (used after logout or modal close)
   const reset = useCallback(() => {
+    const methodToCancel = isWaitingForCode ? 'claude_oauth' : activeProviderOAuthMethod
+    cancelOnboardingOAuth(methodToCancel, window.electronAPI).catch(() => {
+      // Ignore cleanup errors during reset.
+    })
     setState({
       step: initialStep,
       loginStatus: 'idle',
@@ -821,11 +850,13 @@ export function useOnboarding({
       errorMessage: undefined,
     })
     setIsWaitingForCode(false)
+    setActiveProviderOAuthMethod(null)
+    setCopilotDeviceCode(undefined)
     // Clean up any pending OAuth state
     window.electronAPI.clearClaudeOAuthState().catch(() => {
       // Ignore errors - state may not exist
     })
-  }, [initialStep, initialApiSetupMethod])
+  }, [activeProviderOAuthMethod, initialStep, initialApiSetupMethod, isWaitingForCode])
 
   return {
     state,
@@ -838,6 +869,7 @@ export function useOnboarding({
     handleStartOAuth,
     // Two-step OAuth flow
     isWaitingForCode,
+    isProviderOAuthPending: isProviderManagedOAuthMethod(activeProviderOAuthMethod),
     handleSubmitAuthCode,
     handleCancelOAuth,
     // Copilot device code

--- a/apps/electron/src/renderer/pages/settings/AiSettingsPage.tsx
+++ b/apps/electron/src/renderer/pages/settings/AiSettingsPage.tsx
@@ -1243,6 +1243,7 @@ export default function AiSettingsPage() {
                   onStartOAuth={apiSetupOnboarding.handleStartOAuth}
                   onFinish={handleApiSetupFinish}
                   isWaitingForCode={apiSetupOnboarding.isWaitingForCode}
+                  isProviderOAuthPending={apiSetupOnboarding.isProviderOAuthPending}
                   onSubmitAuthCode={apiSetupOnboarding.handleSubmitAuthCode}
                   onCancelOAuth={apiSetupOnboarding.handleCancelOAuth}
                   copilotDeviceCode={apiSetupOnboarding.copilotDeviceCode}

--- a/packages/server-core/src/handlers/rpc/llm-connections.ts
+++ b/packages/server-core/src/handlers/rpc/llm-connections.ts
@@ -14,6 +14,7 @@ import { pushTyped, type RpcServer } from '@craft-agent/server-core/transport'
 import type { HandlerDeps } from '../handler-deps'
 import { randomUUID } from 'node:crypto'
 import { CLIENT_OPEN_EXTERNAL } from '@craft-agent/server-core/transport'
+import { CHATGPT_OAUTH_CONFIG } from '@craft-agent/shared/auth'
 
 // Local OAuth state
 let copilotOAuthAbort: AbortController | null = null
@@ -621,7 +622,7 @@ export function registerLlmConnectionsHandlers(server: RpcServer, deps: HandlerD
     createdAt: number
   }
   const pendingChatGptFlows = new Map<string, PendingChatGptFlow>()
-  const CHATGPT_FLOW_TTL_MS = 5 * 60 * 1000
+  const CHATGPT_FLOW_TTL_MS = CHATGPT_OAUTH_CONFIG.FLOW_TIMEOUT_MS
 
   function cleanupExpiredChatGptFlows() {
     const now = Date.now()

--- a/packages/shared/src/auth/chatgpt-oauth-config.ts
+++ b/packages/shared/src/auth/chatgpt-oauth-config.ts
@@ -39,6 +39,12 @@ export const CHATGPT_OAUTH_CONFIG = {
   CALLBACK_PORT: 1455,
 
   /**
+   * Maximum time to wait for the browser flow to complete before timing out.
+   * Keep this aligned with the server-side pending-flow TTL.
+   */
+  FLOW_TIMEOUT_MS: 5 * 60 * 1000,
+
+  /**
    * OAuth scopes requested during authentication
    * These scopes provide access to ChatGPT Plus features via Codex
    */


### PR DESCRIPTION
## Summary
This fixes onboarding getting stuck when a browser-based OAuth flow is started but never completed, with ChatGPT subscription auth as the reproducible case.

The root cause was that the Electron flow waited indefinitely for the browser callback and did not expose a real cancel path back into the pending OAuth state.

## Changes
- add a shared timeout for pending ChatGPT OAuth flows and reuse it on both the preload and server sides
- make the Electron callback wait cancellable and timeout-aware instead of waiting forever
- wire ChatGPT cancellation through preload so the renderer can abort an in-flight OAuth attempt and clean up server state
- prevent late OAuth completions from overwriting a user-initiated cancel in onboarding state
- show `Cancel` while provider-managed OAuth is pending, so the user is not left with a disabled `Back` button
- keep the pending/cancel onboarding behavior consistent for the shared provider-managed OAuth paths
- add targeted tests for the timeout/cancel wait helper and onboarding OAuth cancellation dispatch

## Testing
- `bun test apps/electron/src/preload/oauth-wait.test.ts apps/electron/src/renderer/hooks/__tests__/oauth-cancel.test.ts apps/electron/src/renderer/hooks/__tests__/useOnboarding.test.ts`
- `cd apps/electron && bun run typecheck`
- `cd packages/server-core && bun run typecheck`
- `bun run electron:build:preload`
- `bun run electron:build:renderer`
- `bun run typecheck:all` currently fails on existing repository baseline issues unrelated to this change, including a missing `tsconfig.base.json`, external `@types/cacheable-request` / `keyv` type issues, and unrelated `packages/session-tools-core` errors

## Screenshots
UI change: while external OAuth is pending, the disabled `Back` action is replaced with an explicit `Cancel` action to let the user abandon the flow cleanly.

![Pending OAuth cancel state](https://github.com/user-attachments/assets/d9ee44a3-36be-48fa-b33e-67e239e87c7f)
