### PR TITLE
Fix excluded filter inheritance for new sessions

### DIFF
--- a/apps/electron/resources/release-notes/next.md
+++ b/apps/electron/resources/release-notes/next.md
@@ -8,4 +8,6 @@ This file accumulates release notes for the next unreleased version. PRs that ad
 
 ## Bug Fixes
 
+- **New sessions respect excluded filters** — Creating a session while status, label, or project exclusions are active now ignores those exclusions and uses workspace defaults unless exactly one included filter is selected. [#970](https://github.com/craft-ai-agents/craft-agents-oss/issues/970) · `6a3ba29`
+
 ## Breaking Changes

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -147,6 +147,10 @@ import {
 import { hasOpenOverlay } from "@/lib/overlay-detection"
 import { clearSourceIconCaches } from "@/lib/icon-cache"
 import { dispatchFocusInputEvent } from "./input/focus-input-events"
+import {
+  resolveInheritedNewSessionParams,
+  type FilterMode,
+} from "./new-session-filter-inheritance"
 
 /**
  * AppShellProps - Minimal props interface for AppShell component
@@ -169,9 +173,6 @@ interface AppShellProps {
   /** Focused mode - hides sidebars, shows only the chat content */
   isFocusedMode?: boolean
 }
-
-/** Filter mode for tri-state filtering: include shows only matching, exclude hides matching */
-type FilterMode = 'include' | 'exclude'
 
 const altClickTooltipLabel = isMac ? '⌥ click to exclude' : 'Alt click to exclude'
 
@@ -2008,32 +2009,6 @@ function AppShellContent({
     }
   }, [activeWorkspace?.id, navigate, t])
 
