### PR TITLE
test(electron): add unit tests for custom ESLint rules

### DIFF
--- a/apps/electron/eslint-rules/__tests__/no-direct-file-open.test.ts
+++ b/apps/electron/eslint-rules/__tests__/no-direct-file-open.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'bun:test'
+import { Linter } from 'eslint'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const rule = require('../no-direct-file-open.cjs')
+
+function runRule(code: string, filename = 'src/renderer/components/Foo.tsx') {
+  const linter = new Linter({ configType: 'eslintrc' })
+  linter.defineRule('craft-links/no-direct-file-open', rule)
+
+  return linter.verify(code, {
+    parserOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    rules: {
+      'craft-links/no-direct-file-open': 'error',
+    },
+  }, { filename })
+}
+
+describe('no-direct-file-open (electron)', () => {
+  it('flags direct window.electronAPI.openFile calls', () => {
+    const messages = runRule("window.electronAPI.openFile(path)")
+    expect(messages.length).toBe(1)
+    expect(messages[0]?.message).toContain('Use onOpenFile')
+  })
+
+  it('allows the link interceptor implementation in App.tsx', () => {
+    const messages = runRule(
+      "window.electronAPI.openFile(path)",
+      'src/renderer/App.tsx',
+    )
+    expect(messages.length).toBe(0)
+  })
+
+  it('allows the link interceptor fallback in useLinkInterceptor.ts', () => {
+    const messages = runRule(
+      "window.electronAPI.openFile(path)",
+      'src/renderer/hooks/useLinkInterceptor.ts',
+    )
+    expect(messages.length).toBe(0)
+  })
+})

--- a/apps/electron/eslint-rules/__tests__/no-direct-navigation-state.test.ts
+++ b/apps/electron/eslint-rules/__tests__/no-direct-navigation-state.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test'
+import { Linter } from 'eslint'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const rule = require('../no-direct-navigation-state.cjs')
+
+function runRule(code: string, filename = 'src/renderer/components/app-shell/AppShell.tsx') {
+  const linter = new Linter({ configType: 'eslintrc' })
+  linter.defineRule('craft-agent/no-direct-navigation-state', rule)
+
+  return linter.verify(code, {
+    parserOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    rules: {
+      'craft-agent/no-direct-navigation-state': 'error',
+    },
+  }, { filename })
+}
+
+describe('no-direct-navigation-state (electron)', () => {
+  it('flags direct setSidebarMode outside the navigation handler', () => {
+    const messages = runRule("function onClick() { setSidebarMode({ type: 'sources' }) }")
+    expect(messages.length).toBe(1)
+    expect(messages[0]?.message).toContain("Do not call 'setSidebarMode()'")
+  })
+
+  it('allows setSidebarMode inside handleSidebarNavigate (function declaration)', () => {
+    const messages = runRule(
+      "function handleSidebarNavigate() { setSidebarMode({ type: 'sources' }) }",
+    )
+    expect(messages.length).toBe(0)
+  })
+
+  it('allows setSidebarMode inside handleSidebarNavigate (useCallback)', () => {
+    const messages = runRule(
+      "const handleSidebarNavigate = useCallback(() => { setSidebarMode({ type: 'sources' }) }, [])",
+    )
+    expect(messages.length).toBe(0)
+  })
+
+  it('does nothing when not in AppShell.tsx', () => {
+    const messages = runRule(
+      "function onClick() { setSidebarMode({ type: 'sources' }) }",
+      'src/renderer/components/Foo.tsx',
+    )
+    expect(messages.length).toBe(0)
+  })
+})

