### PR TITLE
ci: add GitHub Actions workflow to build Windows and macOS binaries

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -1,0 +1,98 @@
+name: Build Electron App
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+concurrency:
+  group: build-electron-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            platform: win
+            arch: x64
+            artifact_name: Craft-Agents-x64.exe
+            artifact_glob: apps/electron/release/*.exe
+          - os: macos-latest
+            platform: mac
+            arch: arm64
+            artifact_name: Craft-Agents-arm64.dmg
+            artifact_glob: apps/electron/release/*.dmg
+
+    runs-on: ${{ matrix.os }}
+    name: Build (${{ matrix.platform }}-${{ matrix.arch }})
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.10"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fix nested dependency versions (Windows)
+        if: matrix.platform == 'win'
+        shell: bash
+        run: |
+          # lru-cache v5 for @babel/helper-compilation-targets
+          mkdir -p node_modules/@babel/helper-compilation-targets/node_modules
+          cd node_modules/@babel/helper-compilation-targets/node_modules
+          npm pack lru-cache@5.1.1 2>&1 | tail -1
+          tar xzf lru-cache-5.1.1.tgz && mv package lru-cache && rm lru-cache-5.1.1.tgz
+          # yallist v3 for lru-cache v5
+          npm pack yallist@3.1.1 2>&1 | tail -1
+          tar xzf yallist-3.1.1.tgz && mv package yallist && rm yallist-3.1.1.tgz
+          # magic-string v0.30 for @tailwindcss/node
+          cd ../../../..
+          mkdir -p node_modules/@tailwindcss/node/node_modules
+          cd node_modules/@tailwindcss/node/node_modules
+          npm pack magic-string@0.30.17 2>&1 | tail -1
+          tar xzf magic-string-0.30.17.tgz && mv package magic-string && rm magic-string-0.30.17.tgz
+          # Fix electron path.txt
+          echo "electron.exe" > ../../electron/path.txt
+
+      - name: Build Electron app
+        run: bun run electron:build
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
+
+      - name: Package (Windows)
+        if: matrix.platform == 'win'
+        run: cd apps/electron && npx electron-builder --config electron-builder.yml --win --x64
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          CRAFT_DEV_RUNTIME: "1"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package (macOS)
+        if: matrix.platform == 'mac'
+        run: cd apps/electron && npx electron-builder --config electron-builder.yml --mac --arm64
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          CRAFT_DEV_RUNTIME: "1"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: craft-agents-${{ matrix.platform }}-${{ matrix.arch }}
+          path: ${{ matrix.artifact_glob }}
+          if-no-files-found: error
+          retention-days: 30


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds distributable Electron app binaries for Windows and macOS.

## What it does

- Matrix build on windows-latest (x64) and macos-latest (arm64)
- Runs bun install, electron:build, then electron-builder to produce installers
- Windows: produces Craft-Agents-x64.exe (NSIS installer)
- macOS: produces Craft-Agents-arm64.dmg (disk image)
- Uploads both as GitHub Actions artifacts (30-day retention)
- Triggers on: push to main, version tags (v*), and manual workflow_dispatch

## Build details

- Uses CRAFT_DEV_RUNTIME=1 so the runtime resolves the SDK binary from node_modules without requiring the full S3 upload pipeline
- Uses CSC_IDENTITY_AUTO_DISCOVERY=false — builds are unsigned (no Apple Developer ID or Windows code signing certificate required)
- Includes a Windows-specific step to fix nested dependency version conflicts (lru-cache v5, yallist v3, magic-string v0.30) that we hit during local builds due to bun's hoisted node_modules layout

## Notes

- The macOS build targets arm64 (Apple Silicon). x64 can be added as a matrix entry if needed.
- Code signing and notarization are not configured — the resulting binaries will show "unidentified developer" warnings. To enable signing, add APPLE_SIGNING_IDENTITY, APPLE_ID, APPLE_TEAM_ID, and APPLE_APP_SPECIFIC_PASSWORD as repository secrets.
- Linux AppImage build can be added as a third matrix entry if desired.

## Testing

The workflow is configured for workflow_dispatch so it can be tested manually before merging.