-  /**
-   * Resolve the "inherit sole active filter" rule: if exactly one filter value
-   * is selected across statuses + labels + projects, return it as new-session
-   * params. Otherwise return null (fall back to workspace defaults).
-   */
-  const resolveInheritedNewSessionParams = useCallback((): { status?: string; label?: string; project?: string } | null => {
-    const statusCount = listFilter.size
-    const labelCount = labelFilter.size
-    const projectCount = projectFilter.size
-    const total = statusCount + labelCount + projectCount
-    if (total !== 1) return null
-    if (statusCount === 1) {
-      const [stateId] = [...listFilter.keys()]
-      return { status: stateId }
-    }
-    if (labelCount === 1) {
-      const [labelId] = [...labelFilter.keys()]
-      return { label: labelId }
-    }
-    if (projectCount === 1) {
-      const [projectId] = [...projectFilter.keys()]
-      return { project: projectId }
-    }
-    return null
-  }, [listFilter, labelFilter, projectFilter])
-
   // Create a new chat and select it
   const handleNewChat = useCallback((newPanel: boolean = false) => {
     if (!activeWorkspace) return
@@ -2042,8 +2017,8 @@ function AppShellContent({
     setSearchActive(false)
     setSearchQuery('')
 
-    // Inherit sole-active filter into the new session when unambiguous.
-    const inherited = resolveInheritedNewSessionParams()
+    // Inherit the sole included filter into the new session when unambiguous.
+    const inherited = resolveInheritedNewSessionParams(listFilter, labelFilter, projectFilter)
 
     // Delegate to NavigationContext which handles session creation
     navigate(
@@ -2053,7 +2028,7 @@ function AppShellContent({
 
     // Focus the chat input after navigation completes
     setTimeout(() => focusZone('chat', { intent: 'programmatic' }), 50)
-  }, [activeWorkspace, focusZone, navigate, resolveInheritedNewSessionParams])
+  }, [activeWorkspace, focusZone, labelFilter, listFilter, navigate, projectFilter])
 
   // Create a brand new dedicated browser window and focus it.
   // Intentionally unbound: this action should always create a NEW window.

--- a/apps/electron/src/renderer/components/app-shell/__tests__/new-session-filter-inheritance.test.ts
+++ b/apps/electron/src/renderer/components/app-shell/__tests__/new-session-filter-inheritance.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  resolveInheritedNewSessionParams,
+  type FilterMode,
+} from '../new-session-filter-inheritance'
+
+const filter = (...entries: Array<[string, FilterMode]>): Map<string, FilterMode> => new Map(entries)
+const emptyFilter = (): Map<string, FilterMode> => filter()
+
+describe('new session filter inheritance', () => {
+  it('inherits a sole included status, label, or project', () => {
+    expect(resolveInheritedNewSessionParams(
+      filter(['in-progress', 'include']),
+      emptyFilter(),
+      emptyFilter(),
+    )).toEqual({ status: 'in-progress' })
+
+    expect(resolveInheritedNewSessionParams(
+      emptyFilter(),
+      filter(['urgent', 'include']),
+      emptyFilter(),
+    )).toEqual({ label: 'urgent' })
+
+    expect(resolveInheritedNewSessionParams(
+      emptyFilter(),
+      emptyFilter(),
+      filter(['project-1', 'include']),
+    )).toEqual({ project: 'project-1' })
+  })
+
+  it('does not inherit an excluded status, label, or project', () => {
+    expect(resolveInheritedNewSessionParams(
+      filter(['done', 'exclude']),
+      emptyFilter(),
+      emptyFilter(),
+    )).toBeNull()
+
+    expect(resolveInheritedNewSessionParams(
+      emptyFilter(),
+      filter(['blocked', 'exclude']),
+      emptyFilter(),
+    )).toBeNull()
+
+    expect(resolveInheritedNewSessionParams(
+      emptyFilter(),
+      emptyFilter(),
+      filter(['project-1', 'exclude']),
+    )).toBeNull()
+  })
+
+  it('ignores excluded filters when resolving a sole included filter', () => {
+    expect(resolveInheritedNewSessionParams(
+      filter(['done', 'exclude']),
+      filter(['urgent', 'include'], ['blocked', 'exclude']),
+      filter(['project-1', 'exclude']),
+    )).toEqual({ label: 'urgent' })
+  })
+
+  it('falls back to defaults when there are no included filters', () => {
+    expect(resolveInheritedNewSessionParams(
+      emptyFilter(),
+      emptyFilter(),
+      emptyFilter(),
+    )).toBeNull()
+  })
+
+  it('falls back to defaults when multiple included filters are active', () => {
+    expect(resolveInheritedNewSessionParams(
+      filter(['todo', 'include'], ['in-progress', 'include']),
+      emptyFilter(),
+      emptyFilter(),
+    )).toBeNull()
+
+    expect(resolveInheritedNewSessionParams(
+      filter(['todo', 'include']),
+      filter(['urgent', 'include']),
+      emptyFilter(),
+    )).toBeNull()
+  })
+})

--- a/apps/electron/src/renderer/components/app-shell/new-session-filter-inheritance.ts
+++ b/apps/electron/src/renderer/components/app-shell/new-session-filter-inheritance.ts
@@ -1,0 +1,34 @@
+export type FilterMode = 'include' | 'exclude'
+
+export interface InheritedNewSessionParams {
+  status?: string
+  label?: string
+  project?: string
+}
+
+type FilterMap = ReadonlyMap<string, FilterMode>
+
+/**
+ * Resolve the sole included filter that a new session should inherit.
+ * Excluded filters are intentionally ignored because they describe which
+ * sessions to hide, not attributes to apply to newly created sessions.
+ */
+export function resolveInheritedNewSessionParams(
+  statusFilter: FilterMap,
+  labelFilter: FilterMap,
+  projectFilter: FilterMap,
+): InheritedNewSessionParams | null {
+  const candidates: InheritedNewSessionParams[] = []
+
+  for (const [status, mode] of statusFilter) {
+    if (mode === 'include') candidates.push({ status })
+  }
+  for (const [label, mode] of labelFilter) {
+    if (mode === 'include') candidates.push({ label })
+  }
+  for (const [project, mode] of projectFilter) {
+    if (mode === 'include') candidates.push({ project })
+  }
+
+  return candidates.length === 1 ? candidates[0] : null
+}


### PR DESCRIPTION
## Summary

Fix new-session filter inheritance so only filters in `include` mode are considered. Excluded status, label, and project filters now leave new sessions on workspace defaults unless exactly one separate included filter is active.

Fixes #970

## Changes

- extract the inheritance rule into a pure, testable helper
- ignore excluded filters when collecting inheritance candidates
- preserve the existing ambiguity fallback when zero or multiple included filters are active
- add regression coverage for statuses, labels, projects, mixed include/exclude filters, and multiple includes
- document the user-visible fix in `apps/electron/resources/release-notes/next.md`

## Testing

- `bun test apps/electron/src/renderer/components/app-shell/__tests__/new-session-filter-inheritance.test.ts` — 5 passed
- `bun test apps/electron/src/renderer/components/app-shell/__tests__` — 45 passed
- `bun run typecheck:electron` — passed
- package-local ESLint on all changed TypeScript files — 0 errors (existing `AppShell.tsx` hook warnings remain)
- `bun run lint:electron` — current `main` has 9 errors in unrelated, untouched files; no errors are reported in this PR's changed TypeScript files
- `bun run typecheck:all` — cannot complete on current `main` because `packages/core/tsconfig.json` extends a root `tsconfig.base.json` that is absent from the OSS checkout; the affected Electron package type check passes

## Screenshots

Not applicable — this changes session creation behavior without visual changes.