--- a/apps/electron/eslint-rules/__tests__/no-direct-platform-check.test.ts
+++ b/apps/electron/eslint-rules/__tests__/no-direct-platform-check.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test'
+import { Linter } from 'eslint'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const rule = require('../no-direct-platform-check.cjs')
+
+function runRule(code: string, filename = 'src/renderer/Foo.tsx') {
+  const linter = new Linter({ configType: 'eslintrc' })
+  linter.defineRule('craft-platform/no-direct-platform-check', rule)
+
+  return linter.verify(code, {
+    parserOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    rules: {
+      'craft-platform/no-direct-platform-check': 'error',
+    },
+  }, { filename })
+}
+
+describe('no-direct-platform-check (electron)', () => {
+  it('flags direct navigator.platform access', () => {
+    const messages = runRule("const isMac = navigator.platform.toLowerCase().includes('mac')")
+    expect(messages.length).toBe(1)
+    expect(messages[0]?.message).toContain("Don't access 'navigator.platform'")
+  })
+
+  it('allows the platform utility source of truth', () => {
+    const messages = runRule(
+      "const isMac = navigator.platform.toLowerCase().includes('mac')",
+      'src/renderer/lib/platform.ts',
+    )
+    expect(messages.length).toBe(0)
+  })
+
+  it('allows importing from @/lib/platform', () => {
+    const messages = runRule("import { isMac } from '@/lib/platform'")
+    expect(messages.length).toBe(0)
+  })
+})

--- a/apps/electron/eslint-rules/__tests__/no-hardcoded-path-separator.test.ts
+++ b/apps/electron/eslint-rules/__tests__/no-hardcoded-path-separator.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'bun:test'
+import { Linter } from 'eslint'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const rule = require('../no-hardcoded-path-separator.cjs')
+
+function runRule(code: string) {
+  const linter = new Linter({ configType: 'eslintrc' })
+  linter.defineRule('craft-paths/no-hardcoded-path-separator', rule)
+
+  return linter.verify(code, {
+    parserOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    rules: {
+      'craft-paths/no-hardcoded-path-separator': 'warn',
+    },
+  })
+}
+
+describe('no-hardcoded-path-separator (electron)', () => {
+  it('flags hardcoded separator inside startsWith', () => {
+    const messages = runRule("filePath.startsWith(dir + '/')")
+    expect(messages.length).toBe(1)
+    expect(messages[0]?.message).toContain('Avoid hardcoded')
+  })
+
+  it('flags hardcoded backslash separator inside endsWith', () => {
+    const messages = runRule("p.endsWith(prefix + '\\\\')")
+    expect(messages.length).toBe(1)
+  })
+
+  it('allows path.sep based concatenation', () => {
+    const messages = runRule("filePath.startsWith(dir + sep)")
+    expect(messages.length).toBe(0)
+  })
+
+  it('allows non-path operations', () => {
+    const messages = runRule("const x = 'a' + '/'")
+    expect(messages.length).toBe(0)
+  })
+})

--- a/apps/electron/eslint-rules/__tests__/no-inline-source-auth-check.test.ts
+++ b/apps/electron/eslint-rules/__tests__/no-inline-source-auth-check.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test'
+import { Linter } from 'eslint'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const rule = require('../no-inline-source-auth-check.cjs')
+
+function runRule(code: string, filename = 'src/renderer/components/Foo.tsx') {
+  const linter = new Linter({ configType: 'eslintrc' })
+  linter.defineRule('craft-sources/no-inline-source-auth-check', rule)
+
+  return linter.verify(code, {
+    parserOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    rules: {
+      'craft-sources/no-inline-source-auth-check': 'error',
+    },
+  }, { filename })
+}
+
+describe('no-inline-source-auth-check (electron)', () => {
+  it('flags inline source.config.isAuthenticated checks', () => {
+    const messages = runRule("if (source.config.isAuthenticated) {}")
+    expect(messages.length).toBe(1)
+    expect(messages[0]?.message).toContain('isSourceUsable')
+  })
+
+  it('flags enabled && isAuthenticated checks', () => {
+    const messages = runRule("if (s.config.enabled && s.config.isAuthenticated) {}")
+    expect(messages.length).toBe(1)
+  })
+
+  it('allows the isSourceUsable definition site', () => {
+    const messages = runRule(
+      "if (source.config.isAuthenticated) {}",
+      'src/sources/storage.ts',
+    )
+    expect(messages.length).toBe(0)
+  })
+
+  it('allows credential-manager and server-builder', () => {
+    expect(runRule("if (source.config.isAuthenticated) {}", 'src/sources/credential-manager.ts').length).toBe(0)
+    expect(runRule("if (source.config.isAuthenticated) {}", 'src/sources/server-builder.ts').length).toBe(0)
+  })
+})

