### PR TITLE
fix: fast connection test for OpenAI-compatible endpoints, and duplicate /v1 path

### DIFF
--- a/packages/server-core/src/handlers/rpc/llm-connections.ts
+++ b/packages/server-core/src/handlers/rpc/llm-connections.ts
@@ -355,7 +355,11 @@ export function registerLlmConnectionsHandlers(server: RpcServer, deps: HandlerD
         allowEmptyApiKey,
         model: testModel,
         baseUrl,
-        timeoutMs: 45000,
+        // Must stay comfortably under the WS RPC client's default request timeout
+        // (30_000ms, see WsRpcClientOptions.requestTimeout) — otherwise the client
+        // gives up and shows "Request timeout" while the server-side test is still
+        // running (or even after it already succeeded).
+        timeoutMs: 25000,
         hostRuntime: buildBackendHostRuntimeContext(deps.platform),
         connection: hint,
       })

--- a/packages/shared/src/agent/backend/internal/drivers/pi.test.ts
+++ b/packages/shared/src/agent/backend/internal/drivers/pi.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it, mock } from 'bun:test';
 import { piDriver } from './pi.ts';
+import type { DriverTestConnectionArgs } from '../driver-types.ts';
+
+function baseTestArgs(overrides: Partial<DriverTestConnectionArgs> = {}): DriverTestConnectionArgs {
+  return {
+    provider: 'pi',
+    apiKey: 'test-key',
+    model: 'custom-model',
+    timeoutMs: 5000,
+    hostRuntime: {} as any,
+    resolvedPaths: {} as any,
+    ...overrides,
+  };
+}
 
 describe('piDriver.buildRuntime custom endpoint models', () => {
   it('preserves explicit per-model supportsImages values', () => {
@@ -38,5 +51,85 @@ describe('piDriver.buildRuntime custom endpoint models', () => {
       { id: 'text-only-model', supportsImages: false },
       'plain-model',
     ]);
+  });
+});
+
+describe('piDriver.testConnection for custom endpoints', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('runs the fast HTTP test for an OpenAI-compatible custom endpoint instead of falling back to the subprocess path', async () => {
+    let requestedUrl: string | undefined;
+    let requestedHeaders: Record<string, string> | undefined;
+    globalThis.fetch = mock(async (url: string, init?: RequestInit) => {
+      requestedUrl = url;
+      requestedHeaders = init?.headers as Record<string, string>;
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const result = await piDriver.testConnection!(baseTestArgs({
+      model: 'custom-endpoint-model',
+      baseUrl: 'https://api.example.com/v1',
+      connection: {
+        providerType: 'pi',
+        piAuthProvider: 'openai',
+        customEndpoint: { api: 'openai-completions' },
+      } as any,
+    }));
+
+    // A non-null result means the driver handled it directly via HTTP — it did NOT
+    // return null (which would fall through to factory.ts's full subprocess spawn).
+    expect(result).toEqual({ success: true });
+    expect(requestedUrl).toBe('https://api.example.com/v1/chat/completions');
+    expect(requestedHeaders?.authorization).toBe('Bearer test-key');
+  });
+
+  it('does not double up the /v1 suffix when the base URL already ends in /v1 (Anthropic-compatible)', async () => {
+    let requestedUrl: string | undefined;
+    globalThis.fetch = mock(async (url: string) => {
+      requestedUrl = url;
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const result = await piDriver.testConnection!(baseTestArgs({
+      model: 'custom-endpoint-model',
+      baseUrl: 'https://api.example.com/v1',
+      connection: {
+        providerType: 'pi',
+        piAuthProvider: 'anthropic',
+        customEndpoint: { api: 'anthropic-messages' },
+      } as any,
+    }));
+
+    expect(result).toEqual({ success: true });
+    expect(requestedUrl).toBe('https://api.example.com/v1/messages');
+  });
+
+  it('appends /v1 when the base URL does not already include it', async () => {
+    let requestedUrl: string | undefined;
+    globalThis.fetch = mock(async (url: string) => {
+      requestedUrl = url;
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await piDriver.testConnection!(baseTestArgs({
+      model: 'custom-endpoint-model',
+      baseUrl: 'https://api.example.com',
+      connection: {
+        providerType: 'pi',
+        piAuthProvider: 'anthropic',
+        customEndpoint: { api: 'anthropic-messages' },
+      } as any,
+    }));
+
+    expect(requestedUrl).toBe('https://api.example.com/v1/messages');
+  });
+
+  it('falls back to the subprocess path (returns null) when there is no provider hint', async () => {
+    const result = await piDriver.testConnection!(baseTestArgs({ connection: undefined }));
+    expect(result).toBeNull();
   });
 });

--- a/packages/shared/src/agent/backend/internal/drivers/pi.ts
+++ b/packages/shared/src/agent/backend/internal/drivers/pi.ts
@@ -180,17 +180,25 @@ async function fetchCopilotModels(
 }
 
 /**
- * Lightweight direct HTTP test for Pi providers that expose an Anthropic-compatible
- * messages endpoint. Avoids spawning a full Pi subprocess (which can exceed the
- * 20s test timeout due to SDK initialization overhead).
+ * Build a versioned API URL from a user-supplied base URL, without doubling the
+ * '/v1' segment. OpenAI-compatible endpoints are conventionally documented (and
+ * placeholder-hinted in our own setup form) as ending in '/v1', so users commonly
+ * enter e.g. 'https://api.example.com/v1' as the base URL. If we always appended
+ * '/v1/<path>' on top of that, we'd request '.../v1/v1/<path>' and get a 404.
  */
-async function testAnthropicCompatible(
-  apiKey: string,
-  baseUrl: string,
-  model: string,
+function buildApiUrl(baseUrl: string, path: string): string {
+  const trimmed = baseUrl.replace(/\/$/, '');
+  const hasV1Suffix = /\/v1$/i.test(trimmed);
+  return hasV1Suffix ? `${trimmed}${path}` : `${trimmed}/v1${path}`;
+}
+
+/** Shared fetch-with-timeout for the lightweight connection-test HTTP calls below. */
+async function postJsonWithTimeout(
+  url: string,
+  headers: Record<string, string>,
+  body: unknown,
   timeoutMs: number,
 ): Promise<{ success: boolean; error?: string }> {
-  const url = `${baseUrl.replace(/\/$/, '')}/v1/messages`;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
@@ -198,16 +206,8 @@ async function testAnthropicCompatible(
     const res = await fetch(url, {
       method: 'POST',
       signal: controller.signal,
-      headers: {
-        'content-type': 'application/json',
-        'x-api-key': apiKey,
-        'anthropic-version': '2023-06-01',
-      },
-      body: JSON.stringify({
-        model,
-        max_tokens: 16,
-        messages: [{ role: 'user', content: 'Say ok' }],
-      }),
+      headers,
+      body: JSON.stringify(body),
     });
 
     if (res.ok) return { success: true };
@@ -222,6 +222,59 @@ async function testAnthropicCompatible(
   } finally {
     clearTimeout(timer);
   }
+}
+
+/**
+ * Lightweight direct HTTP test for Pi providers that expose an Anthropic-compatible
+ * messages endpoint. Avoids spawning a full Pi subprocess (which can exceed the
+ * 20s test timeout due to SDK initialization overhead).
+ */
+async function testAnthropicCompatible(
+  apiKey: string,
+  baseUrl: string,
+  model: string,
+  timeoutMs: number,
+): Promise<{ success: boolean; error?: string }> {
+  return postJsonWithTimeout(
+    buildApiUrl(baseUrl, '/messages'),
+    {
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    {
+      model,
+      max_tokens: 16,
+      messages: [{ role: 'user', content: 'Say ok' }],
+    },
+    timeoutMs,
+  );
+}
+
+/**
+ * Lightweight direct HTTP test for Pi providers that expose an OpenAI-compatible
+ * chat completions endpoint. Mirrors testAnthropicCompatible() above — avoids
+ * spawning a full Pi subprocess just to check that credentials work.
+ */
+async function testOpenAICompatible(
+  apiKey: string,
+  baseUrl: string,
+  model: string,
+  timeoutMs: number,
+): Promise<{ success: boolean; error?: string }> {
+  return postJsonWithTimeout(
+    buildApiUrl(baseUrl, '/chat/completions'),
+    {
+      'content-type': 'application/json',
+      'authorization': `Bearer ${apiKey}`,
+    },
+    {
+      model,
+      max_tokens: 16,
+      messages: [{ role: 'user', content: 'Say ok' }],
+    },
+    timeoutMs,
+  );
 }
 
 export const piDriver: ProviderDriver = {
@@ -280,24 +333,34 @@ export const piDriver: ProviderDriver = {
       return null;
     }
 
-    // Resolve the model's API type from the Pi SDK registry.
-    // For anthropic-messages providers, do a lightweight direct HTTP test
-    // instead of spawning a full Pi subprocess (which can exceed the timeout).
-    let modelApi: string | undefined;
+    // Resolve the model's API type.
+    // For a user-configured custom endpoint (arbitrary base URL + explicit protocol
+    // toggle), trust that toggle directly — factory.ts stamps piAuthProvider as the
+    // literal 'anthropic'/'openai' marker for these connections, which is NOT a real
+    // Pi SDK provider id. Looking that up in the registry below would match against
+    // known providers' own model catalogs (e.g. real OpenAI's 'gpt-4'), not the
+    // user's custom model id, silently resolving to the wrong api type.
+    // For anthropic-messages and openai-completions providers, do a lightweight
+    // direct HTTP test instead of spawning a full Pi subprocess (which can
+    // exceed the timeout).
+    let modelApi: string | undefined = args.connection?.customEndpoint?.api;
     let modelBaseUrl: string | undefined;
-    try {
-      const { getModels } = await import('@earendil-works/pi-ai/compat');
-      const models = getModels(piAuthProvider as Parameters<typeof getModels>[0]);
-      const requestedId = args.model.startsWith('pi/') ? args.model.slice(3) : args.model;
-      const match = models.find(m => m.id === requestedId) || models[0];
-      if (match) {
-        modelApi = (match as { api?: string }).api;
-        modelBaseUrl = (match as { baseUrl?: string }).baseUrl;
-      }
-    } catch { /* ignore — fall through to subprocess */ }
+    if (!modelApi) {
+      try {
+        const { getModels } = await import('@earendil-works/pi-ai/compat');
+        const models = getModels(piAuthProvider as Parameters<typeof getModels>[0]);
+        const requestedId = args.model.startsWith('pi/') ? args.model.slice(3) : args.model;
+        const match = models.find(m => m.id === requestedId) || models[0];
+        if (match) {
+          modelApi = (match as { api?: string }).api;
+          modelBaseUrl = (match as { baseUrl?: string }).baseUrl;
+        }
+      } catch { /* ignore — fall through to subprocess */ }
+    }
 
-    if (modelApi !== 'anthropic-messages') {
-      // Non-Anthropic API types need the full Pi SDK — let factory.ts handle it
+    if (modelApi !== 'anthropic-messages' && modelApi !== 'openai-completions') {
+      // Other API types (Responses, Bedrock, Vertex, ...) need the full Pi SDK —
+      // let factory.ts handle it
       return null;
     }
 
@@ -306,13 +369,15 @@ export const piDriver: ProviderDriver = {
       return { success: false, error: 'Could not determine API endpoint for provider' };
     }
 
-    // Strip Pi SDK's 'pi/' prefix — Anthropic-compatible endpoints only accept bare model IDs
+    // Strip Pi SDK's 'pi/' prefix — compatible endpoints only accept bare model IDs
     let bareModel = args.model.startsWith('pi/') ? args.model.slice(3) : args.model;
     // MiniMax CN API doesn't accept the 'MiniMax-' prefix on model names
     if (piAuthProvider === 'minimax-cn' && bareModel.startsWith('MiniMax-')) {
       bareModel = bareModel.slice('MiniMax-'.length);
     }
-    return testAnthropicCompatible(args.apiKey, baseUrl, bareModel, args.timeoutMs);
+    return modelApi === 'anthropic-messages'
+      ? testAnthropicCompatible(args.apiKey, baseUrl, bareModel, args.timeoutMs)
+      : testOpenAICompatible(args.apiKey, baseUrl, bareModel, args.timeoutMs);
   },
   validateStoredConnection: async () => ({ success: true }),
 };


### PR DESCRIPTION
## Summary

Fixes two bugs in the "API configuration" connection test that make it impossible to set up a custom OpenAI-compatible LLM connection, and one timeout mismatch that hides the result even when the test does succeed.

Both were found while configuring a provider that exposes an OpenAI- **and** an Anthropic-compatible API under the same base URL, and both were verified live against that provider. Both still reproduce on `main` (v0.12.0).

## Changes

**1. No fast connection test for "OpenAI Compatible" (`packages/shared/src/agent/backend/internal/drivers/pi.ts`)**

`piDriver.testConnection` only had a lightweight HTTP path for `anthropic-messages`. Anything else returned `null` and fell through to `factory.ts`'s generic path, which spawns a **full Pi agent subprocess** just to answer "do these credentials work". On a small VPS that regularly exceeds the client's 30s RPC timeout, even though the actual upstream API call completes in well under a second.

The root cause turned out to run deeper than a missing HTTP test. For a user-configured custom endpoint, `factory.ts` sets `piAuthProvider` to the literal `'openai'`/`'anthropic'` marker, which is **not a real Pi SDK provider id**. The old code fed that marker into `getModels()` and then matched the user's custom model id against the *known* provider's catalog, falling back to `models[0]`. For a custom OpenAI-compatible endpoint that resolved to real OpenAI's `gpt-4` with `api: 'openai-responses'`, so the api type had nothing to do with the endpoint being configured. `testConnection` now reads `connection.customEndpoint.api` first (exactly what the user picked in the protocol toggle) and only falls back to the registry lookup for genuine Pi SDK providers.

Adds `testOpenAICompatible()` (POST `{baseUrl}/chat/completions`, `Authorization: Bearer`), mirroring the existing `testAnthropicCompatible()`.

**2. Duplicate `/v1` segment (same file)**

`testAnthropicCompatible()` unconditionally appended `/v1/messages`. A base URL already ending in `/v1` (which is what the OpenAI-compatible field asks for, and what users commonly leave in place when they only flip the protocol toggle) produced `.../v1/v1/messages` and a 404 "API endpoint not found. Check the URL." New `buildApiUrl()` helper detects an existing `/v1` suffix and appends only the endpoint path.

The two bugs compound: a user hitting bug 1 who switches to "Anthropic Compatible" as a workaround immediately lands in bug 2, because the endpoint field still carries the `/v1` from the previous attempt.

**3. Timeout mismatch (`packages/server-core/src/handlers/rpc/llm-connections.ts`)**

`TEST_LLM_CONNECTION_SETUP` used `timeoutMs: 45000`, which is *longer* than the WS RPC client's 30s default (`WsRpcClientOptions.requestTimeout`). The browser could therefore show "Request timeout" while the server-side test was still running, or even after it had already succeeded. Lowered to 25s so it stays under the client budget.

## Testing

- 4 new cases in `packages/shared/src/agent/backend/internal/drivers/pi.test.ts`, covering the fast-path dispatch for both protocols, both base-URL shapes (`/v1` present and absent), and the fall-through to the subprocess path when there is no provider hint.
- `bun test packages/shared/src/agent/backend/internal/drivers/pi.test.ts` passes (5/5).
- `bun run tsc --noEmit` passes clean in both touched packages (`packages/shared`, `packages/server-core`).
- Note: `bun run typecheck:all` does **not** currently pass on `main`, independently of this PR. `tsconfig.base.json` is referenced by `packages/pi-agent-server`, `packages/session-mcp-server` and `packages/session-tools-core` but is not committed to the repo, so tsc aborts with `TS5083: Cannot read file '.../tsconfig.base.json'`. I reproduced the identical failure on a pristine `main` checkout (v0.12.0) with this commit reverted, so it is pre-existing and out of scope here. Happy to open a separate issue or PR for it if useful.
- Verified live against a real OpenAI/Anthropic-compatible provider: `/v1/messages` returns 200, `/v1/v1/messages` returns 404.

## Screenshots

n/a, no UI changes.
