### PR TITLE
Fix OpenAI streams with empty tool_calls arrays

### DIFF
--- a/apps/electron/resources/release-notes/next.md
+++ b/apps/electron/resources/release-notes/next.md
@@ -8,4 +8,6 @@ This file accumulates release notes for the next unreleased version. PRs that ad
 
 ## Bug Fixes
 
+- **OpenAI-compatible streams preserve chunks with empty tool-call arrays** — Custom endpoints that include `tool_calls: []` on ordinary content and terminal chunks no longer lose those chunks in the network interceptor, preventing valid responses from failing with `Stream ended without finish_reason`. Fixes [#995](https://github.com/craft-ai-agents/craft-agents-oss/issues/995).
+
 ## Breaking Changes

--- a/packages/shared/src/__tests__/unified-network-interceptor.sse.test.ts
+++ b/packages/shared/src/__tests__/unified-network-interceptor.sse.test.ts
@@ -61,6 +61,20 @@ describe('unified-network-interceptor SSE processors', () => {
     rmSync(sessionDir, { recursive: true, force: true });
   });
 
+  it('OpenAI: passes through chunks with empty tool_calls arrays', async () => {
+    const sse = [
+      'data: {"choices":[{"index":0,"delta":{"content":"ok","tool_calls":[]},"finish_reason":""}]}\n\n',
+      'data: {"choices":[{"index":0,"delta":{"content":"","tool_calls":[]},"finish_reason":"stop"}]}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    const out = await runThroughProcessor(createOpenAiSseStrippingStream(), sse);
+
+    expect(out).toContain('"content":"ok"');
+    expect(out).toContain('"finish_reason":"stop"');
+    expect(out).toContain('data: [DONE]');
+  });
+
   it('OpenAI: handles multiple tool calls in one delta chunk without dropping calls', async () => {
     const sse = [
       'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"toolA","arguments":"{\\"a\\":1,\\"_intent\\":\\"intent-1\\",\\"_displayName\\":\\"Display 1\\"}"}},{"index":1,"id":"call_2","type":"function","function":{"name":"toolB","arguments":"{\\"b\\":2,\\"_intent\\":\\"intent-2\\",\\"_displayName\\":\\"Display 2\\"}"}}]}}]}\n\n',

--- a/packages/shared/src/unified-network-interceptor.ts
+++ b/packages/shared/src/unified-network-interceptor.ts
@@ -1004,7 +1004,7 @@ export function createOpenAiSseStrippingStream(): TransformStream<Uint8Array, Ui
     //     those args to the matching phase-1 entry by walking the open calls
     //     in order rather than allocating a new bucket for them.
     for (const choice of choices) {
-      if (!choice?.delta?.tool_calls) continue;
+      if (!choice?.delta?.tool_calls?.length) continue;
       handledToolCalls = true;
 
       const choiceIndex = choice.index ?? 0;


### PR DESCRIPTION
## Summary

- preserve OpenAI-compatible SSE chunks whose deltas contain an empty `tool_calls` array
- add regression coverage for content and terminal chunks with `tool_calls: []`
- document the user-visible fix in the pending release notes

## Root cause

The OpenAI SSE interceptor treated any present `delta.tool_calls` value as a handled tool-call delta. Because empty arrays are truthy in JavaScript, providers that include `tool_calls: []` on ordinary content or terminal chunks caused those chunks to be suppressed. Pi then received `[DONE]` without the upstream `finish_reason: "stop"` chunk and reported `Stream ended without finish_reason`.

## Changes

- require `delta.tool_calls` to contain at least one entry before entering the tool-call buffering path
- verify that content, `finish_reason: "stop"`, and `[DONE]` pass through when `tool_calls` is empty
- retain the existing behavior for non-empty, repeated, parallel, and shifted-index tool calls

## Testing

- `bun test` across the OpenAI interceptor SSE, relay, hint, response-repair, and validation suites: 43 passed, 0 failed
- `bun run typecheck:shared`
- replayed an OpenAI-compatible SSE stream through the interceptor and confirmed content, `finish_reason: "stop"`, and `[DONE]` are all preserved
- `git diff --check`

## Validation note

`bun run typecheck:all` could not complete because the v0.11.2 checkout does not contain the root `tsconfig.base.json` referenced by several package configs. The affected `packages/shared` typecheck passes.

Fixes #995