--- a/apps/electron/eslint-rules/__tests__/no-localstorage.test.ts
+++ b/apps/electron/eslint-rules/__tests__/no-localstorage.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'bun:test'
+import { Linter } from 'eslint'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const rule = require('../no-localstorage.cjs')
+
+function runRule(code: string) {
+  const linter = new Linter({ configType: 'eslintrc' })
+  linter.defineRule('craft-agent/no-localstorage', rule)
+
+  return linter.verify(code, {
+    parserOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    rules: {
+      'craft-agent/no-localstorage': 'warn',
+    },
+  })
+}
+
+describe('no-localstorage (electron)', () => {
+  it('flags localStorage.getItem', () => {
+    const messages = runRule("localStorage.getItem('key')")
+    expect(messages.length).toBe(1)
+    expect(messages[0]?.message).toContain('Avoid localStorage')
+  })
+
+  it('flags localStorage.setItem', () => {
+    const messages = runRule("localStorage.setItem('key', 'value')")
+    expect(messages.length).toBe(1)
+  })
+
+  it('flags window.localStorage access', () => {
+    const messages = runRule("window.localStorage.getItem('key')")
+    expect(messages.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('allows file-based preferences via electronAPI', () => {
+    const messages = runRule("window.electronAPI.readPreferences()")
+    expect(messages.length).toBe(0)
+  })
+})

--- a/apps/electron/eslint-rules/__tests__/no-nonstandard-shadows.test.ts
+++ b/apps/electron/eslint-rules/__tests__/no-nonstandard-shadows.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test'
+import { Linter } from 'eslint'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const rule = require('../no-nonstandard-shadows.cjs')
+
+function runRule(code: string) {
+  const linter = new Linter({ configType: 'eslintrc' })
+  linter.defineRule('craft-styles/no-nonstandard-shadows', rule)
+
+  return linter.verify(code, {
+    parserOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    rules: {
+      'craft-styles/no-nonstandard-shadows': ['error', {
+        allowedClasses: ['shadow-none', 'shadow-minimal', 'shadow-modal-small'],
+        allowInlineNone: true,
+      }],
+    },
+  })
+}
+
+describe('no-nonstandard-shadows (electron)', () => {
+  it('flags disallowed shadow utility classes', () => {
+    const messages = runRule('const cls = "shadow-foo"')
+    expect(messages.length).toBe(1)
+    expect(messages[0]?.message).toContain('Disallowed shadow class')
+  })
+
+  it('flags arbitrary shadow-[...] classes', () => {
+    const messages = runRule('const cls = "shadow-[0_0_10px_red]"')
+    expect(messages.length).toBe(1)
+  })
+
+  it('flags inline boxShadow style', () => {
+    const messages = runRule("const style = { boxShadow: '5px 5px red' }")
+    expect(messages.length).toBe(1)
+    expect(messages[0]?.message).toContain('Avoid inline boxShadow')
+  })
+
+  it('allows approved shadow classes', () => {
+    const messages = runRule('const cls = "shadow-minimal"')
+    expect(messages.length).toBe(0)
+  })
+
+  it('allows inline boxShadow: none', () => {
+    const messages = runRule("const style = { boxShadow: 'none' }")
+    expect(messages.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Add focused unit tests for the seven custom ESLint rules under
`apps/electron/eslint-rules`.

## Scope

- Adds tests only
- Does not modify rule behavior
- Does not change shared ESLint rules or CI configuration

## Notes

The existing `no-localstorage` rule may report
`window.localStorage.getItem(...)` more than once. The test intentionally checks
for at least one report so this PR does not encode the duplicate-report behavior
as the expected contract.