### PR TITLE
fix(tests): fetch-stub leaks across test files; Windows-style path semantics; stale koffi warning

### DIFF
--- a/packages/shared/src/agent/mode-manager.ts
+++ b/packages/shared/src/agent/mode-manager.ts
@@ -173,9 +173,17 @@ function normalizeForComparison(path: string): string {
   return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
 }
 
-function isWithin(base: string, target: string): boolean {
-  const normalizedBase = normalizeForComparison(base);
-  const normalizedTarget = normalizeForComparison(target);
+function isWindowsStylePath(path: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(path) || path.startsWith('\\\\');
+}
+
+function isWithin(base: string, target: string, caseInsensitive?: boolean): boolean {
+  let normalizedBase = normalizeForComparison(base);
+  let normalizedTarget = normalizeForComparison(target);
+  if (caseInsensitive) {
+    normalizedBase = normalizedBase.toLowerCase();
+    normalizedTarget = normalizedTarget.toLowerCase();
+  }
   const rel = relative(normalizedBase, normalizedTarget);
   return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
 }
@@ -190,10 +198,27 @@ function isPathWithinDirectory(targetPath: string, baseDir: string): boolean {
   const expandedTarget = expandHome(targetPath);
   const expandedBase = expandHome(baseDir);
 
+  // Windows-style paths get Windows comparison semantics (case-insensitive)
+  // on any host — validating a remote Windows shell's path from macOS/Linux
+  // must behave the same as validating it on Windows itself.
+  const windowsSemantics =
+    process.platform === 'win32' ||
+    isWindowsStylePath(expandedTarget) ||
+    isWindowsStylePath(expandedBase);
+
   const resolvedTarget = resolve(expandedTarget);
   const resolvedBase = resolve(expandedBase);
-  if (!isWithin(resolvedBase, resolvedTarget)) {
+  if (!isWithin(resolvedBase, resolvedTarget, windowsSemantics)) {
     return false;
+  }
+
+  // On a POSIX host a Windows-style path can never be a real filesystem
+  // path: resolve() folds it into a single literal component and the
+  // realpath walk below would escape to the cwd. Lexical containment is the
+  // only meaningful check here; the symlink-escape hardening still applies
+  // to native paths on every platform.
+  if (process.platform !== 'win32' && windowsSemantics) {
+    return true;
   }
 
   const realBase = existsSync(resolvedBase) ? realpathSync.native(resolvedBase) : resolvedBase;

--- a/packages/shared/src/auth/__tests__/oauth-callback-url.test.ts
+++ b/packages/shared/src/auth/__tests__/oauth-callback-url.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, beforeEach } from 'bun:test'
+import { describe, it, expect, mock, beforeAll, afterAll } from 'bun:test'
 
 /**
  * Tests that all OAuth prepare functions correctly support callbackUrl
@@ -6,8 +6,18 @@ import { describe, it, expect, mock, beforeEach } from 'bun:test'
  */
 
 // Mock fetch globally to prevent real HTTP requests during metadata discovery
+// The original fetch MUST be restored afterAll — this suite previously leaked a
+// 404-everywhere stub into every test file running after it in the shared
+// bun:test process (tests hitting their own localhost servers received the
+// 404 stub instead of their actual response).
+const originalFetch = globalThis.fetch
 const mockFetch = mock(() => Promise.resolve(new Response('Not Found', { status: 404 })))
-globalThis.fetch = mockFetch as any
+beforeAll(() => {
+  globalThis.fetch = mockFetch as unknown as typeof fetch
+})
+afterAll(() => {
+  globalThis.fetch = originalFetch
+})
 
 import { prepareGoogleOAuth } from '../google-oauth'
 

--- a/packages/shared/src/sources/__tests__/oauth-relay.test.ts
+++ b/packages/shared/src/sources/__tests__/oauth-relay.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
 
 import { OAUTH_RELAY_CALLBACK_URL, decodeOAuthRelayState, isOAuthRelayState } from '../../auth/oauth-relay.ts';
 import { SourceCredentialManager } from '../credential-manager.ts';
@@ -52,6 +52,11 @@ function createMcpSource(overrides: Partial<FolderSourceConfig> = {}): LoadedSou
 
 describe('SourceCredentialManager.prepareOAuth relay wrapping', () => {
   const credManager = new SourceCredentialManager();
+  const originalFetch = globalThis.fetch;
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
 
   beforeEach(() => {
     globalThis.fetch = mock((input: string | URL | Request) => {

--- a/scripts/build/common.ts
+++ b/scripts/build/common.ts
@@ -538,7 +538,9 @@ export function copyPiAgentServer(config: BuildConfig): void {
   const koffiSource = join(rootDir, 'node_modules', 'koffi');
 
   if (!existsSync(koffiSource)) {
-    console.warn('  Warning: koffi not found in node_modules. Pi SDK sessions may not work.');
+    // Optional: current @earendil-works/pi-* (>=0.80.x) vendors its own native
+    // Windows VT helper and never loads koffi — ship it only when installed.
+    console.log('  Copied index.js (koffi not installed — not required by current Pi SDK)');
     return;
   }
 


### PR DESCRIPTION
## Изменения

### 1. Cross-file fetch stub leaks (test isolation)
`packages/shared/src/auth/__tests__/oauth-callback-url.test.ts` присваивал `globalThis.fetch = mockFetch` на верхнем уровне модуля и **никогда не восстанавливал** — заглушка `404 Not Found` протекала во ВСЕ последующие тестовые файлы в общем bun-test процессе. Аналогично `packages/shared/src/sources/__tests__/oauth-relay.test.ts` заменял fetch в `beforeEach` без restore.

Симптом, который это ловит: любой тест, делающий реальные HTTP-запросы (в т.ч. к собственному localhost-серверу) после этих файлов получает «404 Not Found» из мока. Фикс: захват originalFetch + `afterAll` restore в обоих файлах.

### 2. Windows-style path semantics in isPathWithinDirectory
`packages/shared/src/agent/mode-manager.ts`: realpath-hardening v0.7.0 резолвит Windows-пути (`C:\...`, `\\server\...`) через POSIX `resolve()` на POSIX-хостах → бэкслеши склеиваются в один компонент, ancestor-walk уходит в cwd, и любой check возвращает false (ломает allowlist для PowerShell/Windows-shell команд с хоста macOS/Linux). Теперь: форма пути детектируется (drive/UNC) и для неё применяется case-insensitive lexical containment на любой ОС; realpath-hardening сохранён только для нативных путей.

### 3. Stale koffi warning in build
`scripts/build/common.ts` предупреждал «Pi SDK sessions may not work» при отсутствии koffi, но `@earendil-works/pi-*` >= 0.80.x вендорит собственный Windows VT helper и koffi не загружает вовсе (grep по dist — ноль ссылок). Теперь — тихий log, package не меняется.

## Верификация
- `bun test packages/shared` — 3008 тестов, **0 fail** (файлы oauth/mode-manager, 444 теста mode-manager зелёные).
- Без правок было бы: N фейлов в кластерах fetch-pollution (manifest сейчас), 3/3 mode-manager PowerShell allowlist фейлов на non-Windows хостах с установленным pwsh.

Сделано в форке, где та же ветка мержилась в нашу main линию параллельно.